### PR TITLE
This is a fix for #83 support @Rule on methods

### DIFF
--- a/src/main/java/org/junit/ClassRule.java
+++ b/src/main/java/org/junit/ClassRule.java
@@ -6,8 +6,9 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotates static fields that contain rules. Such a field must be public,
- * static, and a subtype of {@link org.junit.rules.TestRule}.  
+ * Annotates static fields that contain rules or methods that return them. A field must be public,
+ * static, and a subtype of {@link org.junit.rules.TestRule}.  A method must be public static, and return
+ * a subtype of {@link org.junit.rules.TestRule} 
  * The {@link org.junit.runners.model.Statement} passed 
  * to the {@link org.junit.rules.TestRule} will run any {@link BeforeClass} methods, 
  * then the entire body of the test class (all contained methods, if it is
@@ -25,13 +26,13 @@ import java.lang.annotation.Target;
  * If there are multiple
  * annotated {@link ClassRule}s on a class, they will be applied in an order
  * that depends on your JVM's implementation of the reflection API, which is
- * undefined, in general.
+ * undefined, in general. However, Rules defined by fields will always be applied
+ * before Rules defined by methods.
  *
  * For example, here is a test suite that connects to a server once before
  * all the test classes run, and disconnects after they are finished:
  * 
  * <pre>
- * 
  * &#064;RunWith(Suite.class)
  * &#064;SuiteClasses({A.class, B.class, C.class})
  * public class UsesExternalResource {
@@ -52,9 +53,34 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  * 
+ * and the same using a method
+ * 
+ * <pre>
+ * &#064;RunWith(Suite.class)
+ * &#064;SuiteClasses({A.class, B.class, C.class})
+ * public class UsesExternalResource {
+ * 	public static Server myServer= new Server();
+ * 
+ * 	&#064;ClassRule
+ *	public static ExternalResource getResource() {
+ * 		return new ExternalResource() {
+ *			&#064;Override
+ * 			protected void before() throws Throwable {
+ * 				myServer.connect();
+ * 			}
+ * 
+ * 			&#064;Override
+ * 			protected void after() {
+ * 				myServer.disconnect();
+ * 			}
+ * 		};
+ * 	}
+ * }
+ * </pre>
+ * 
  * For more information and more examples, see {@link org.junit.rules.TestRule}. 
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.METHOD})
 public @interface ClassRule {
 }

--- a/src/main/java/org/junit/Rule.java
+++ b/src/main/java/org/junit/Rule.java
@@ -6,15 +6,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotates fields that contain rules. Such a field must be public, not
- * static, and a subtype of {@link org.junit.rules.TestRule}.  
+ * Annotates fields that contain rules or methods that return a rule. A field must be public, not
+ * static, and a subtype of {@link org.junit.rules.TestRule}. A method must be public, not static
+ * and must return a subtype of {@link org.junit.rules.TestRule}.   
  * The {@link org.junit.runners.model.Statement} passed 
  * to the {@link org.junit.rules.TestRule} will run any {@link Before} methods, 
  * then the {@link Test} method, and finally any {@link After} methods,
  * throwing an exception if any of these fail.  If there are multiple
- * annotated {@link Rule}s on a class, they will be applied in an order
+ * annotated {@link Rule}s on a class, they will be applied in order of fields first, then methods.
+ * However, if there are mutliple fields (or methods) they will be applied in an order
  * that depends on your JVM's implementation of the reflection API, which is
- * undefined, in general.
+ * undefined, in general. Rules defined by fields will always be applied
+ * before Rules defined by methods.
  *
  * For example, here is a test class that creates a temporary folder before
  * each test method, and deletes it after each:
@@ -33,15 +36,35 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  * 
+ * And the same using a method.
+ *
+ * <pre>
+ * public static class HasTempFolder {
+ * 	private TemporaryFolder folder= new TemporaryFolder();
+ *
+ * 	&#064;Rule
+ * 	public TemporaryFolder getFolder() {
+ * 		return folder;
+ * 	}
+ *
+ * 	&#064;Test
+ * 	public void testUsingTempFolder() throws IOException {
+ * 		File createdFile= folder.newFile(&quot;myfile.txt&quot;);
+ * 		File createdFolder= folder.newFolder(&quot;subfolder&quot;);
+ * 		// ...
+ * 	}
+ * }
+ * </pre>
+ * 
  * For more information and more examples, see 
  * {@link org.junit.rules.TestRule}. 
  *
  * Note: for backwards compatibility, this annotation may also mark
- * fields of type {@link org.junit.rules.MethodRule}, which will be honored.  However,
+ * fields or methods of type {@link org.junit.rules.MethodRule}, which will be honored.  However,
  * this is a deprecated interface and feature.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.METHOD})
 public @interface Rule {
 
 }

--- a/src/main/java/org/junit/internal/runners/rules/RuleFieldValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/RuleFieldValidator.java
@@ -5,8 +5,9 @@ import java.util.List;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
-import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMember;
 import org.junit.runners.model.TestClass;
 
 /**
@@ -14,28 +15,42 @@ import org.junit.runners.model.TestClass;
  * {@link org.junit.runners.model.TestClass}. All reasons for rejecting the
  * {@code TestClass} are written to a list of errors.
  * 
- * There are two slightly different validators. The {@link #CLASS_RULE_VALIDATOR}
+ * There are four slightly different validators. The {@link #CLASS_RULE_VALIDATOR}
  * validates fields with a {@link ClassRule} annotation and the
  * {@link #RULE_VALIDATOR} validates fields with a {@link Rule} annotation.
+ * 
+ * The {@link #CLASS_RULE_METHOD_VALIDATOR}
+ * validates methods with a {@link ClassRule} annotation and the
+ * {@link #RULE_METHOD_VALIDATOR} validates methods with a {@link Rule} annotation.
  */
 public enum RuleFieldValidator {
 	/**
 	 * Validates fields with a {@link ClassRule} annotation.
 	 */
-	CLASS_RULE_VALIDATOR(ClassRule.class, true),
+	CLASS_RULE_VALIDATOR(ClassRule.class, false, true),
 	/**
 	 * Validates fields with a {@link Rule} annotation.
 	 */
-	RULE_VALIDATOR(Rule.class, false);
+	RULE_VALIDATOR(Rule.class, false, false),
+	/**
+	 * Validates methods with a {@link ClassRule} annotation.
+	 */
+	CLASS_RULE_METHOD_VALIDATOR(ClassRule.class, true, true),
+	/**
+	 * Validates methods with a {@link Rule} annotation.
+	 */
+	RULE_METHOD_VALIDATOR(Rule.class, true, false);
 
 	private final Class<? extends Annotation> fAnnotation;
 
-	private final boolean fOnlyStaticFields;
+	private final boolean fOnlyStaticMembers;
+	private final boolean fMethods;
 
 	private RuleFieldValidator(Class<? extends Annotation> annotation,
-			boolean onlyStaticFields) {
+			boolean methods, boolean fOnlyStaticMembers) {
 		this.fAnnotation= annotation;
-		this.fOnlyStaticFields= onlyStaticFields;
+		this.fOnlyStaticMembers= fOnlyStaticMembers;
+		this.fMethods= methods;
 	}
 
 	/**
@@ -45,48 +60,51 @@ public enum RuleFieldValidator {
 	 * @param errors the list of errors.
 	 */
 	public void validate(TestClass target, List<Throwable> errors) {
-		List<FrameworkField> fields= target.getAnnotatedFields(fAnnotation);
-		for (FrameworkField each : fields)
-			validateField(each, errors);
+		List<? extends FrameworkMember<?>> members= fMethods ? target.getAnnotatedMethods(fAnnotation)
+										: target.getAnnotatedFields(fAnnotation);
+		
+		for (FrameworkMember<?> each : members)
+			validateMember(each, errors);
 	}
 
-	private void validateField(FrameworkField field, List<Throwable> errors) {
-		optionallyValidateStatic(field, errors);
-		validatePublic(field, errors);
-		validateTestRuleOrMethodRule(field, errors);
+	private void validateMember(FrameworkMember<?> member, List<Throwable> errors) {
+		optionallyValidateStatic(member, errors);
+		validatePublic(member, errors);
+		validateTestRuleOrMethodRule(member, errors);
 	}
 
-	private void optionallyValidateStatic(FrameworkField field,
+	private void optionallyValidateStatic(FrameworkMember<?> member,
 			List<Throwable> errors) {
-		if (fOnlyStaticFields && !field.isStatic())
-			addError(errors, field, "must be static.");
+		if (fOnlyStaticMembers && !member.isStatic())
+			addError(errors, member, "must be static.");
 	}
 
-	private void validatePublic(FrameworkField field, List<Throwable> errors) {
-		if (!field.isPublic())
-			addError(errors, field, "must be public.");
+	private void validatePublic(FrameworkMember<?> member, List<Throwable> errors) {
+		if (!member.isPublic())
+			addError(errors, member, "must be public.");
 	}
 
-	private void validateTestRuleOrMethodRule(FrameworkField field,
+	private void validateTestRuleOrMethodRule(FrameworkMember<?> member,
 			List<Throwable> errors) {
-		if (!isMethodRule(field) && !isTestRule(field))
-			addError(errors, field, "must implement MethodRule or TestRule.");
+		if (!isMethodRule(member) && !isTestRule(member))
+			addError(errors, member, fMethods ?
+					"must return an implementation of MethodRule or TestRule." :
+					"must implement MethodRule or TestRule.");
 	}
 
-	private boolean isTestRule(FrameworkField target) {
-		return TestRule.class.isAssignableFrom(target.getType());
+	private boolean isTestRule(FrameworkMember<?> member) {
+		return TestRule.class.isAssignableFrom(member.getType());
 	}
 
 	@SuppressWarnings("deprecation")
-	private boolean isMethodRule(FrameworkField target) {
-		return org.junit.rules.MethodRule.class.isAssignableFrom(target
-				.getType());
+	private boolean isMethodRule(FrameworkMember<?> member) {
+		return MethodRule.class.isAssignableFrom(member.getType());
 	}
 
-	private void addError(List<Throwable> errors, FrameworkField field,
+	private void addError(List<Throwable> errors, FrameworkMember<?> member,
 			String suffix) {
 		String message= "The @" + fAnnotation.getSimpleName() + " '"
-				+ field.getName() + "' " + suffix;
+				+ member.getName() + "' " + suffix;
 		errors.add(new Exception(message));
 	}
 }

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -1,6 +1,7 @@
 package org.junit.runners;
 
 import static org.junit.internal.runners.rules.RuleFieldValidator.RULE_VALIDATOR;
+import static org.junit.internal.runners.rules.RuleFieldValidator.RULE_METHOD_VALIDATOR;
 
 import java.util.List;
 
@@ -101,6 +102,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 		validateConstructor(errors);
 		validateInstanceMethods(errors);
 		validateFields(errors);
+		validateMethods(errors);
 	}
 
 	protected void validateNoNonStaticInnerClass(List<Throwable> errors) {
@@ -168,6 +170,10 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 
 	private void validateFields(List<Throwable> errors) {
 		RULE_VALIDATOR.validate(getTestClass(), errors);
+	}
+
+	private void validateMethods(List<Throwable> errors) {
+		RULE_METHOD_VALIDATOR.validate(getTestClass(), errors);
 	}
 
 	/**
@@ -326,16 +332,17 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 
 	private Statement withRules(FrameworkMethod method, Object target,
 			Statement statement) {
+		List<TestRule> testRules= getTestRules(target);
 		Statement result= statement;
-		result= withMethodRules(method, target, result);
-		result= withTestRules(method, target, result);
+		result= withMethodRules(method, testRules, target, result);
+		result= withTestRules(method, testRules, result);
+		
 		return result;
 	}
 
 	@SuppressWarnings("deprecation")
-	private Statement withMethodRules(FrameworkMethod method, Object target,
-			Statement result) {
-		List<TestRule> testRules= getTestRules(target);
+	private Statement withMethodRules(FrameworkMethod method, List<TestRule> testRules,
+			Object target, Statement result) {
 		for (org.junit.rules.MethodRule each : getMethodRules(target))
 			if (! testRules.contains(each))
 				result= each.apply(result, method, target);
@@ -365,14 +372,14 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 	/**
 	 * Returns a {@link Statement}: apply all non-static {@link Value} fields
 	 * annotated with {@link Rule}.
-	 *
+	 * @param method 
+	 * @param testRules 
 	 * @param statement The base statement
 	 * @return a RunRules statement if any class-level {@link Rule}s are
 	 *         found, or the base statement
 	 */
-	private Statement withTestRules(FrameworkMethod method, Object target,
+	private Statement withTestRules(FrameworkMethod method, List<TestRule> testRules,
 			Statement statement) {
-		List<TestRule> testRules= getTestRules(target);
 		return testRules.isEmpty() ? statement :
 			new RunRules(statement, testRules, describeChild(method));
 	}
@@ -384,10 +391,15 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 	 *         test
 	 */
 	protected List<TestRule> getTestRules(Object target) {
-		return getTestClass().getAnnotatedFieldValues(target,
+		List<TestRule> result = getTestClass().getAnnotatedMethodValues(target,
 				Rule.class, TestRule.class);
-	}
+			
+		result.addAll(getTestClass().getAnnotatedFieldValues(target,
+				Rule.class, TestRule.class));
 
+		return result;
+	}
+	
 	private Class<? extends Throwable> getExpectedException(Test annotation) {
 		if (annotation == null || annotation.expected() == None.class)
 			return null;

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -1,6 +1,7 @@
 package org.junit.runners;
 
 import static org.junit.internal.runners.rules.RuleFieldValidator.CLASS_RULE_VALIDATOR;
+import static org.junit.internal.runners.rules.RuleFieldValidator.CLASS_RULE_METHOD_VALIDATOR;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -133,6 +134,7 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
 
 	private void validateClassRules(List<Throwable> errors) {
 		CLASS_RULE_VALIDATOR.validate(getTestClass(), errors);
+		CLASS_RULE_METHOD_VALIDATOR.validate(getTestClass(), errors);
 	}
 
 	/** 
@@ -207,7 +209,11 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
 	 *         each method in the tested class.
 	 */
 	protected List<TestRule> classRules() {
-		return fTestClass.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class);
+		List<TestRule> result= fTestClass.getAnnotatedMethodValues(null, ClassRule.class, TestRule.class);
+
+		result.addAll(fTestClass.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class));
+		
+		return result;
 	}
 
 	/**

--- a/src/main/java/org/junit/runners/model/FrameworkField.java
+++ b/src/main/java/org/junit/runners/model/FrameworkField.java
@@ -17,6 +17,7 @@ public class FrameworkField extends FrameworkMember<FrameworkField> {
 		fField= field;
 	}
 
+	@Override
 	public String getName() {
 		return getField().getName();
 	}
@@ -26,6 +27,7 @@ public class FrameworkField extends FrameworkMember<FrameworkField> {
 		return fField.getAnnotations();
 	}
 
+	@Override
 	public boolean isPublic() {
 		int modifiers= fField.getModifiers();
 		return Modifier.isPublic(modifiers);
@@ -36,6 +38,7 @@ public class FrameworkField extends FrameworkMember<FrameworkField> {
 		return otherMember.getName().equals(getName());
 	}
 
+	@Override
 	public boolean isStatic() {
 		int modifiers= fField.getModifiers();
 		return Modifier.isStatic(modifiers);
@@ -52,6 +55,7 @@ public class FrameworkField extends FrameworkMember<FrameworkField> {
 	 * @return the underlying Java Field type
 	 * @see java.lang.reflect.Field#getType()
 	 */
+	@Override
 	public Class<?> getType() {
 		return fField.getType();
 	}

--- a/src/main/java/org/junit/runners/model/FrameworkMember.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMember.java
@@ -3,7 +3,7 @@ package org.junit.runners.model;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
-abstract class FrameworkMember<T extends FrameworkMember<T>> {
+public abstract class FrameworkMember<T extends FrameworkMember<T>> {
 	/**
 	 * Returns the annotations on this method
 	 */
@@ -17,4 +17,9 @@ abstract class FrameworkMember<T extends FrameworkMember<T>> {
 				return true;
 		return false;
 	}
+	
+	public abstract boolean isPublic();
+	public abstract boolean isStatic();
+	public abstract String getName();
+	public abstract Class<?> getType();
 }

--- a/src/main/java/org/junit/runners/model/FrameworkMethod.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMethod.java
@@ -50,6 +50,7 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
 	/**
 	 * Returns the method's name
 	 */
+	@Override
 	public String getName() {
 		return fMethod.getName();
 	}
@@ -90,6 +91,37 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
 		if (fMethod.getReturnType() != Void.TYPE)
 			errors.add(new Exception("Method " + fMethod.getName() + "() should be void"));
 	}
+	
+	/**
+	 * Returns true if this method is static, false if not
+	 */
+	@Override
+	public boolean isStatic() {
+		return Modifier.isStatic(fMethod.getModifiers());
+	}
+
+	/**
+	 * Returns true if this method is public, false if not
+	 */
+	@Override
+	public boolean isPublic() {
+		return Modifier.isPublic(fMethod.getModifiers());
+	}
+
+	/**
+	 * Returns the return type of the method
+	 */
+	public Class<?> getReturnType() {
+		return fMethod.getReturnType();
+	}
+
+	/**
+	 * Returns the return type of the method
+	 */
+	@Override
+	public Class<?> getType() {
+		return getReturnType();
+	}
 
 	public void validateNoTypeParametersOnArgs(List<Throwable> errors) {
 		new NoGenericTypeParametersValidator(fMethod).validate(errors);
@@ -120,7 +152,7 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
 	}
 
 	/**
-	 * Returns true iff this is a no-arg method that returns a value assignable
+	 * Returns true if this is a no-arg method that returns a value assignable
 	 * to {@code type}
 	 *
 	 * @deprecated This is used only by the Theories runner, and does not

--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -153,6 +153,22 @@ public class TestClass {
 		return results;
 	}
 
+	public <T> List<T> getAnnotatedMethodValues(Object test,
+			Class<? extends Annotation> annotationClass, Class<T> valueClass) {
+		List<T> results= new ArrayList<T>();
+		for (FrameworkMethod each : getAnnotatedMethods(annotationClass)) {
+			try {
+				Object fieldValue= each.invokeExplosively(test, new Object[]{});
+				if (valueClass.isInstance(fieldValue))
+					results.add(valueClass.cast(fieldValue));
+			} catch (Throwable e) {
+				throw new RuntimeException(
+						"Exception in " + each.getName(), e);
+			}
+		}
+		return results;
+	}
+	
 	public boolean isANonStaticInnerClass() {
 		return fClass.isMemberClass() && !isStatic(fClass.getModifiers());
 	}

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -29,6 +29,7 @@ import org.junit.tests.experimental.rules.ExpectedExceptionRuleTest;
 import org.junit.tests.experimental.rules.ExternalResourceRuleTest;
 import org.junit.tests.experimental.rules.MethodRulesTest;
 import org.junit.tests.experimental.rules.NameRulesTest;
+import org.junit.tests.experimental.rules.RuleFieldValidatorTest;
 import org.junit.tests.experimental.rules.RuleChainTest;
 import org.junit.tests.experimental.rules.TempFolderRuleTest;
 import org.junit.tests.experimental.rules.TestRuleTest;
@@ -77,7 +78,7 @@ import org.junit.tests.validation.FailedConstructionTest;
 import org.junit.tests.validation.InaccessibleBaseClassTest;
 import org.junit.tests.validation.ValidationTest;
 
-// These test files need to be cleaned.  See
+// These test files need to be cleaned. See
 // https://sourceforge.net/pm/task.php?func=detailtask&project_task_id=136507&group_id=15278&group_project_id=51407
 
 @SuppressWarnings("deprecation")
@@ -152,9 +153,10 @@ import org.junit.tests.validation.ValidationTest;
 	CategoryTest.class,
 	CategoriesAndParameterizedTest.class,
 	ParentRunnerFilteringTest.class,
+	BlockJUnit4ClassRunnerOverrideTest.class,
+	RuleFieldValidatorTest.class,
 	RuleChainTest.class,
-	BlockJUnit4ClassRunnerTest.class,
-	BlockJUnit4ClassRunnerOverrideTest.class
+	BlockJUnit4ClassRunnerTest.class
 })
 public class AllTests {
 	public static Test suite() {

--- a/src/test/java/org/junit/tests/experimental/rules/ClassRulesTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/ClassRulesTest.java
@@ -4,11 +4,18 @@
 package org.junit.tests.experimental.rules;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.experimental.results.PrintableResult.testResult;
+import static org.junit.experimental.results.ResultMatchers.isSuccessful;
+
+import java.util.LinkedList;
+import java.util.List;
+
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TestRule;
 import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
@@ -16,6 +23,9 @@ import org.junit.runners.model.Statement;
 
 /**
  * Tests to exercise class-level rules.
+ * This test class is very similar to {@link ClassRulesMethodTest}. If you add a test here, then it is likely that the other will have to be changed.
+ * This tests {@link ClassRule}s attached to fields.
+ * {@link ClassRulesMethodTest} tests {@link ClassRule}s attached to methods.
  */
 public class ClassRulesTest {
 	public static class Counter extends ExternalResource {
@@ -97,5 +107,131 @@ public class ClassRulesTest {
 		Result result= JUnitCore.runClasses(ExampleTestWithCustomClassRule.class);
 		assertTrue(result.wasSuccessful());
 		assertEquals(1, ExampleTestWithCustomClassRule.counter.count);
+	}
+	
+	private static final List<String> orderList= new LinkedList<String>();
+	
+	private static class OrderTestRule implements TestRule {
+		private String name;
+		
+		public OrderTestRule(String name) {
+			this.name= name;
+		}
+		
+		public Statement apply(final Statement base, final Description description) {
+			return new Statement() {				
+				@Override
+				public void evaluate() throws Throwable {
+					orderList.add(name);
+					base.evaluate();
+				}
+			};
+		}
+	};
+	
+	public static class UsesFieldAndMethodRule {
+		@ClassRule public static OrderTestRule orderMethod() { return new OrderTestRule("orderMethod"); }
+		@ClassRule public static OrderTestRule orderField= new OrderTestRule("orderField");
+		@Test public void foo() {
+			assertEquals("orderField", orderList.get(0));
+			assertEquals("orderMethod", orderList.get(1));
+		}
+	}
+	
+	@Test public void usesFieldAndMethodRule() {
+		orderList.clear();
+		assertThat(testResult(UsesFieldAndMethodRule.class), isSuccessful());
+	}
+
+	
+	public static class MethodExampleTestWithClassRule {
+		private static Counter counter= new Counter();
+		
+		@ClassRule
+		public static Counter getCounter() {
+			return counter;
+		}
+
+		@Test
+		public void firstTest() {
+			assertEquals(1, counter.count);
+		}
+
+		@Test
+		public void secondTest() {
+			assertEquals(1, counter.count);
+		}
+	}
+
+	@Test
+	public void methodRuleIsAppliedOnce() {
+		MethodExampleTestWithClassRule.counter.count= 0;
+		JUnitCore.runClasses(MethodExampleTestWithClassRule.class);
+		assertEquals(1, MethodExampleTestWithClassRule.counter.count);
+	}
+
+	public static class MethodSubclassOfTestWithClassRule extends
+		MethodExampleTestWithClassRule {
+
+	}
+
+	@Test
+	public void methodRuleIsIntroducedAndEvaluatedOnSubclass() {
+		MethodExampleTestWithClassRule.counter.count= 0;
+		JUnitCore.runClasses(MethodSubclassOfTestWithClassRule.class);
+		assertEquals(1, MethodExampleTestWithClassRule.counter.count);
+	}
+	
+	public static class MethodExampleTestWithCustomClassRule {
+		private static CustomCounter counter= new CustomCounter();
+
+		@ClassRule
+		public static CustomCounter getCounter() {
+			return counter;
+		}
+
+		@Test
+		public void firstTest() {
+			assertEquals(1, counter.count);
+		}
+
+		@Test
+		public void secondTest() {
+			assertEquals(1, counter.count);
+		}
+	}
+	
+
+	@Test
+	public void methodCustomRuleIsAppliedOnce() {
+		MethodExampleTestWithCustomClassRule.counter.count= 0;
+		Result result= JUnitCore.runClasses(MethodExampleTestWithCustomClassRule.class);
+		assertTrue(result.wasSuccessful());
+		assertEquals(1, MethodExampleTestWithCustomClassRule.counter.count);
+	}
+	
+	public static class CallMethodOnlyOnceRule {
+		static int countOfMethodCalls = 0;
+		private static class Dummy implements TestRule {
+			public Statement apply(final Statement base, Description description) {
+				return new Statement() {
+					@Override
+					public void evaluate() throws Throwable {
+						base.evaluate();
+					};
+				};
+			}
+		}
+		@ClassRule public static Dummy both() { countOfMethodCalls++; return new Dummy(); }
+		
+		@Test public void onlyOnce() {
+			assertEquals(1, countOfMethodCalls);
+		}
+	}
+
+	@Test
+	public void testCallMethodOnlyOnceRule() {
+		CallMethodOnlyOnceRule.countOfMethodCalls = 0;
+		assertTrue(JUnitCore.runClasses(CallMethodOnlyOnceRule.class).wasSuccessful());
 	}
 }

--- a/src/test/java/org/junit/tests/experimental/rules/RuleFieldValidatorTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/RuleFieldValidatorTest.java
@@ -1,7 +1,9 @@
 package org.junit.tests.experimental.rules;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.internal.runners.rules.RuleFieldValidator.CLASS_RULE_METHOD_VALIDATOR;
 import static org.junit.internal.runners.rules.RuleFieldValidator.CLASS_RULE_VALIDATOR;
+import static org.junit.internal.runners.rules.RuleFieldValidator.RULE_METHOD_VALIDATOR;
 import static org.junit.internal.runners.rules.RuleFieldValidator.RULE_VALIDATOR;
 
 import java.util.ArrayList;
@@ -83,6 +85,73 @@ public class RuleFieldValidatorTest {
 	public static class TestWithArbitraryObjectWithRuleAnnotation {
 		@Rule
 		public Object arbitraryObject = 1;
+	}
+
+	@Test
+	public void methodRejectProtectedClassRule() {
+		TestClass target= new TestClass(MethodTestWithProtectedClassRule.class);
+		CLASS_RULE_METHOD_VALIDATOR.validate(target, errors);
+		assertOneErrorWithMessage("The @ClassRule 'getTemporaryFolder' must be public.");
+	}
+
+	public static class MethodTestWithProtectedClassRule {
+		@ClassRule
+		protected static TestRule getTemporaryFolder() {
+			return new TemporaryFolder();
+		}
+	}
+
+	@Test
+	public void methodRejectNonStaticClassRule() {
+		TestClass target= new TestClass(MethodTestWithNonStaticClassRule.class);
+		CLASS_RULE_METHOD_VALIDATOR.validate(target, errors);
+		assertOneErrorWithMessage("The @ClassRule 'getTemporaryFolder' must be static.");
+	}
+
+	public static class MethodTestWithNonStaticClassRule {
+		@ClassRule
+		public TestRule getTemporaryFolder() { return new TemporaryFolder(); }
+	}
+
+	@Test
+	public void acceptMethodNonStaticTestRule() {
+		TestClass target= new TestClass(TestMethodWithNonStaticTestRule.class);
+		RULE_METHOD_VALIDATOR.validate(target, errors);
+		assertNumberOfErrors(0);
+	}
+
+	public static class TestMethodWithNonStaticTestRule {
+		@Rule
+		public TestRule getTemporaryFolder() { return new TemporaryFolder(); }
+	}
+
+	@Test
+	public void methodAcceptMethodRuleMethod() throws Exception {
+		TestClass target= new TestClass(MethodTestWithMethodRule.class);
+		RULE_METHOD_VALIDATOR.validate(target, errors);
+		assertNumberOfErrors(0);
+	}
+
+	public static class MethodTestWithMethodRule {
+		@Rule
+		public MethodRule getTemporaryFolder() { return new MethodRule(){
+			public Statement apply(Statement base, FrameworkMethod method,
+					Object target) {
+				return null;
+			}};
+		}
+	}
+
+	@Test
+	public void methodRejectArbitraryObjectWithRuleAnnotation() throws Exception {
+		TestClass target= new TestClass(MethodTestWithArbitraryObjectWithRuleAnnotation.class);
+		RULE_METHOD_VALIDATOR.validate(target, errors);
+		assertOneErrorWithMessage("The @Rule 'getArbitraryObject' must return an implementation of MethodRule or TestRule.");
+	}
+
+	public static class MethodTestWithArbitraryObjectWithRuleAnnotation {
+		@Rule
+		public Object getArbitraryObject() { return 1; }
 	}
 
 	private void assertOneErrorWithMessage(String message) {

--- a/src/test/java/org/junit/tests/experimental/rules/TestRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TestRuleTest.java
@@ -9,6 +9,10 @@ import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.hasSingleFailureContaining;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 import static org.junit.matchers.JUnitMatchers.containsString;
+
+import java.util.LinkedList;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -22,6 +26,11 @@ import org.junit.runner.Result;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 
+/**
+ * This test class is very similar to {@link TestMethodRuleTest}. If you add a test here, then it is likely that the other will have to be changed.
+ * This tests {@link Rule}s attached to fields.
+ * {@link TestMethodRuleTest} tests {@link Rule}s attached to methods.
+ */
 public class TestRuleTest {
 	private static boolean wasRun;
 
@@ -285,5 +294,360 @@ public class TestRuleTest {
 	
 	@Test public void useCustomMethodRule() {
 		assertThat(testResult(UsesCustomMethodRule.class), isSuccessful());
+	}
+	
+	public static class MethodExampleTest {
+		private TestRule example = new TestRule() {
+			public Statement apply(final Statement base, Description description) {
+				return new Statement() {
+					@Override
+					public void evaluate() throws Throwable {
+						wasRun= true;
+						base.evaluate();
+					};
+				};
+			}
+		};
+		
+		@Rule
+		public TestRule getExample() {
+			return example;
+		}
+
+		@Test
+		public void nothing() {
+
+		}
+	}
+
+	@Test
+	public void methodRuleIsIntroducedAndEvaluated() {
+		wasRun= false;
+		JUnitCore.runClasses(MethodExampleTest.class);
+		assertTrue(wasRun);
+	}
+	
+	@SuppressWarnings("deprecation")
+	public static class MethodBothKindsOfRule implements TestRule, org.junit.rules.MethodRule {
+		public int applications = 0;
+		
+		public Statement apply(Statement base, FrameworkMethod method,
+				Object target) {
+			applications++;
+			return base;
+		}
+
+		public Statement apply(Statement base, Description description) {
+			applications++;
+			return base;
+		}
+	}
+	
+	public static class MethodOneFieldTwoKindsOfRule {
+		private MethodBothKindsOfRule both = new MethodBothKindsOfRule();
+		
+		@Rule
+		public MethodBothKindsOfRule getBoth() {
+			return both;
+		}
+		
+		@Test public void onlyOnce() {
+			assertEquals(1, both.applications);
+		}
+	}
+	
+
+	@Test
+	public void methodOnlyApplyOnceEvenIfImplementsBothInterfaces() {
+		assertTrue(JUnitCore.runClasses(MethodOneFieldTwoKindsOfRule.class).wasSuccessful());
+	}
+
+	public static class MethodSonOfExampleTest extends MethodExampleTest {
+		
+	}
+
+	@Test
+	public void methodRuleIsIntroducedAndEvaluatedOnSubclass() {
+		wasRun= false;
+		JUnitCore.runClasses(MethodSonOfExampleTest.class);
+		assertTrue(wasRun);
+	}
+	
+//	private static int runCount;
+
+	public static class MethodMultipleRuleTest {
+		private static class Increment implements TestRule {
+			public Statement apply(final Statement base, Description description) {
+				return new Statement() {
+					@Override
+					public void evaluate() throws Throwable {
+						runCount++;
+						base.evaluate();
+					};
+				};
+			}
+		}
+
+		private TestRule incrementor1= new Increment();
+		
+		@Rule
+		public TestRule getIncrementor1() {
+			return incrementor1;
+		}
+
+		private TestRule incrementor2= new Increment();
+
+		@Rule
+		public TestRule getIncrementor2() {
+			return incrementor2;
+		}
+
+		@Test
+		public void nothing() {
+
+		}
+	}
+
+	@Test
+	public void methodMultipleRulesAreRun() {
+		runCount= 0;
+		JUnitCore.runClasses(MethodMultipleRuleTest.class);
+		assertEquals(2, runCount);
+	}
+
+	public static class MethodNoRulesTest {
+		public int x;
+
+		@Test
+		public void nothing() {
+
+		}
+	}
+
+	@Test
+	public void methodIgnoreNonRules() {
+		Result result= JUnitCore.runClasses(MethodNoRulesTest.class);
+		assertEquals(0, result.getFailureCount());
+	}
+
+	public static class MethodOnFailureTest {
+		private TestRule watchman= new TestWatcher() {
+			@Override
+			protected void failed(Throwable e, Description description) {
+				log+= description + " " + e.getClass().getSimpleName();
+			}
+		};
+		
+		@Rule
+		public TestRule getWatchman() {
+			return watchman;
+		}
+
+		@Test
+		public void nothing() {
+			fail();
+		}
+	}
+
+	@Test
+	public void methodOnFailure() {
+		log= "";
+		Result result= JUnitCore.runClasses(MethodOnFailureTest.class);
+		assertEquals(String.format("nothing(%s) AssertionError", MethodOnFailureTest.class.getName()), log);
+		assertEquals(1, result.getFailureCount());
+	}
+
+	public static class MethodWatchmanTest {
+		private static String watchedLog;
+
+		private TestRule watchman= new TestWatcher() {
+			@Override
+			protected void failed(Throwable e, Description description) {
+				watchedLog+= description + " "
+						+ e.getClass().getSimpleName() + "\n";
+			}
+
+			@Override
+			protected void succeeded(Description description) {
+				watchedLog+= description + " " + "success!\n";
+			}
+		};
+
+		@Rule
+		public TestRule getWatchman() {
+			return watchman;
+		}
+
+		@Test
+		public void fails() {
+			fail();
+		}
+
+		@Test
+		public void succeeds() {
+		}
+	}
+
+	@Test
+	public void methodSucceeded() {
+		WatchmanTest.watchedLog= "";
+		JUnitCore.runClasses(WatchmanTest.class);
+		assertThat(WatchmanTest.watchedLog, containsString(String.format("fails(%s) AssertionError", WatchmanTest.class.getName())));
+		assertThat(WatchmanTest.watchedLog, containsString(String.format("succeeds(%s) success!", WatchmanTest.class.getName())));
+	}
+
+	public static class MethodBeforesAndAfters {
+		private static String watchedLog;
+
+		@Before public void before() {
+			watchedLog+= "before ";
+		}
+		
+		private TestRule watchman= new TestWatcher() {
+			@Override
+			protected void starting(Description d) {
+				watchedLog+= "starting ";
+			}
+			
+			@Override
+			protected void finished(Description d) {
+				watchedLog+= "finished ";
+			}
+			
+			@Override
+			protected void succeeded(Description d) {
+				watchedLog+= "succeeded ";
+			}
+		};
+		
+		@Rule
+		public TestRule getWatchman() {
+			return watchman;
+		}
+
+		@After public void after() {
+			watchedLog+= "after ";
+		}
+
+		@Test
+		public void succeeds() {
+			watchedLog+= "test ";
+		}
+	}
+
+	@Test
+	public void methodBeforesAndAfters() {
+		MethodBeforesAndAfters.watchedLog= "";
+		JUnitCore.runClasses(MethodBeforesAndAfters.class);
+		assertThat(MethodBeforesAndAfters.watchedLog, is("starting before test after succeeded finished "));
+	}
+	
+	public static class MethodWrongTypedField {
+		@Rule public int getX() { return 5; }
+		@Test public void foo() {}
+	}
+	
+	@Test public void methodValidateWrongTypedField() {
+		assertThat(testResult(MethodWrongTypedField.class), 
+				hasSingleFailureContaining("must return an implementation of MethodRule"));
+	}
+	
+	public static class MethodSonOfWrongTypedField extends MethodWrongTypedField {
+		
+	}
+
+	@Test public void methodValidateWrongTypedFieldInSuperclass() {
+		assertThat(testResult(MethodSonOfWrongTypedField.class), 
+				hasSingleFailureContaining("must return an implementation of MethodRule"));
+	}
+
+	public static class MethodPrivateRule {
+		@SuppressWarnings("unused")
+		@Rule private TestRule getRule() { return new TestName(); }
+		@Test public void foo() {}
+	}
+	
+	@Test public void methodValidatePrivateRule() {
+		assertThat(testResult(MethodPrivateRule.class), 
+				hasSingleFailureContaining("must be public"));
+	}
+	
+	public static class MethodUsesCustomMethodRule {
+		private CustomTestName counter = new CustomTestName();
+		@Rule public CustomTestName getCounter() { return counter; }
+		@Test public void foo() {
+			assertEquals("foo", counter.name);
+		}
+	}
+
+	@Test public void methodUseCustomMethodRule() {
+ 		assertThat(testResult(MethodUsesCustomMethodRule.class), isSuccessful());
+ 	}
+
+ 	private static final List<String> orderList= new LinkedList<String>();
+	
+	private static class OrderTestRule implements TestRule {
+		private String name;
+		
+		public OrderTestRule(String name) {
+			this.name= name;
+		}
+		
+		public Statement apply(final Statement base, final Description description) {
+			return new Statement() {				
+				@Override
+				public void evaluate() throws Throwable {
+					orderList.add(name);
+					base.evaluate();
+				}
+			};
+		}
+	};
+	
+	public static class UsesFieldAndMethodRule {
+		@Rule public OrderTestRule orderMethod() { return new OrderTestRule("orderMethod"); }
+		@Rule public OrderTestRule orderField= new OrderTestRule("orderField");
+		@Test public void foo() {
+			assertEquals("orderField", orderList.get(0));
+			assertEquals("orderMethod", orderList.get(1));
+		}
+	}
+	
+	@Test public void usesFieldAndMethodRule() {
+		orderList.clear();
+		assertThat(testResult(UsesFieldAndMethodRule.class), isSuccessful());
+	}
+	
+	public static class MultipleCallsTest implements TestRule {
+		public int applications = 0;
+		
+		public Statement apply(Statement base, Description description) {
+			applications++;
+			return base;
+		}
+	}
+	
+	public static class CallMethodOnlyOnceRule {
+		int countOfMethodCalls = 0;
+		private static class Dummy implements TestRule {
+			public Statement apply(final Statement base, Description description) {
+				return new Statement() {
+					@Override
+					public void evaluate() throws Throwable {
+						base.evaluate();
+					};
+				};
+			}
+		}
+		@Rule public Dummy both() { countOfMethodCalls++; return new Dummy(); }
+		
+		@Test public void onlyOnce() {
+			assertEquals(1, countOfMethodCalls);
+		}
+	}
+
+	@Test
+	public void testCallMethodOnlyOnceRule() {
+		assertTrue(JUnitCore.runClasses(CallMethodOnlyOnceRule.class).wasSuccessful());
 	}
 }


### PR DESCRIPTION
Extend rules to support @Rule public MethodRule someRule() { return new SomeRule(); }

Scala does not allow the creation of public fields. If you declare a field public, the field is created as private but with accessor methods.
To allow the use of @Rule with Scala fields, this patch allows the addition
of @Rule to methods. When BlockJUnit4ClassRunner retrieves the list of fields
that have the @Rule annotation, it also searches for methods with @Rule.
These methods are called and the values returned are added to the list of
TestRule.

@ClassRule has been similarly changed.

This is intended to be used as follows:

private ExpectedException thrown = rules.ExpectedException.none();

@Rule public ExpectedException getThrown() {
    return thrown;
}

or

@Rule public Timeout getTimeout() {
    return new Timeout(20);
}

The validation is exactly the same as for the fields, i.e the methods must be
public and return a TestRule/MethodRule. In the case of @ClassRule, the
methods must also be static.
