### PR TITLE
Fixes #278: TemporaryFolder creates files in the current working directory if applying the rule fails

### DIFF
--- a/acknowledgements.txt
+++ b/acknowledgements.txt
@@ -110,3 +110,6 @@
 
 2011 July 16
 	Rob Dawson: Submitted a patch that makes Results serlializable.
+
+2011 Aug 7
+	Esko Luontola: Fixed TemporaryFolder creating files in the current working directory (github#278).

--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -51,7 +51,7 @@ public class TemporaryFolder extends ExternalResource {
 	 * Returns a new fresh file with the given name under the temporary folder.
 	 */
 	public File newFile(String fileName) throws IOException {
-		File file= new File(folder, fileName);
+		File file= new File(getRoot(), fileName);
 		file.createNewFile();
 		return file;
 	}
@@ -60,7 +60,7 @@ public class TemporaryFolder extends ExternalResource {
 	 * Returns a new fresh folder with the given name under the temporary folder.
 	 */
 	public File newFolder(String folderName) {
-		File file= new File(folder, folderName);
+		File file= new File(getRoot(), folderName);
 		file.mkdir();
 		return file;
 	}
@@ -69,12 +69,15 @@ public class TemporaryFolder extends ExternalResource {
 	 * @return the location of this temporary folder.
 	 */
 	public File getRoot() {
+		if (folder == null) {
+			throw new IllegalStateException("the temporary folder has not yet been created");
+		}
 		return folder;
 	}
 
 	/**
 	 * Delete all files and folders under the temporary folder.
-	 * Usually not called directly, since it is automatically applied 
+	 * Usually not called directly, since it is automatically applied
 	 * by the {@link Rule}
 	 */
 	public void delete() {

--- a/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
@@ -4,11 +4,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.experimental.results.PrintableResult.testResult;
+import static org.junit.experimental.results.ResultMatchers.failureCountIs;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 
 import java.io.File;
 import java.io.IOException;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -67,5 +69,45 @@ public class TempFolderRuleTest {
 		folder.create();
 		folder.delete();
 		assertFalse(folder.getRoot().exists());
+	}
+
+	private static final String GET_ROOT_DUMMY= "dummy-getRoot";
+
+	private static final String NEW_FILE_DUMMY= "dummy-newFile";
+
+	private static final String NEW_FOLDER_DUMMY= "dummy-newFolder";
+
+	public static class IncorrectUsage {
+		public TemporaryFolder folder= new TemporaryFolder();
+
+		@Test
+		public void testGetRoot() throws IOException {
+			new File(folder.getRoot(), GET_ROOT_DUMMY).createNewFile();
+		}
+
+		@Test
+		public void testNewFile() throws IOException {
+			folder.newFile(NEW_FILE_DUMMY);
+		}
+
+		@Test
+		public void testNewFolder() throws IOException {
+			folder.newFolder(NEW_FOLDER_DUMMY);
+		}
+	}
+
+	@Test
+	public void incorrectUsageWithoutApplyingTheRuleShouldNotPolluteTheCurrentWorkingDirectory() {
+		assertThat(testResult(IncorrectUsage.class), failureCountIs(3));
+		assertFalse("getRoot should have failed early", new File(GET_ROOT_DUMMY).exists());
+		assertFalse("newFile should have failed early", new File(NEW_FILE_DUMMY).exists());
+		assertFalse("newFolder should have failed early", new File(NEW_FOLDER_DUMMY).exists());
+	}
+
+	@After
+	public void cleanCurrentWorkingDirectory() {
+		new File(GET_ROOT_DUMMY).delete();
+		new File(NEW_FILE_DUMMY).delete();
+		new File(NEW_FOLDER_DUMMY).delete();
 	}
 }


### PR DESCRIPTION
Replaces pull request https://github.com/KentBeck/junit/pull/279
