### PR TITLE
Change Paramaterized.java to be more extensible

### DIFF
--- a/src/main/java/org/junit/runners/Parameterized.java
+++ b/src/main/java/org/junit/runners/Parameterized.java
@@ -128,8 +128,8 @@ public class Parameterized extends Suite {
 		super(klass, Collections.<Runner>emptyList());
 		List<Object[]> parametersList= getParametersList(getTestClass());
 		for (int i= 0; i < parametersList.size(); i++)
-			runners.add(new TestClassRunnerForParameters(getTestClass().getJavaClass(),
-					parametersList, i));
+			addTestClassRunnerForParameters(getTestClass(), parametersList, i);
+
 	}
 
 	@Override
@@ -142,6 +142,13 @@ public class Parameterized extends Suite {
 			throws Throwable {
 		return (List<Object[]>) getParametersMethod(klass).invokeExplosively(
 				null);
+	}
+
+	protected void addTestClassRunnerForParameters (
+			TestClass testClass, List<Object[]> parametersList, int i)
+			throws Throwable {
+		runners.add(new TestClassRunnerForParameters(getTestClass().getJavaClass(),
+				parametersList, i));
 	}
 
 	protected FrameworkMethod getParametersMethod(TestClass testClass)


### PR DESCRIPTION
In this particular case, declaring methods and members private precludes extending the Parameterized runner to do 'other things' during the course of a Parameterized Test.

In my particular case, I wanted to change the names of the Tests run by the Parameterized runner to be "test_Name[i]_arg1_arg2 etc..."

Whilst I'm not asking for this naming change to JUnit itself, I cannot see any reason to stop people from extending the Parameterized test runner, and I cannot see any logical reason to mark these methods or fields as private.

I have also written a gist to show how I used my changes to create a new, extended test runner that does what I need:

https://gist.github.com/1141041
