### PR TITLE
Adding ExpectedException.expectCause()

### DIFF
--- a/doc/ReleaseNotes4.9-SNAPSHOT-20100512-0041.html
+++ b/doc/ReleaseNotes4.9-SNAPSHOT-20100512-0041.html
@@ -1,4 +1,4 @@
-
-Can't open /Users/saff/Documents/git-repos/junit/doc/ReleaseNotes4.9-SNAPSHOT-20100512-0041.txt: No such file or directory at build/Markdown.pl line 218.
+Can't open /Users/pholser/java/junit-with-expected-exception-rule-with-cause/doc/ReleaseNotes4.9-SNAPSHOT-20100512-0041.txt: No such file or directory at build/Markdown.pl line 218.
 Use of uninitialized value in substitution (s///) at build/Markdown.pl line 245.
 Use of uninitialized value in substitution (s///) at build/Markdown.pl line 246.
+

--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -14,24 +14,24 @@ import org.junit.runners.model.Statement;
 /**
  * The ExpectedException Rule allows in-test specification of expected exception
  * types and messages:
- * 
+ *
  * <pre>
  * // These tests all pass.
  * public static class HasExpectedException {
  * 	&#064;Rule
  * 	public ExpectedException thrown= new ExpectedException();
- * 
+ *
  * 	&#064;Test
  * 	public void throwsNothing() {
  *    // no exception expected, none thrown: passes.
  * 	}
- * 
+ *
  * 	&#064;Test
  * 	public void throwsNullPointerException() {
  * 		thrown.expect(NullPointerException.class);
  * 		throw new NullPointerException();
  * 	}
- * 
+ *
  * 	&#064;Test
  * 	public void throwsNullPointerExceptionWithMessage() {
  * 		thrown.expect(NullPointerException.class);
@@ -54,9 +54,9 @@ public class ExpectedException implements MethodRule {
 	private Matcher<Object> fMatcher= null;
 
 	private ExpectedException() {
-		
+
 	}
-	
+
 	public Statement apply(Statement base, FrameworkMethod method, Object target) {
 		return new ExpectedExceptionStatement(base);
 	}
@@ -90,7 +90,7 @@ public class ExpectedException implements MethodRule {
 	}
 
 	/**
-	 * Adds {@code matcher} to the list of requirements for the message 
+	 * Adds {@code matcher} to the list of requirements for the message
 	 * returned from any thrown exception.
 	 */
 	public void expectMessage(Matcher<String> matcher) {
@@ -126,10 +126,31 @@ public class ExpectedException implements MethodRule {
 				description.appendText("exception with message ");
 				description.appendDescriptionOf(matcher);
 			}
-		
+
 			@Override
 			public boolean matchesSafely(Throwable item) {
 				return matcher.matches(item.getMessage());
+			}
+		};
+	}
+
+	public void expectCause(Class<? extends Throwable> type) {
+		expect(hasCauseOfType(type));
+	}
+
+	private Matcher<?> hasCauseOfType(final Class<? extends Throwable> type) {
+		return new TypeSafeMatcher<Throwable>() {
+			@Override
+			public boolean matchesSafely(Throwable item) {
+				if (item == null)
+					return false;
+				Throwable cause = item.getCause();
+				return cause != null && type.isInstance(cause);
+			}
+
+			public void describeTo(Description description) {
+				description.appendText("exception with cause that is an instance of ");
+				description.appendValue(type);
 			}
 		};
 	}

--- a/src/test/java/org/junit/tests/experimental/rules/ExpectedExceptionRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/ExpectedExceptionRuleTest.java
@@ -182,14 +182,14 @@ public class ExpectedExceptionRuleTest {
 				description.appendText("starts with ");
 				description.appendText(prefix);
 			}
-		
+
 			@Override
 			public boolean matchesSafely(String item) {
 				return item.startsWith(prefix);
 			}
 		};
 	}
-	
+
 	@Test
 	public void failsWithMatcher() {
 		assertThat(testResult(ExpectedMessageMatcherFails.class),
@@ -228,5 +228,79 @@ public class ExpectedExceptionRuleTest {
 	public void failsWithMultipleMatchers() {
 		assertThat(testResult(ExpectsMultipleMatchers.class),
 				hasSingleFailureContaining("IllegalArgumentException"));
+	}
+
+	public static class HasExpectedExceptionWithCause {
+		@Rule
+		public final ExpectedException thrown= ExpectedException.none();
+
+		@Test
+		public void throwsExceptionWithExpectedCause() {
+			thrown.expectCause(IllegalArgumentException.class);
+			throw new IllegalStateException(new IllegalArgumentException());
+		}
+	}
+
+	@Test
+	public void succeedsWithCauseMatcher() {
+		assertThat(testResult(HasExpectedExceptionWithCause.class), isSuccessful());
+	}
+
+	public static class HasExpectedExceptionWithUnexpectedCause {
+		@Rule
+		public final ExpectedException thrown= ExpectedException.none();
+
+		@Test
+		public void throwsExceptionWithUnexpectedCause() {
+			thrown.expectCause(UnsupportedOperationException.class);
+			throw new IllegalStateException(new IllegalArgumentException());
+		}
+	}
+
+	@Test
+	public void failsWithUnexpectedCause() {
+		assertThat(testResult(HasExpectedExceptionWithUnexpectedCause.class),
+				hasSingleFailureContaining("exception with cause that is an instance of"
+						+ " <class java.lang.UnsupportedOperationException>"));
+	}
+
+	public static class HasUnexpectedExceptionWithCause {
+		@Rule
+		public final ExpectedException thrown= ExpectedException.none();
+
+		@Test
+		public void throwsUnexpectedExceptionWithCause() {
+			thrown.expect(IllegalArgumentException.class);
+			thrown.expectCause(UnsupportedOperationException.class);
+			throw new IllegalStateException(new UnsupportedOperationException());
+		}
+	}
+
+	@Test
+	public void failsWithUnexpectedExceptionWithCause() {
+		assertThat(testResult(HasUnexpectedExceptionWithCause.class),
+				hasSingleFailureContaining("exception with cause that is an instance of"
+						+ " <class java.lang.UnsupportedOperationException> and an instance of"
+						+ " java.lang.IllegalArgumentException"));
+	}
+
+	public static class HasExpectedExceptionWithNoCause {
+		@Rule
+		public final ExpectedException thrown= ExpectedException.none();
+
+		@Test
+		public void throwsUnexpectedExceptionWithCause() {
+			thrown.expect(IllegalArgumentException.class);
+			thrown.expectCause(UnsupportedOperationException.class);
+			throw new IllegalArgumentException();
+		}
+	}
+
+	@Test
+	public void failsWithExpectedExceptionWithNoCause() {
+		assertThat(testResult(HasUnexpectedExceptionWithCause.class),
+				hasSingleFailureContaining("exception with cause that is an instance of"
+						+ " <class java.lang.UnsupportedOperationException> and an instance of"
+						+ " java.lang.IllegalArgumentException"));
 	}
 }


### PR DESCRIPTION
Hi there,

Found the need in my project to check the cause of an expected exception, but couldn't do it with what was there. Have a look at my changes and let me know what you think.

Another option would be to make the zero-arg ctor of ExpectedException protected or public, so that someone can subclass ExpectedException and add things like expectCause. I understand that you'd have to grant subclasses some means of tweaking field fMatcher at that point...bummer...8^(

Thanks,
p
