### PR TITLE
Removed explicit constructor of JUnitCore

### DIFF
--- a/src/main/java/org/junit/runner/JUnitCore.java
+++ b/src/main/java/org/junit/runner/JUnitCore.java
@@ -25,14 +25,7 @@ import org.junit.runner.notification.RunNotifier;
  * @see org.junit.runner.Request
  */
 public class JUnitCore {
-	private RunNotifier fNotifier;
-
-	/**
-	 * Create a new <code>JUnitCore</code> to run tests.
-	 */
-	public JUnitCore() {
-		fNotifier= new RunNotifier();
-	}
+	private final RunNotifier fNotifier= new RunNotifier();
 
 	/**
 	 * Run the tests contained in the classes named in the <code>args</code>.


### PR DESCRIPTION
The constructor was used to create the RunNotifier. Now the
initial value of the RunNotifier is provided in its declaration.

Additionally added the final modifiert to the RunNotifier in
order to make it clear, that it never changes.
