### PR TITLE
Attempt 2: Setting up for resolving issue 64, Theories honoring generic type parameters.

### DIFF
--- a/src/main/java/org/junit/runners/model/FrameworkMethod.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMethod.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.List;
 
 import org.junit.internal.runners.model.ReflectiveCallable;
@@ -90,6 +91,10 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
 			errors.add(new Exception("Method " + fMethod.getName() + "() should be void"));
 	}
 
+	public void validateNoTypeParametersOnArgs(List<Throwable> errors) {
+		new NoGenericTypeParametersValidator(fMethod).validate(errors);
+	}
+
 	@Override
 	public boolean isShadowedBy(FrameworkMethod other) {
 		if (!other.getName().equals(getName()))
@@ -117,10 +122,14 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
 	/**
 	 * Returns true iff this is a no-arg method that returns a value assignable
 	 * to {@code type}
+	 *
+	 * @deprecated To be supplanted by a forthcoming
+	 * ParameterSignature#canAcceptResultOf(FrameworkMethod)
 	 */
-	public boolean producesType(Class<?> type) {
-		return getParameterTypes().length == 0
-				&& type.isAssignableFrom(fMethod.getReturnType());
+	@Deprecated
+	public boolean producesType(Type type) {
+		return getParameterTypes().length == 0 && type instanceof Class<?>
+		    && ((Class<?>) type).isAssignableFrom(fMethod.getReturnType());
 	}
 
 	private Class<?>[] getParameterTypes() {

--- a/src/main/java/org/junit/runners/model/NoGenericTypeParametersValidator.java
+++ b/src/main/java/org/junit/runners/model/NoGenericTypeParametersValidator.java
@@ -1,0 +1,53 @@
+package org.junit.runners.model;
+
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.List;
+
+class NoGenericTypeParametersValidator {
+	private final Method fMethod;
+
+	NoGenericTypeParametersValidator(Method method) {
+		this.fMethod = method;
+	}
+
+	void validate(List<Throwable> errors) {
+		for (Type each : fMethod.getGenericParameterTypes())
+			validateNoTypeParameterOnType(each, errors);
+	}
+
+	private void validateNoTypeParameterOnType(Type type, List<Throwable> errors) {
+		if (type instanceof TypeVariable<?>) {
+			errors.add(new Exception("Method " + fMethod.getName()
+					+ "() contains unresolved type variable " + type));
+		} else if (type instanceof ParameterizedType)
+			validateNoTypeParameterOnParameterizedType((ParameterizedType) type, errors);
+		else if (type instanceof WildcardType)
+			validateNoTypeParameterOnWildcardType((WildcardType) type, errors);
+		else if (type instanceof GenericArrayType)
+			validateNoTypeParameterOnGenericArrayType((GenericArrayType) type, errors);
+	}
+
+	private void validateNoTypeParameterOnParameterizedType(ParameterizedType parameterized,
+			List<Throwable> errors) {
+		for (Type each : parameterized.getActualTypeArguments())
+			validateNoTypeParameterOnType(each, errors);
+	}
+
+	private void validateNoTypeParameterOnWildcardType(WildcardType wildcard,
+			List<Throwable> errors) {
+		for (Type each : wildcard.getUpperBounds())
+		    validateNoTypeParameterOnType(each, errors);
+		for (Type each : wildcard.getLowerBounds())
+		    validateNoTypeParameterOnType(each, errors);
+	}
+
+	private void validateNoTypeParameterOnGenericArrayType(
+			GenericArrayType arrayType, List<Throwable> errors) {
+		validateNoTypeParameterOnType(arrayType.getGenericComponentType(), errors);
+	}
+}

--- a/src/test/java/org/junit/tests/experimental/theories/runner/WithUnresolvedGenericTypeVariablesOnTheoryParms.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/WithUnresolvedGenericTypeVariablesOnTheoryParms.java
@@ -1,0 +1,177 @@
+package org.junit.tests.experimental.theories.runner;
+
+import static org.junit.Assert.*;
+import static org.junit.experimental.results.PrintableResult.*;
+import static org.junit.experimental.results.ResultMatchers.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.junit.experimental.theories.DataPoint;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+public class WithUnresolvedGenericTypeVariablesOnTheoryParms {
+	@Test
+	public void whereTypeVariableIsOnTheTheory() {
+		PrintableResult result= testResult(TypeVariableOnTheoryOnly.class);
+		assertThat(result, isSuccessful());
+	}
+
+	@RunWith(Theories.class)
+	public static class TypeVariableOnTheoryOnly {
+		@DataPoint
+		public static List<String> strings = Arrays.asList("foo", "bar");
+
+		@Theory
+		public <T> void forItems(Collection<?> items) {
+		}
+	}
+
+	@Test
+	public void whereTypeVariableIsOnTheoryParm() {
+		PrintableResult result= testResult(TypeVariableOnTheoryParm.class);
+		assertThat(result, hasSingleFailureContaining("unresolved type variable T"));
+	}
+
+	@RunWith(Theories.class)
+	public static class TypeVariableOnTheoryParm {
+		@DataPoint
+		public static String string = "foo";
+
+		@Theory
+		public <T> void forItem(T item) {
+		}
+	}
+
+	@Test
+	public void whereTypeVariableIsOnParameterizedTheoryParm() {
+		PrintableResult result= testResult(TypeVariableOnParameterizedTheoryParm.class);
+		assertThat(result, hasSingleFailureContaining("unresolved type variable T"));
+	}
+
+	@RunWith(Theories.class)
+	public static class TypeVariableOnParameterizedTheoryParm {
+		@DataPoint
+		public static List<String> strings = Arrays.asList("foo", "bar");
+
+		@Theory
+		public <T> void forItems(Collection<T> items) {
+		}
+	}
+
+	@Test
+	public void whereTypeVariableIsOnWildcardUpperBoundOnTheoryParm() {
+		PrintableResult result= testResult(TypeVariableOnWildcardUpperBoundOnTheoryParm.class);
+		assertThat(result, hasSingleFailureContaining("unresolved type variable U"));
+	}
+
+	@RunWith(Theories.class)
+	public static class TypeVariableOnWildcardUpperBoundOnTheoryParm {
+		@DataPoint
+		public static List<String> strings = Arrays.asList("foo", "bar");
+
+		@Theory
+		public <U> void forItems(Collection<? extends U> items) {
+		}
+	}
+
+	@Test
+	public void whereTypeVariableIsOnWildcardLowerBoundOnTheoryParm() {
+		PrintableResult result= testResult(TypeVariableOnWildcardLowerBoundOnTheoryParm.class);
+		assertThat(result, hasSingleFailureContaining("unresolved type variable V"));
+	}
+
+	@RunWith(Theories.class)
+	public static class TypeVariableOnWildcardLowerBoundOnTheoryParm {
+		@DataPoint
+		public static List<String> strings = Arrays.asList("foo", "bar");
+
+		@Theory
+		public <V> void forItems(Collection<? super V> items) {
+		}
+	}
+
+	@Test
+	public void whereTypeVariableIsOnArrayTypeOnTheoryParm() {
+		PrintableResult result= testResult(TypeVariableOnArrayTypeOnTheoryParm.class);
+		assertThat(result, hasSingleFailureContaining("unresolved type variable T"));
+	}
+
+	@RunWith(Theories.class)
+	public static class TypeVariableOnArrayTypeOnTheoryParm {
+		@DataPoints
+		public static String[][] items() {
+			return new String[][] { new String[] { "foo" }, new String[] { "bar" } };
+		}
+
+		@Theory
+		public <T> void forItems(T[] items) {
+		}
+	}
+
+	@Test
+	public void whereTypeVariableIsOnComponentOfArrayTypeOnTheoryParm() {
+		PrintableResult result= testResult(TypeVariableOnComponentOfArrayTypeOnTheoryParm.class);
+		assertThat(result, hasSingleFailureContaining("unresolved type variable U"));
+	}
+
+	@RunWith(Theories.class)
+	public static class TypeVariableOnComponentOfArrayTypeOnTheoryParm {
+		@DataPoints
+		public static List<?>[][] items() {
+			return new List<?>[][] {
+					new List<?>[] { Arrays.asList("foo") },
+					new List<?>[] { Arrays.asList("bar") }
+					};
+		}
+
+		@Theory
+		public <U> void forItems(Collection<U>[] items) {
+		}
+	}
+
+	@Test
+	public void whereTypeVariableIsOnTheoryClass() {
+		PrintableResult result= testResult(TypeVariableOnTheoryClass.class);
+		assertThat(result, hasSingleFailureContaining("unresolved type variable T"));
+	}
+
+	@RunWith(Theories.class)
+	public static class TypeVariableOnTheoryClass<T> {
+		@DataPoint
+		public static String item = "bar";
+
+		@Theory
+		public void forItem(T item) {
+		}
+	}
+
+	@Test
+	public void whereTypeVariablesAbound() {
+		PrintableResult result= testResult(TypeVariablesAbound.class);
+		assertThat(result, failureCountIs(7));
+		assertThat(result, hasFailureContaining("unresolved type variable A"));
+		assertThat(result, hasFailureContaining("unresolved type variable B"));
+		assertThat(result, hasFailureContaining("unresolved type variable C"));
+		assertThat(result, hasFailureContaining("unresolved type variable D"));
+		assertThat(result, hasFailureContaining("unresolved type variable E"));
+		assertThat(result, hasFailureContaining("unresolved type variable F"));
+		assertThat(result, hasFailureContaining("unresolved type variable G"));
+	}
+
+	@RunWith(Theories.class)
+	public static class TypeVariablesAbound<A, B extends A, C extends Collection<B>> {
+		@Theory
+		public <D, E extends D, F, G> void forItem(A first, Collection<B> second,
+				Map<C, ? extends D> third, List<? super E> fourth, F[] fifth,
+				Collection<G>[] sixth) {
+		}
+	}
+}


### PR DESCRIPTION
Attempt 2: Setting up for resolving issue 64, Theories honoring generic type parameters. This commit comprises only those changes required in the core of JUnit -- basically adding a validator that the Theories runner can call to reject theories with generic type variables (that are hard to resolve), and deprecating FrameworkMethod#producesType, which only the Theories runner uses, and which will be supplanted by an equivalent method on ParameterSignature. Other required changes will be added to the Theories experiment once it migrates over to junit.contrib.
