### PR TITLE
fix for #49 Master now builds on windows

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -132,7 +132,8 @@
   
   <target name="release-notes">
     <property name="basename" value="doc/ReleaseNotes${version-base}" />
-    <exec executable="build/Markdown.pl" failonerror="true">
+    <exec executable="perl" failonerror="true">
+      <arg file="build/Markdown.pl"/>
       <arg file="${basename}.txt"/>
       <redirector output="${basename}.html" />
     </exec>


### PR DESCRIPTION
When running ant on windows, running build/markdown.pl doesn't work, so we run perl with parameter build/markdown.pl instead.
