### PR TITLE
Simple removal of (seemingly) redundant asserts

### DIFF
--- a/src/test/java/org/junit/tests/experimental/categories/CategoryTest.java
+++ b/src/test/java/org/junit/tests/experimental/categories/CategoryTest.java
@@ -100,7 +100,6 @@ public class CategoryTest {
 	@Test
 	public void testCountOnAWithoutSlowTests() {
 		Result result= JUnitCore.runClasses(SomeAreSlowSuite.class);
-		assertThat(testResult(SomeAreSlowSuite.class), isSuccessful());
 		assertEquals(2, result.getRunCount());
 		assertTrue(result.wasSuccessful());
 	}
@@ -115,7 +114,6 @@ public class CategoryTest {
 	@Test
 	public void testsThatAreBothIncludedAndExcludedAreExcluded() {
 		Result result= JUnitCore.runClasses(IncludeAndExcludeSuite.class);
-		assertThat(testResult(SomeAreSlowSuite.class), isSuccessful());
 		assertEquals(1, result.getRunCount());
 		assertTrue(result.wasSuccessful());
 	}


### PR DESCRIPTION
While reading the Categories code to understand how it works, I noticed these two calls that execute a suite simply to check it works, but the first is redundant, as it's being run in the test already, and the other seems unrelated to the test it's in.
