### PR TITLE
protected constructor for Description

### DIFF
--- a/src/main/java/org/junit/runner/Description.java
+++ b/src/main/java/org/junit/runner/Description.java
@@ -91,7 +91,7 @@ public class Description implements Serializable {
 	
 	private final Annotation[] fAnnotations;
 	
-	private Description(final String displayName, Annotation... annotations) {
+	protected Description(final String displayName, Annotation... annotations) {
 		fDisplayName= displayName;
 		fAnnotations= annotations;
 	}


### PR DESCRIPTION
I'm the author of Cucumber - http://cukes.info/, which I'm in the process of porting to pure Java and integrating with JUnit.

While doing this I realised that often Descriptions (representing  Cucumber "scenario" or "step) will have the same name while representing different parts of the test hierarchy. That's fine in Cucumber, but I don't want them to be treated as equal since this breaks behaviour in IntelliJ's runner (and possibly others). I need to subclass Description so I can override equals().

This simple patch makes that possible. I would greatly appreciate it if this small fix made it into the next release.

Aslak
