### PR TITLE
Added naming feature to Parameterized (Issue #24).

### DIFF
--- a/src/main/java/org/junit/runners/Parameterized.java
+++ b/src/main/java/org/junit/runners/Parameterized.java
@@ -67,6 +67,24 @@ public class Parameterized extends Suite {
 	@Target(ElementType.METHOD)
 	public static @interface Parameters {
 	}
+	
+	/**
+	 * A Name can be used to identify a Parameterized Test.
+	 * Let one of the parameters be a Name.
+	 * The constructor of the class under test must also pick up the name.
+	 */
+	public static class Name {
+		private final String fName;
+		
+		public Name(final String name) {
+			fName = name;
+		}
+		
+		@Override
+		public String toString() {
+			return fName;
+		}
+	}
 
 	private class TestClassRunnerForParameters extends
 			BlockJUnit4ClassRunner {
@@ -97,16 +115,33 @@ public class Parameterized extends Suite {
 								getTestClass()).getName()));
 			}
 		}
-
+		
+		private String getTestcaseName() {
+			Object params = fParameterList.get(fParameterSetNumber);
+			// it's uncertain that the parameters are really an array 
+			// of objects
+			// in case computeParams catches a ClassCast, this method
+			// would cause another ClassCast while constructing a
+			// meaningful exception
+			if (params instanceof Object[]) {
+				for (Object o : (Object[]) params) {
+					if (o instanceof Name) {
+						return String.valueOf(o);
+					}
+				}
+			}
+			return String.valueOf(fParameterSetNumber);
+		}
+		
 		@Override
 		protected String getName() {
-			return String.format("[%s]", fParameterSetNumber);
+			return String.format("[%s]", getTestcaseName());
 		}
 
 		@Override
 		protected String testName(final FrameworkMethod method) {
 			return String.format("%s[%s]", method.getName(),
-					fParameterSetNumber);
+					getTestcaseName());
 		}
 
 		@Override

--- a/src/test/java/org/junit/tests/running/classes/ParameterizedTestTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParameterizedTestTest.java
@@ -19,6 +19,7 @@ import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 import org.junit.runner.Runner;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Name;
 import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.model.InitializationError;
 
@@ -49,7 +50,7 @@ public class ParameterizedTestTest {
 			return 0;
 		}
 	}
-
+	
 	@Test
 	public void count() {
 		Result result= JUnitCore.runClasses(FibonacciTest.class);
@@ -213,4 +214,36 @@ public class ParameterizedTestTest {
 	public void exceptionWhenPrivateConstructor() throws Throwable {
 		new Parameterized(PrivateConstructor.class);
 	}
+
+	@RunWith(Parameterized.class)
+	public static class SinusTest {
+		@Parameters
+		public static Collection<Object[]> data() {
+			return Arrays.asList(new Object[][]{ { new Name("sin-90¡"), 90, 0.893996664 } });
+		}
+		
+		private static final double ACCEPTED_DELTA = 0.0000000001;
+		
+		private int fDegrees;
+		private double fExpected;
+		
+		public SinusTest(Name name, int degrees, double expected) {
+			this.fDegrees = degrees;
+			this.fExpected = expected;
+		}
+		
+		@Test
+		public void test() {
+			assertEquals(fExpected, Math.sin(fDegrees), ACCEPTED_DELTA);
+		}
+	}
+	
+	@Test
+	public void namedTestsLookFine() {
+		Result result = JUnitCore.runClasses(SinusTest.class);
+		assertEquals(String.format("%s[%s](%s)", "test", "sin-90¡", 
+				SinusTest.class.getName()), result.getFailures()
+				.get(0).getTestHeader());
+	}
+
 }


### PR DESCRIPTION
This tiny patch implements the feature request #24 "Flexible naming of parameterized tests".
It adds a Name class which can be used as one of the parameters returned by the @Parameter method.
The first Name found will be used, if none is found the old parameter index will be used.
In both cases, the old name format will be used, so either "NAME" for a test-class, or "method [NAME]" for each test-method.

Hope you'll find it as useful as I do, so please have a look.
Kindly asking to pull this feature.

Best regards,

Florian
