### PR TITLE
Fixes gh-311: Fix 4.9.1 release notes, make sure markdown errors halt build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -132,7 +132,7 @@
   
   <target name="release-notes">
     <property name="basename" value="doc/ReleaseNotes${version-base}" />
-    <exec executable="build/Markdown.pl">
+    <exec executable="build/Markdown.pl" failonerror="true">
       <arg file="${basename}.txt"/>
       <redirector output="${basename}.html" />
     </exec>

--- a/doc/ReleaseNotes4.9.1.html
+++ b/doc/ReleaseNotes4.9.1.html
@@ -1,4 +1,0 @@
-
-Can't open /Users/saff/git-repos/stems_and_seeds/junit/doc/ReleaseNotes4.9.1.txt: No such file or directory at build/Markdown.pl line 218.
-Use of uninitialized value $text in substitution (s///) at build/Markdown.pl line 245.
-Use of uninitialized value $text in substitution (s///) at build/Markdown.pl line 246.


### PR DESCRIPTION
Fixes gh-311: Fix 4.9.1 release notes, make sure markdown errors halt build
