### PR TITLE
Rules step should be the last in the javadoc of BlockJUnit4ClassRunner.methodBlock

### DIFF
--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -223,10 +223,6 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 	 * <li>HOWEVER, if {@code method}'s {@code @Test} annotation has the {@code
 	 * timeout} attribute, throw an exception if the previous step takes more
 	 * than the specified number of milliseconds.
-	 * <li>ALWAYS allow {@code @Rule} fields to modify the execution of the
-	 * above steps. A {@code Rule} may prevent all execution of the above steps,
-	 * or add additional behavior before and after, or modify thrown exceptions.
-	 * For more information, see {@link TestRule}
 	 * <li>ALWAYS run all non-overridden {@code @Before} methods on this class
 	 * and superclasses before any of the previous steps; if any throws an
 	 * Exception, stop execution and pass the exception on.
@@ -235,6 +231,10 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 	 * always executed: exceptions thrown by previous steps are combined, if
 	 * necessary, with exceptions from After methods into a
 	 * {@link MultipleFailureException}.
+	 * <li>ALWAYS allow {@code @Rule} fields to modify the execution of the
+	 * above steps. A {@code Rule} may prevent all execution of the above steps,
+	 * or add additional behavior before and after, or modify thrown exceptions.
+	 * For more information, see {@link TestRule}
 	 * </ul>
 	 * 
 	 * This can be overridden in subclasses, either by overriding this method,


### PR DESCRIPTION
In the javadoc of 
  org.junit.runners.BlockJUnit4ClassRunner.methodBlock(FrameworkMethod method)
the step of modification by rules should be the last one.

As Statements in general only expose their "evaluate" method and nothing more, rules can actually only either totally prevent the execution of all steps together, or decorate the whole bunch. And that includes RunBefores and RunAfters, as well as all the other recursively wrapped Statements.

And they can also modify thrown exceptions, including the ones thrown by befores and afters.
