### PR TITLE
Created JUnitSelfTestRunner

### DIFF
--- a/src/main/java/org/junit/test/DescriptionMatchers.java
+++ b/src/main/java/org/junit/test/DescriptionMatchers.java
@@ -1,0 +1,29 @@
+package org.junit.test;
+
+import org.hamcrest.Matcher;
+import org.junit.runner.Description;
+import org.junit.test.internal.HasDisplayName;
+
+/**
+ * A collection of hamcrest matchers for the {@link Description}.
+ */
+public class DescriptionMatchers {
+	/**
+	 * Evaluates to true if the {@link Description} has the specified display
+	 * name.
+	 * 
+	 * @param name
+	 *            the expected display name.
+	 */
+	public static Matcher<Description> hasDisplayName(String name) {
+		return new HasDisplayName(name);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher returns true for the
+	 * {@link Description}'s display name.
+	 */
+	public static Matcher<Description> hasDisplayName(Matcher<String> matcher) {
+		return new HasDisplayName(matcher);
+	}
+}

--- a/src/main/java/org/junit/test/EventCollector.java
+++ b/src/main/java/org/junit/test/EventCollector.java
@@ -1,0 +1,219 @@
+package org.junit.test;
+
+import static java.util.Arrays.asList;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.test.internal.ReadEventsCommand;
+import org.junit.test.internal.ReadFailedAssumptionsCommand;
+import org.junit.test.internal.ReadFailuresCommand;
+import org.junit.test.internal.ReadFinishedTestRunsCommand;
+import org.junit.test.internal.ReadFinishedTestsCommand;
+import org.junit.test.internal.ReadIgnoredTestsCommand;
+import org.junit.test.internal.ReadStartedTestRunsCommand;
+import org.junit.test.internal.ReadStartedTestsCommand;
+
+/**
+ * The {@code EventCollector} is a simple {@link RunListener}, that collects all
+ * the events of a test run.
+ */
+public class EventCollector extends RunListener {
+	private final List<Description> fTestRunsStarted= new ArrayList<Description>();
+
+	private final List<Result> fTestRunsFinished= new ArrayList<Result>();
+
+	private final List<Description> fTestsStarted= new ArrayList<Description>();
+
+	private final List<Description> fTestsFinished= new ArrayList<Description>();
+
+	private final List<Failure> fFailures= new ArrayList<Failure>();
+
+	private final List<Failure> fFailedAssumptions= new ArrayList<Failure>();
+
+	private final List<Description> fTestsIgnored= new ArrayList<Description>();
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void testRunStarted(Description description) throws Exception {
+		fTestRunsStarted.add(description);
+	}
+
+	/**
+	 * Returns a list of the {@code Description}s of all started test runs.
+	 * 
+	 * @return a list of the started test runs.
+	 */
+	public List<Description> getStartedTestRuns() {
+		return new ArrayList<Description>(fTestRunsStarted);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void testRunFinished(Result result) throws Exception {
+		fTestRunsFinished.add(result);
+	}
+
+	/**
+	 * Returns a list of the {@code Result}s of all finished test runs.
+	 * 
+	 * @return a list of the finished test runs.
+	 */
+	public List<Result> getFinishedTestRuns() {
+		return new ArrayList<Result>(fTestRunsFinished);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void testStarted(Description description) throws Exception {
+		fTestsStarted.add(description);
+	}
+
+	/**
+	 * Returns a list of the {@code Description}s of all started tests.
+	 * 
+	 * @return a list of the started tests.
+	 */
+	public List<Description> getStartedTests() {
+		return new ArrayList<Description>(fTestsStarted);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void testFinished(Description description) throws Exception {
+		fTestsFinished.add(description);
+	}
+
+	/**
+	 * Returns a list of the {@code Description}s of all finished tests.
+	 * 
+	 * @return a list of the finished tests.
+	 */
+	public List<Description> getFinishedTests() {
+		return new ArrayList<Description>(fTestsFinished);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void testFailure(Failure failure) throws Exception {
+		fFailures.add(failure);
+	}
+
+	/**
+	 * Returns a list of all {@code Failure}s.
+	 * 
+	 * @return a list of the failures.
+	 */
+	public List<Failure> getFailures() {
+		return new ArrayList<Failure>(fFailures);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void testAssumptionFailure(Failure failure) {
+		fFailedAssumptions.add(failure);
+	}
+
+	/**
+	 * Returns a list of the {@code Failure}s fo all failed assumptions.
+	 * 
+	 * @return a list of the failed assumptions.
+	 */
+	public List<Failure> getFailedAssumptions() {
+		return new ArrayList<Failure>(fFailedAssumptions);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void testIgnored(Description description) throws Exception {
+		fTestsIgnored.add(description);
+	}
+
+	/**
+	 * Returns a list of the {@code Description}s of all ignored tests.
+	 * 
+	 * @return a list of the ignored tests.
+	 */
+	public List<Description> getIgnoredTests() {
+		return new ArrayList<Description>(fTestsIgnored);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this).toString();
+	}
+
+	private static class ToStringBuilder {
+		@SuppressWarnings("unchecked")
+		static final List<ReadEventsCommand<? extends Serializable>> READ_EVENTS_COMMANDS= asList(
+				new ReadStartedTestRunsCommand(),
+				new ReadFinishedTestRunsCommand(),
+				new ReadStartedTestsCommand(), new ReadFinishedTestsCommand(),
+				new ReadFailedAssumptionsCommand(), new ReadFailuresCommand(),
+				new ReadIgnoredTestsCommand());
+
+		StringBuilder sb= new StringBuilder();
+
+		ToStringBuilder(EventCollector eventCollector) {
+			for (ReadEventsCommand<?> command : READ_EVENTS_COMMANDS) {
+				addItemsWithHeadline(command, eventCollector);
+			}
+		}
+
+		void addItemsWithHeadline(ReadEventsCommand<?> command,
+				EventCollector eventCollector) {
+			List<?> items= command.getEventsFromEventCollector(eventCollector);
+			String headline= command.getName() + "s";
+			addItemsWithHeadline(items, headline);
+		}
+
+		void addItemsWithHeadline(List<?> items, String headline) {
+			if (items.isEmpty())
+				noItemsWithHeadline(headline);
+			else {
+				numberOfItemsWithHeadline(items, headline);
+				appendItems(items);
+			}
+		}
+
+		void noItemsWithHeadline(String headline) {
+			sb.append("no " + headline + "\n");
+		}
+
+		void numberOfItemsWithHeadline(List<?> items, String headline) {
+			sb.append(items.size() + " " + headline + "\n");
+		}
+
+		void appendItems(List<?> items) {
+			for (Object item : items) {
+				sb.append(" * ");
+				sb.append(item.toString());
+				sb.append("\n");
+			}
+		}
+
+		@Override
+		public String toString() {
+			return sb.toString();
+		}
+	}
+}

--- a/src/main/java/org/junit/test/EventCollectorMatchers.java
+++ b/src/main/java/org/junit/test/EventCollectorMatchers.java
@@ -1,0 +1,238 @@
+package org.junit.test;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import org.hamcrest.Matcher;
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.test.internal.AtLeastOnEvent;
+import org.junit.test.internal.NumberOfEvents;
+import org.junit.test.internal.ReadFailedAssumptionsCommand;
+import org.junit.test.internal.ReadFailuresCommand;
+import org.junit.test.internal.ReadFinishedTestRunsCommand;
+import org.junit.test.internal.ReadFinishedTestsCommand;
+import org.junit.test.internal.ReadIgnoredTestsCommand;
+import org.junit.test.internal.ReadStartedTestRunsCommand;
+import org.junit.test.internal.ReadStartedTestsCommand;
+
+/**
+ * A collection of hamcrest matchers for the {@link EventCollector}.
+ */
+public class EventCollectorMatchers {
+	private static final ReadFailedAssumptionsCommand READ_FAILED_ASSUMPTIONS= new ReadFailedAssumptionsCommand();
+
+	private static final ReadFailuresCommand READ_FAILURES= new ReadFailuresCommand();
+
+	private static final ReadFinishedTestRunsCommand READ_FINISHED_TEST_RUNS= new ReadFinishedTestRunsCommand();
+
+	private static final ReadFinishedTestsCommand READ_FINISHED_TESTS= new ReadFinishedTestsCommand();
+
+	private static final ReadIgnoredTestsCommand READ_IGNORED_TESTS= new ReadIgnoredTestsCommand();
+
+	private static final ReadStartedTestsCommand READ_STARTED_TESTS= new ReadStartedTestsCommand();
+
+	private static final ReadStartedTestRunsCommand READ_STARTED_TEST_RUNS= new ReadStartedTestRunsCommand();
+
+	/**
+	 * This is a shortcut for the frequently used Matcher combination
+	 * {@code allOf(noFailures(), noFailedAssumptions(), noIgnoredTests())}
+	 */
+	@SuppressWarnings("unchecked")
+	public static Matcher<EventCollector> onlySuccessfulTests() {
+		return allOf(noFailures(), noFailedAssumptions(), noIgnoredTests());
+	}
+
+	/**
+	 * Evaluates to true if the specified number of failed assumptions occurred.
+	 * 
+	 * @param numberOfFailedAssumptions
+	 *            the expected number of failed assumptions.
+	 */
+	public static Matcher<EventCollector> numberOfFailedAssumptions(
+			int numberOfFailedAssumptions) {
+		return new NumberOfEvents<Failure>(READ_FAILED_ASSUMPTIONS,
+				numberOfFailedAssumptions);
+	}
+
+	/**
+	 * Evaluates to true if no assumption failed.
+	 */
+	public static Matcher<EventCollector> noFailedAssumptions() {
+		return numberOfFailedAssumptions(0);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher evaluates to true for at least
+	 * one of the failed assumptions.
+	 */
+	public static Matcher<EventCollector> failedAssumption(
+			Matcher<Failure> matcher) {
+		return new AtLeastOnEvent<Failure>(READ_FAILED_ASSUMPTIONS, matcher);
+	}
+
+	/**
+	 * Evaluates to true if the specified number of failures occurred.
+	 * 
+	 * @param numberOfFailures
+	 *            the expected number of failures.
+	 */
+	public static Matcher<EventCollector> numberOfFailures(int numberOfFailures) {
+		return new NumberOfEvents<Failure>(READ_FAILURES, numberOfFailures);
+	}
+
+	/**
+	 * Evaluates to true if no failures occurred.
+	 */
+	public static Matcher<EventCollector> noFailures() {
+		return numberOfFailures(0);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher evaluates to true for at least
+	 * one of the failures.
+	 */
+	public static Matcher<EventCollector> failure(Matcher<Failure> matcher) {
+		return new AtLeastOnEvent<Failure>(READ_FAILURES, matcher);
+	}
+
+	/**
+	 * Evaluates to true if the specified number of tests have been finished.
+	 * 
+	 * @param numberOfFinishedTests
+	 *            the expected number of finished tests.
+	 */
+	public static Matcher<EventCollector> numberOfFinishedTests(
+			int numberOfFinishedTests) {
+		return new NumberOfEvents<Description>(READ_FINISHED_TESTS,
+				numberOfFinishedTests);
+	}
+
+	/**
+	 * Evaluates to true if no test finished.
+	 */
+	public static Matcher<EventCollector> noFinishedTests() {
+		return numberOfFinishedTests(0);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher evaluates to true for at least
+	 * one of the finished tests.
+	 */
+	public static Matcher<EventCollector> finishedTest(
+			Matcher<Description> matcher) {
+		return new AtLeastOnEvent<Description>(READ_FINISHED_TESTS, matcher);
+	}
+
+	/**
+	 * Evaluates to true if the specified number of test runs have been
+	 * finished.
+	 * 
+	 * @param numberOfFinishedTestRuns
+	 *            the expected number of finished test runs.
+	 */
+	public static Matcher<EventCollector> numberOfFinishedTestRuns(
+			int numberOfFinishedTestRuns) {
+		return new NumberOfEvents<Result>(READ_FINISHED_TEST_RUNS,
+				numberOfFinishedTestRuns);
+	}
+
+	/**
+	 * Evaluates to true if no test run finished.
+	 */
+	public static Matcher<EventCollector> noFinishedTestRuns() {
+		return numberOfFinishedTestRuns(0);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher evaluates to true for at least
+	 * one of the finished test runs.
+	 */
+	public static Matcher<EventCollector> finishedTestRun(
+			Matcher<Result> matcher) {
+		return new AtLeastOnEvent<Result>(READ_FINISHED_TEST_RUNS, matcher);
+	}
+
+	/**
+	 * Evaluates to true if the specified number of tests have been ignored.
+	 * 
+	 * @param numberOfIgnoredTests
+	 *            the expected number of ignored tests.
+	 */
+	public static Matcher<EventCollector> numberOfIgnoredTests(
+			int numberOfIgnoredTests) {
+		return new NumberOfEvents<Description>(READ_IGNORED_TESTS,
+				numberOfIgnoredTests);
+	}
+
+	/**
+	 * Evaluates to true if no test has been ignored.
+	 */
+	public static Matcher<EventCollector> noIgnoredTests() {
+		return numberOfIgnoredTests(0);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher evaluates to true for at least
+	 * one of the ignored tests.
+	 */
+	public static Matcher<EventCollector> ignoredTest(
+			Matcher<Description> matcher) {
+		return new AtLeastOnEvent<Description>(READ_IGNORED_TESTS, matcher);
+	}
+
+	/**
+	 * Evaluates to true if the specified number of tests have been started.
+	 * 
+	 * @param numberOfStartedTests
+	 *            the expected number of started tests.
+	 */
+	public static Matcher<EventCollector> numberOfStartedTests(
+			int numberOfStartedTests) {
+		return new NumberOfEvents<Description>(READ_STARTED_TESTS,
+				numberOfStartedTests);
+	}
+
+	/**
+	 * Evaluates to true if no test has been started.
+	 */
+	public static Matcher<EventCollector> noStartedTests() {
+		return numberOfStartedTests(0);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher evaluates to true for at least
+	 * one of the started tests.
+	 */
+	public static Matcher<EventCollector> startedTest(
+			Matcher<Description> matcher) {
+		return new AtLeastOnEvent<Description>(READ_STARTED_TESTS, matcher);
+	}
+
+	/**
+	 * Evaluates to true if the specified number of test runs have been started.
+	 * 
+	 * @param numberOfStartedTestRuns
+	 *            the expected number of started test runs.
+	 */
+	public static Matcher<EventCollector> numberOfStartedTestRuns(
+			int numberOfStartedTestRuns) {
+		return new NumberOfEvents<Description>(READ_STARTED_TEST_RUNS,
+				numberOfStartedTestRuns);
+	}
+
+	/**
+	 * Evaluates to true if no test run has been started.
+	 */
+	public static Matcher<EventCollector> noStartedTestRuns() {
+		return numberOfStartedTestRuns(0);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher evaluates to true for at least
+	 * one of the started test runs.
+	 */
+	public static Matcher<EventCollector> startedTestRun(
+			Matcher<Description> matcher) {
+		return new AtLeastOnEvent<Description>(READ_STARTED_TEST_RUNS, matcher);
+	}
+}

--- a/src/main/java/org/junit/test/ExpectedEvents.java
+++ b/src/main/java/org/junit/test/ExpectedEvents.java
@@ -1,0 +1,18 @@
+package org.junit.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@code ExpectedEvents} annotation is used to tell the
+ * {@link JUnitSelfTestRunner}, which field provides the test specification.
+ * 
+ * @see JUnitSelfTestRunner
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD })
+public @interface ExpectedEvents {
+
+}

--- a/src/main/java/org/junit/test/FailureMatchers.java
+++ b/src/main/java/org/junit/test/FailureMatchers.java
@@ -1,0 +1,48 @@
+package org.junit.test;
+
+import org.hamcrest.Matcher;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.test.internal.HasDescription;
+import org.junit.test.internal.HasMessage;
+
+/**
+ * A collection of hamcrest matchers for the {@link Failure}.
+ */
+public class FailureMatchers {
+	/**
+	 * Evaluates to true if the {@link Failure} has the specified message.
+	 * 
+	 * @param message
+	 *            the expected message.
+	 */
+	public static Matcher<Failure> hasMessage(String message) {
+		return new HasMessage(message);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher returns true for the
+	 * {@link Failure}'s message.
+	 */
+	public static Matcher<Failure> hasMessage(Matcher<String> matcher) {
+		return new HasMessage(matcher);
+	}
+
+	/**
+	 * Evaluates to true if the {@link Failure} has the specified description.
+	 * 
+	 * @param description
+	 *            the expected description.
+	 */
+	public static Matcher<Failure> hasDescription(Description description) {
+		return new HasDescription(description);
+	}
+
+	/**
+	 * Evaluates to true if the specified matcher returns true for the
+	 * {@link Failure}'s description.
+	 */
+	public static Matcher<Failure> hasDescription(Matcher<Description> matcher) {
+		return new HasDescription(matcher);
+	}
+}

--- a/src/main/java/org/junit/test/JUnitSelfTest.java
+++ b/src/main/java/org/junit/test/JUnitSelfTest.java
@@ -1,0 +1,18 @@
+package org.junit.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@code JUnitSelfTest} annotation is used to tell the
+ * {@link JUnitSelfTestRunner}, that an inner classes is a test.
+ * 
+ * @see JUnitSelfTestRunner
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+public @interface JUnitSelfTest {
+
+}

--- a/src/main/java/org/junit/test/JUnitSelfTestRunner.java
+++ b/src/main/java/org/junit/test/JUnitSelfTestRunner.java
@@ -1,0 +1,147 @@
+package org.junit.test;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.runner.Description.createTestDescription;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hamcrest.Matcher;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.TestClass;
+
+/**
+ * The {@code JUnitSelfTestRunner} is a test runner for declarative tests of
+ * JUnit itself. It runs your test classes and verifies the JUnit events
+ * (failure, test started, ...) according to your specification.
+ * 
+ * <p>
+ * A test class using this runner has several static inner classes, which are
+ * annotated with {@link JUnitSelfTest}. Every such class is a single test and
+ * the test specification is provided by a hamcrest matcher, which is an
+ * additional field annotated with {@link ExpectedEvents}. The
+ * {@link EventCollectorMatchers} class provides some matchers.
+ * 
+ * <p>
+ * Here is an example of a test class with two tests.
+ * 
+ * <pre>
+ * &#064;RunWith(JUnitSelfTestRunner.class)
+ * public class MySelfTests {
+ * 	&#064;JUnitSelfTest
+ * 	public static class FirstSelfTest {
+ * 		&#064;ExpectedEvents
+ * 		public static final Matcher&lt;EventCollector&gt; EXPECTED_EVENTS= onlySuccessfulTests();
+ * 
+ * 		&#064;Test
+ * 		public void successfulTest() {
+ * 			assertTrue(true);
+ * 		}
+ * 	}
+ * 
+ * 	&#064;JUnitSelfTest
+ * 	public static class SecondSelfTest {
+ * 		&#064;ExpectedEvents
+ * 		public static final Matcher&lt;EventCollector&gt; EXPECTED_EVENTS= numberOfFailures(1);
+ * 
+ * 		&#064;Test
+ * 		public void successfulTest() {
+ * 			assertTrue(true);
+ * 		}
+ * 
+ * 		&#064;Test
+ * 		public void failingTest() {
+ * 			fail();
+ * 		}
+ * 	}
+ * }
+ * </pre>
+ */
+public class JUnitSelfTestRunner extends ParentRunner<Class<?>> {
+
+	public JUnitSelfTestRunner(Class<?> testClass) throws InitializationError {
+		super(testClass);
+	}
+
+	@Override
+	protected List<Class<?>> getChildren() {
+		Class<?>[] declaredClasses= getTestClass().getJavaClass()
+				.getDeclaredClasses();
+		return filterJUnitSelfTests(declaredClasses);
+	}
+
+	private List<Class<?>> filterJUnitSelfTests(Class<?>[] declaredClasses) {
+		ArrayList<Class<?>> jUnitSelfTests= new ArrayList<Class<?>>();
+		for (Class<?> each : declaredClasses)
+			if (each.isAnnotationPresent(JUnitSelfTest.class))
+				jUnitSelfTests.add(each);
+		return jUnitSelfTests;
+	}
+
+	@Override
+	protected Description describeChild(Class<?> child) {
+		return createTestDescription(getTestClass().getJavaClass(),
+				testname(child));
+	}
+
+	private String testname(Class<?> child) {
+		return child.getSimpleName();
+	}
+
+	@Override
+	protected void runChild(Class<?> child, RunNotifier notifier) {
+		Description description= describeChild(child);
+		notifier.fireTestStarted(description);
+		EventCollector collector= collectEventsForTest(child);
+		verify(description, child, collector, notifier);
+		notifier.fireTestFinished(description);
+	}
+
+	private EventCollector collectEventsForTest(Class<?> test) {
+		EventCollector collector= new EventCollector();
+		JUnitCore core= new JUnitCore();
+		core.addListener(collector);
+		core.run(test);
+		return collector;
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private void verify(Description description, Class<?> testClass,
+			EventCollector collector, RunNotifier notifier) {
+		List<Matcher> matchers= getMatchersOfClass(testClass);
+		if (matchers.size() == 1)
+			verifyErrorCollector(collector, matchers.get(0), description,
+					notifier);
+		else
+			fireWrongNumberOfMatchers(description, notifier, matchers.size());
+	}
+
+	@SuppressWarnings("rawtypes")
+	private List<Matcher> getMatchersOfClass(Class<?> testClass) {
+		return new TestClass(testClass).getAnnotatedFieldValues(null,
+				ExpectedEvents.class, Matcher.class);
+	}
+
+	private void verifyErrorCollector(EventCollector collector,
+			Matcher<EventCollector> matcher, Description description,
+			RunNotifier notifier) {
+		try {
+			assertThat(collector, matcher);
+		} catch (AssertionError e) {
+			notifier.fireTestFailure(new Failure(description, e));
+		}
+	}
+
+	private void fireWrongNumberOfMatchers(Description description,
+			RunNotifier notifier, int numberOfMatchers) {
+		RuntimeException exception= new RuntimeException(numberOfMatchers
+				+ " fields with ExpectedEvents annotation instead of one.");
+		Failure failure= new Failure(description, exception);
+		notifier.fireTestFailure(failure);
+	}
+}

--- a/src/main/java/org/junit/test/internal/AtLeastOnEvent.java
+++ b/src/main/java/org/junit/test/internal/AtLeastOnEvent.java
@@ -1,0 +1,39 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.test.EventCollector;
+
+public class AtLeastOnEvent<T> extends BaseMatcher<EventCollector> {
+	private final ReadEventsCommand<T> fReadEventsCommand;
+	private final Matcher<T> fMatcher;
+
+	public AtLeastOnEvent(ReadEventsCommand<T> readEventsCommand,
+			Matcher<T> matcher) {
+		fReadEventsCommand= readEventsCommand;
+		fMatcher= matcher;
+	}
+
+	public boolean matches(Object item) {
+		EventCollector collector= (EventCollector) item;
+		return (collector != null) && matchesAtLeastOneEvent(collector);
+	}
+
+	private boolean matchesAtLeastOneEvent(EventCollector collector) {
+		List<T> events= fReadEventsCommand
+				.getEventsFromEventCollector(collector);
+		for (T event : events)
+			if (fMatcher.matches(event))
+				return true;
+		return false;
+	}
+
+	public void describeTo(Description description) {
+		description.appendText(fReadEventsCommand.getName());
+		description.appendText(": ");
+		description.appendDescriptionOf(fMatcher);
+	}
+}

--- a/src/main/java/org/junit/test/internal/HasDescription.java
+++ b/src/main/java/org/junit/test/internal/HasDescription.java
@@ -1,0 +1,30 @@
+package org.junit.test.internal;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Matcher;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+
+public class HasDescription extends BaseMatcher<Failure> {
+	private final Matcher<Description> fMatcher;
+
+	public HasDescription(Description description) {
+		this(is(equalTo(description)));
+	}
+
+	public HasDescription(Matcher<Description> matcher) {
+		fMatcher= matcher;
+	}
+
+	public boolean matches(Object item) {
+		Failure failure= (Failure) item;
+		return (failure != null) && fMatcher.matches(failure.getDescription());
+	}
+
+	public void describeTo(org.hamcrest.Description description) {
+		description.appendText("description ");
+		description.appendDescriptionOf(fMatcher);
+	}
+}

--- a/src/main/java/org/junit/test/internal/HasDisplayName.java
+++ b/src/main/java/org/junit/test/internal/HasDisplayName.java
@@ -1,0 +1,30 @@
+package org.junit.test.internal;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Matcher;
+import org.junit.runner.Description;
+
+public class HasDisplayName extends BaseMatcher<Description> {
+	private final Matcher<String> fMatcher;
+
+	public HasDisplayName(String name) {
+		this(is(equalTo(name)));
+	}
+
+	public HasDisplayName(Matcher<String> matcher) {
+		this.fMatcher= matcher;
+	}
+
+	public boolean matches(Object item) {
+		Description description= (Description) item;
+		return (description != null)
+				&& fMatcher.matches(description.getDisplayName());
+	}
+
+	public void describeTo(org.hamcrest.Description description) {
+		description.appendText("display name ");
+		description.appendDescriptionOf(fMatcher);
+	}
+}

--- a/src/main/java/org/junit/test/internal/HasMessage.java
+++ b/src/main/java/org/junit/test/internal/HasMessage.java
@@ -1,0 +1,30 @@
+package org.junit.test.internal;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.runner.notification.Failure;
+
+public class HasMessage extends BaseMatcher<Failure> {
+	private final Matcher<String> fMatcher;
+
+	public HasMessage(String name) {
+		this(is(equalTo(name)));
+	}
+
+	public HasMessage(Matcher<String> matcher) {
+		fMatcher= matcher;
+	}
+
+	public boolean matches(Object item) {
+		Failure failure= (Failure) item;
+		return (failure != null) && fMatcher.matches(failure.getMessage());
+	}
+
+	public void describeTo(Description description) {
+		description.appendText("message ");
+		description.appendDescriptionOf(fMatcher);
+	}
+}

--- a/src/main/java/org/junit/test/internal/NumberOfEvents.java
+++ b/src/main/java/org/junit/test/internal/NumberOfEvents.java
@@ -1,0 +1,37 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.junit.test.EventCollector;
+
+public class NumberOfEvents<T> extends BaseMatcher<EventCollector> {
+	private final ReadEventsCommand<T> fReadEventsCommand;
+
+	private final int fNumberOfEvents;
+
+	public NumberOfEvents(ReadEventsCommand<T> readEventsCommand,
+			int numberOfEvents) {
+		fReadEventsCommand= readEventsCommand;
+		fNumberOfEvents= numberOfEvents;
+	}
+
+	public boolean matches(Object item) {
+		EventCollector collector= (EventCollector) item;
+		return (collector != null) && hasExpectedNumberOfEvents(collector);
+	}
+
+	private boolean hasExpectedNumberOfEvents(EventCollector collector) {
+		List<T> events= fReadEventsCommand
+				.getEventsFromEventCollector(collector);
+		return events.size() == fNumberOfEvents;
+	}
+
+	public void describeTo(Description description) {
+		description.appendText(Integer.toString(fNumberOfEvents));
+		description.appendText(" ");
+		description.appendText(fReadEventsCommand.getName());
+		description.appendText("s");
+	}
+}

--- a/src/main/java/org/junit/test/internal/ReadEventsCommand.java
+++ b/src/main/java/org/junit/test/internal/ReadEventsCommand.java
@@ -1,0 +1,11 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.junit.test.EventCollector;
+
+public interface ReadEventsCommand<T> {
+	String getName();
+
+	List<T> getEventsFromEventCollector(EventCollector eventCollector);
+}

--- a/src/main/java/org/junit/test/internal/ReadFailedAssumptionsCommand.java
+++ b/src/main/java/org/junit/test/internal/ReadFailedAssumptionsCommand.java
@@ -1,0 +1,17 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.junit.runner.notification.Failure;
+import org.junit.test.EventCollector;
+
+public class ReadFailedAssumptionsCommand implements ReadEventsCommand<Failure> {
+	public String getName() {
+		return "failed assumption";
+	}
+
+	public List<Failure> getEventsFromEventCollector(
+			EventCollector eventCollector) {
+		return eventCollector.getFailedAssumptions();
+	}
+}

--- a/src/main/java/org/junit/test/internal/ReadFailuresCommand.java
+++ b/src/main/java/org/junit/test/internal/ReadFailuresCommand.java
@@ -1,0 +1,17 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.junit.runner.notification.Failure;
+import org.junit.test.EventCollector;
+
+public class ReadFailuresCommand implements ReadEventsCommand<Failure> {
+	public String getName() {
+		return "failure";
+	}
+
+	public List<Failure> getEventsFromEventCollector(
+			EventCollector eventCollector) {
+		return eventCollector.getFailures();
+	}
+}

--- a/src/main/java/org/junit/test/internal/ReadFinishedTestRunsCommand.java
+++ b/src/main/java/org/junit/test/internal/ReadFinishedTestRunsCommand.java
@@ -1,0 +1,17 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.junit.runner.Result;
+import org.junit.test.EventCollector;
+
+public class ReadFinishedTestRunsCommand implements ReadEventsCommand<Result> {
+	public String getName() {
+		return "finished test run";
+	}
+
+	public List<Result> getEventsFromEventCollector(
+			EventCollector eventCollector) {
+		return eventCollector.getFinishedTestRuns();
+	}
+}

--- a/src/main/java/org/junit/test/internal/ReadFinishedTestsCommand.java
+++ b/src/main/java/org/junit/test/internal/ReadFinishedTestsCommand.java
@@ -1,0 +1,17 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.junit.runner.Description;
+import org.junit.test.EventCollector;
+
+public class ReadFinishedTestsCommand implements ReadEventsCommand<Description> {
+	public String getName() {
+		return "finished test";
+	}
+
+	public List<Description> getEventsFromEventCollector(
+			EventCollector eventCollector) {
+		return eventCollector.getFinishedTests();
+	}
+}

--- a/src/main/java/org/junit/test/internal/ReadIgnoredTestsCommand.java
+++ b/src/main/java/org/junit/test/internal/ReadIgnoredTestsCommand.java
@@ -1,0 +1,17 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.junit.runner.Description;
+import org.junit.test.EventCollector;
+
+public class ReadIgnoredTestsCommand implements ReadEventsCommand<Description> {
+	public String getName() {
+		return "ignored test";
+	}
+
+	public List<Description> getEventsFromEventCollector(
+			EventCollector eventCollector) {
+		return eventCollector.getIgnoredTests();
+	}
+}

--- a/src/main/java/org/junit/test/internal/ReadStartedTestRunsCommand.java
+++ b/src/main/java/org/junit/test/internal/ReadStartedTestRunsCommand.java
@@ -1,0 +1,18 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.junit.runner.Description;
+import org.junit.test.EventCollector;
+
+public class ReadStartedTestRunsCommand implements
+		ReadEventsCommand<Description> {
+	public String getName() {
+		return "started test run";
+	}
+
+	public List<Description> getEventsFromEventCollector(
+			EventCollector eventCollector) {
+		return eventCollector.getStartedTestRuns();
+	}
+}

--- a/src/main/java/org/junit/test/internal/ReadStartedTestsCommand.java
+++ b/src/main/java/org/junit/test/internal/ReadStartedTestsCommand.java
@@ -1,0 +1,17 @@
+package org.junit.test.internal;
+
+import java.util.List;
+
+import org.junit.runner.Description;
+import org.junit.test.EventCollector;
+
+public class ReadStartedTestsCommand implements ReadEventsCommand<Description> {
+	public String getName() {
+		return "started test";
+	}
+
+	public List<Description> getEventsFromEventCollector(
+			EventCollector eventCollector) {
+		return eventCollector.getStartedTests();
+	}
+}

--- a/src/test/java/org/junit/test/EventCollectorMatchersTest.java
+++ b/src/test/java/org/junit/test/EventCollectorMatchersTest.java
@@ -1,0 +1,120 @@
+package org.junit.test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.runner.Description.createSuiteDescription;
+import static org.junit.test.EventCollectorMatchers.failedAssumption;
+import static org.junit.test.EventCollectorMatchers.failure;
+import static org.junit.test.EventCollectorMatchers.finishedTest;
+import static org.junit.test.EventCollectorMatchers.finishedTestRun;
+import static org.junit.test.EventCollectorMatchers.ignoredTest;
+import static org.junit.test.EventCollectorMatchers.numberOfFailedAssumptions;
+import static org.junit.test.EventCollectorMatchers.numberOfFailures;
+import static org.junit.test.EventCollectorMatchers.numberOfFinishedTestRuns;
+import static org.junit.test.EventCollectorMatchers.numberOfFinishedTests;
+import static org.junit.test.EventCollectorMatchers.numberOfIgnoredTests;
+import static org.junit.test.EventCollectorMatchers.numberOfStartedTestRuns;
+import static org.junit.test.EventCollectorMatchers.numberOfStartedTests;
+import static org.junit.test.EventCollectorMatchers.startedTest;
+import static org.junit.test.EventCollectorMatchers.startedTestRun;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+public class EventCollectorMatchersTest {
+	private static final Description ARBITRARY_DESCRIPTION= createSuiteDescription("arbtirary name");
+
+	private static final Result ARBITRARY_RESULT= new Result();
+
+	private static final AssertionError ARBITRARY_EXCEPTION= new AssertionError();
+
+	private static final Failure ARBITRARY_FAILURE= new Failure(
+			ARBITRARY_DESCRIPTION, ARBITRARY_EXCEPTION);
+
+	private final EventCollector collector= new EventCollector();
+
+	@Test
+	public void matchFailedAssumption() throws Exception {
+		collector.testAssumptionFailure(ARBITRARY_FAILURE);
+		assertThat(collector, failedAssumption(equalTo(ARBITRARY_FAILURE)));
+	}
+
+	@Test
+	public void matchOneFailedAssumption() throws Exception {
+		collector.testAssumptionFailure(ARBITRARY_FAILURE);
+		assertThat(collector, numberOfFailedAssumptions(1));
+	}
+
+	@Test
+	public void matchFailure() throws Exception {
+		collector.testFailure(ARBITRARY_FAILURE);
+		assertThat(collector, failure(equalTo(ARBITRARY_FAILURE)));
+	}
+
+	@Test
+	public void matchOneFailure() throws Exception {
+		collector.testFailure(ARBITRARY_FAILURE);
+		assertThat(collector, numberOfFailures(1));
+	}
+
+	@Test
+	public void matchFinishedTest() throws Exception {
+		collector.testFinished(ARBITRARY_DESCRIPTION);
+		assertThat(collector, finishedTest(equalTo(ARBITRARY_DESCRIPTION)));
+	}
+
+	@Test
+	public void matchOneFinishedTest() throws Exception {
+		collector.testFinished(ARBITRARY_DESCRIPTION);
+		assertThat(collector, numberOfFinishedTests(1));
+	}
+
+	@Test
+	public void matchFinishedTestRun() throws Exception {
+		collector.testRunFinished(ARBITRARY_RESULT);
+		assertThat(collector, finishedTestRun(equalTo(ARBITRARY_RESULT)));
+	}
+
+	@Test
+	public void matchOneFinishedTestRun() throws Exception {
+		collector.testRunFinished(ARBITRARY_RESULT);
+		assertThat(collector, numberOfFinishedTestRuns(1));
+	}
+
+	@Test
+	public void matchIgnoredTest() throws Exception {
+		collector.testIgnored(ARBITRARY_DESCRIPTION);
+		assertThat(collector, ignoredTest(equalTo(ARBITRARY_DESCRIPTION)));
+	}
+
+	@Test
+	public void matchOneIgnoredTest() throws Exception {
+		collector.testIgnored(ARBITRARY_DESCRIPTION);
+		assertThat(collector, numberOfIgnoredTests(1));
+	}
+
+	@Test
+	public void matchStartedTest() throws Exception {
+		collector.testStarted(ARBITRARY_DESCRIPTION);
+		assertThat(collector, startedTest(equalTo(ARBITRARY_DESCRIPTION)));
+	}
+
+	@Test
+	public void matchOneStartedTest() throws Exception {
+		collector.testStarted(ARBITRARY_DESCRIPTION);
+		assertThat(collector, numberOfStartedTests(1));
+	}
+
+	@Test
+	public void matchStartedTestRun() throws Exception {
+		collector.testRunStarted(ARBITRARY_DESCRIPTION);
+		assertThat(collector, startedTestRun(equalTo(ARBITRARY_DESCRIPTION)));
+	}
+
+	@Test
+	public void matchOneStartedTestRun() throws Exception {
+		collector.testRunStarted(ARBITRARY_DESCRIPTION);
+		assertThat(collector, numberOfStartedTestRuns(1));
+	}
+}

--- a/src/test/java/org/junit/test/EventCollectorTest.java
+++ b/src/test/java/org/junit/test/EventCollectorTest.java
@@ -1,0 +1,108 @@
+package org.junit.test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.runner.Description.createSuiteDescription;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+public class EventCollectorTest {
+	private static final Description DESCRIPTION= createSuiteDescription("any description");
+	private static final Failure FAILURE= new Failure(null, null);
+
+	private static final Result RESULT= new Result();
+	private final EventCollector collector= new EventCollector();
+
+	@Test
+	public void collectTestRunsStarted() throws Exception {
+		collector.testRunStarted(DESCRIPTION);
+		assertThat(collector.getStartedTestRuns().get(0), is(DESCRIPTION));
+	}
+
+	@Test
+	public void cannotModifyTestRunsStartedList() throws Exception {
+		collector.testRunStarted(DESCRIPTION);
+		collector.getStartedTestRuns().clear();
+		assertThat(collector.getStartedTestRuns().size(), is(1));
+	}
+
+	@Test
+	public void collectTestRunsFinished() throws Exception {
+		collector.testRunFinished(RESULT);
+		assertThat(collector.getFinishedTestRuns().get(0), is(RESULT));
+	}
+
+	@Test
+	public void cannotModifyTestRunsFinishedList() throws Exception {
+		collector.testRunFinished(RESULT);
+		collector.getFinishedTestRuns().clear();
+		assertThat(collector.getFinishedTestRuns().size(), is(1));
+	}
+
+	@Test
+	public void collectTestsStarted() throws Exception {
+		collector.testStarted(DESCRIPTION);
+		assertThat(collector.getStartedTests().get(0), is(DESCRIPTION));
+	}
+
+	@Test
+	public void cannotModifyTestsStartedList() throws Exception {
+		collector.testStarted(DESCRIPTION);
+		collector.getStartedTests().clear();
+		assertThat(collector.getStartedTests().size(), is(1));
+	}
+
+	@Test
+	public void collectTestsFinished() throws Exception {
+		collector.testFinished(DESCRIPTION);
+		assertThat(collector.getFinishedTests().get(0), is(DESCRIPTION));
+	}
+
+	@Test
+	public void cannotModifyTestsFinishedList() throws Exception {
+		collector.testFinished(DESCRIPTION);
+		collector.getFinishedTests().clear();
+		assertThat(collector.getFinishedTests().size(), is(1));
+	}
+
+	@Test
+	public void collectFailure() throws Exception {
+		collector.testFailure(FAILURE);
+		assertThat(collector.getFailures().get(0), is(FAILURE));
+	}
+
+	@Test
+	public void cannotModifyFailureList() throws Exception {
+		collector.testFailure(FAILURE);
+		collector.getFailures().clear();
+		assertThat(collector.getFailures().size(), is(1));
+	}
+
+	@Test
+	public void collectAssumptionFailure() throws Exception {
+		collector.testAssumptionFailure(FAILURE);
+		assertThat(collector.getFailedAssumptions().get(0), is(FAILURE));
+	}
+
+	@Test
+	public void cannotModifyAssumptionFailureList() throws Exception {
+		collector.testAssumptionFailure(FAILURE);
+		collector.getFailedAssumptions().clear();
+		assertThat(collector.getFailedAssumptions().size(), is(1));
+	}
+
+	@Test
+	public void collectTestsIgnored() throws Exception {
+		collector.testIgnored(DESCRIPTION);
+		assertThat(collector.getIgnoredTests().get(0), is(DESCRIPTION));
+	}
+
+	@Test
+	public void cannotModifyTestsIgnoredList() throws Exception {
+		collector.testIgnored(DESCRIPTION);
+		collector.getIgnoredTests().clear();
+		assertThat(collector.getIgnoredTests().size(), is(1));
+	}
+}

--- a/src/test/java/org/junit/test/JUnitSelfTestRunnerTest.java
+++ b/src/test/java/org/junit/test/JUnitSelfTestRunnerTest.java
@@ -1,0 +1,145 @@
+package org.junit.test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.test.DescriptionMatchers.hasDisplayName;
+import static org.junit.test.EventCollectorMatchers.finishedTest;
+import static org.junit.test.EventCollectorMatchers.noFailures;
+import static org.junit.test.EventCollectorMatchers.numberOfFailures;
+import static org.junit.test.EventCollectorMatchers.numberOfStartedTests;
+import static org.junit.test.EventCollectorMatchers.onlySuccessfulTests;
+import static org.junit.test.EventCollectorMatchers.startedTest;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitSelfTestRunner.class)
+public class JUnitSelfTestRunnerTest {
+	@JUnitSelfTest
+	@RunWith(JUnitSelfTestRunner.class)
+	public static class SuccessfulSelfTest {
+		@ExpectedEvents
+		public static final Matcher<EventCollector> EXPECTED_EVENTS= onlySuccessfulTests();
+
+		@JUnitSelfTest
+		public static class FirstSelfTest {
+			@ExpectedEvents
+			public static final Matcher<EventCollector> EXPECTED_EVENTS= onlySuccessfulTests();
+
+			@Test
+			public void successfulTest() {
+				assertTrue(true);
+			}
+		}
+	}
+
+	@JUnitSelfTest
+	@RunWith(JUnitSelfTestRunner.class)
+	public static class TwoFailingSelfTests {
+		@ExpectedEvents
+		public static final Matcher<EventCollector> EXPECTED_EVENTS= noFailures();
+
+		@JUnitSelfTest
+		public static class SelfTest {
+			@ExpectedEvents
+			public static final Matcher<EventCollector> EXPECTED_EVENTS= numberOfFailures(0);
+
+			@Test
+			public void successfulTest() {
+				assertTrue(true);
+			}
+		}
+	}
+
+	@JUnitSelfTest
+	@RunWith(JUnitSelfTestRunner.class)
+	public static class UseClassNameAsTestName {
+		@ExpectedEvents
+		public static final Matcher<EventCollector> EXPECTED_EVENTS= startedTest(hasDisplayName("SelfTest(org.junit.test.JUnitSelfTestRunnerTest$UseClassNameAsTestName)"));
+
+		@JUnitSelfTest
+		public static class SelfTest {
+			@ExpectedEvents
+			public static final Matcher<EventCollector> EXPECTED_EVENTS= onlySuccessfulTests();
+
+			@Test
+			public void successfulTest() {
+				assertTrue(true);
+			}
+		}
+	}
+
+	@JUnitSelfTest
+	@RunWith(JUnitSelfTestRunner.class)
+	public static class CreateFinishedEvent {
+		@ExpectedEvents
+		public static final Matcher<EventCollector> EXPECTED_EVENTS= finishedTest(hasDisplayName("SelfTest(org.junit.test.JUnitSelfTestRunnerTest$CreateFinishedEvent)"));
+
+		@JUnitSelfTest
+		public static class SelfTest {
+			@ExpectedEvents
+			public static final Matcher<EventCollector> EXPECTED_EVENTS= onlySuccessfulTests();
+
+			@Test
+			public void successfulTest() {
+				assertTrue(true);
+			}
+		}
+	}
+
+	@JUnitSelfTest
+	@RunWith(JUnitSelfTestRunner.class)
+	public static class FailWithoutExpectedEvents {
+		@ExpectedEvents
+		public static final Matcher<EventCollector> EXPECTED_EVENTS= numberOfFailures(1);
+
+		@JUnitSelfTest
+		public static class SelfTest {
+			@Test
+			public void successfulTest() {
+				assertTrue(true);
+			}
+		}
+	}
+
+	@JUnitSelfTest
+	@RunWith(JUnitSelfTestRunner.class)
+	public static class FailWithMoreThanOneExpectedEvents {
+		@ExpectedEvents
+		public static final Matcher<EventCollector> EXPECTED_EVENTS= numberOfFailures(1);
+
+		@JUnitSelfTest
+		public static class SelfTest {
+			@ExpectedEvents
+			public static final Matcher<EventCollector> FIRST_EXPECTED_EVENTS= noFailures();
+
+			@ExpectedEvents
+			public static final Matcher<EventCollector> SECOND_EXPECTED_EVENTS= noFailures();
+
+			@Test
+			public void successfulTest() {
+				assertTrue(true);
+			}
+		}
+	}
+
+	@JUnitSelfTest
+	@RunWith(JUnitSelfTestRunner.class)
+	public static class DontConsiderNonAnnotatedClass {
+		@ExpectedEvents
+		public static final Matcher<EventCollector> EXPECTED_EVENTS= numberOfStartedTests(1);
+
+		public static class IrrelevantClass {
+		}
+
+		@JUnitSelfTest
+		public static class SelfTest {
+			@ExpectedEvents
+			public static final Matcher<EventCollector> FIRST_EXPECTED_EVENTS= noFailures();
+
+			@Test
+			public void successfulTest() {
+				assertTrue(true);
+			}
+		}
+	}
+}

--- a/src/test/java/org/junit/test/internal/AtLeastOneEventTest.java
+++ b/src/test/java/org/junit/test/internal/AtLeastOneEventTest.java
@@ -1,0 +1,66 @@
+package org.junit.test.internal;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.runner.Description.createSuiteDescription;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.test.EventCollector;
+
+public class AtLeastOneEventTest {
+	private static final Description ARBITRARY_DESCRIPTION= createSuiteDescription("arbtirary name");
+
+	private static final AssertionError ARBITRARY_EXCEPTION= new AssertionError(
+			"arbitrary message");
+
+	private static final Failure FIRST_FAILURE= new Failure(
+			ARBITRARY_DESCRIPTION, ARBITRARY_EXCEPTION);
+
+	private static final Failure SECOND_FAILURE= new Failure(
+			ARBITRARY_DESCRIPTION, ARBITRARY_EXCEPTION);
+
+	private final EventCollector collector= new EventCollector();
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void matchTwoFailures() throws Exception {
+		collector.testFailure(FIRST_FAILURE);
+		collector.testFailure(SECOND_FAILURE);
+		assertThat(
+				collector,
+				allOf(atLeastOneFailure(FIRST_FAILURE),
+						atLeastOneFailure(SECOND_FAILURE)));
+	}
+
+	@Test
+	public void dontMatchWrongFailure() throws Exception {
+		collector.testFailure(SECOND_FAILURE);
+		assertThat(collector, not(atLeastOneFailure(FIRST_FAILURE)));
+	}
+
+	@Test
+	public void dontMatchNull() {
+		assertThat(null, not(atLeastOneFailure(FIRST_FAILURE)));
+	}
+
+	@Test
+	public void hasMeaningfulDescription() {
+		AtLeastOnEvent<Failure> matcher= atLeastOneFailure(FIRST_FAILURE);
+		StringDescription description= new StringDescription();
+		matcher.describeTo(description);
+		assertThat(
+				description.toString().startsWith(
+						"failure: <arbtirary name: arbitrary message>"),
+				is(true));
+	}
+
+	private AtLeastOnEvent<Failure> atLeastOneFailure(Failure failure) {
+		return new AtLeastOnEvent<Failure>(new ReadFailuresCommand(),
+				equalTo(failure));
+	}
+}

--- a/src/test/java/org/junit/test/internal/HasDescriptionTest.java
+++ b/src/test/java/org/junit/test/internal/HasDescriptionTest.java
@@ -1,0 +1,52 @@
+package org.junit.test.internal;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.runner.Description.createSuiteDescription;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+
+public class HasDescriptionTest {
+	private static final String NAME_OF_DESCRIPTION= "a description";
+
+	private final Description description= createSuiteDescription(NAME_OF_DESCRIPTION);
+
+	private final Description anotherDescription= createSuiteDescription("another description");
+
+	private final RuntimeException exception= new RuntimeException();
+
+	private final Failure failure= new Failure(description, exception);
+
+	@Test
+	public void matchWithMatcher() {
+		assertThat(failure, new HasDescription(equalTo(description)));
+	}
+
+	@Test
+	public void matchWithDescription() {
+		assertThat(failure, new HasDescription(description));
+	}
+
+	@Test
+	public void dontMatchWrongDescription() {
+		assertThat(failure, not(new HasDescription(anotherDescription)));
+	}
+
+	@Test
+	public void dontMatchNull() {
+		assertThat(null, not(new HasDescription(description)));
+	}
+
+	@Test
+	public void hasMeaningfulDescription() {
+		HasDescription matcher= new HasDescription(description);
+		StringDescription description= new StringDescription();
+		matcher.describeTo(description);
+		assertThat(description.toString(), is(equalTo("description is <"
+				+ NAME_OF_DESCRIPTION + ">")));
+	}
+}

--- a/src/test/java/org/junit/test/internal/HasDisplayNameTest.java
+++ b/src/test/java/org/junit/test/internal/HasDisplayNameTest.java
@@ -1,0 +1,45 @@
+package org.junit.test.internal;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.runner.Description.createSuiteDescription;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+import org.junit.runner.Description;
+
+public class HasDisplayNameTest {
+	private static final String DUMMY_NAME= "dummy name";
+
+	private final Description dummyDescription= createSuiteDescription(DUMMY_NAME);
+
+	@Test
+	public void matchWithMatcher() {
+		assertThat(dummyDescription, new HasDisplayName(equalTo(DUMMY_NAME)));
+	}
+
+	@Test
+	public void matchWithString() {
+		assertThat(dummyDescription, new HasDisplayName(DUMMY_NAME));
+	}
+
+	@Test
+	public void dontMatchWrongName() {
+		assertThat(dummyDescription, not(new HasDisplayName("wrong name")));
+	}
+
+	@Test
+	public void dontMatchNull() {
+		assertThat(null, not(new HasDisplayName("a name")));
+	}
+
+	@Test
+	public void hasMeaningfulDescription() {
+		HasDisplayName matcher= new HasDisplayName("a name");
+		StringDescription description= new StringDescription();
+		matcher.describeTo(description);
+		assertThat(description.toString(),
+				is(equalTo("display name is \"a name\"")));
+	}
+}

--- a/src/test/java/org/junit/test/internal/HasMessageTest.java
+++ b/src/test/java/org/junit/test/internal/HasMessageTest.java
@@ -1,0 +1,51 @@
+package org.junit.test.internal;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.runner.Description.createSuiteDescription;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+
+public class HasMessageTest {
+	private static final String DUMMY_MESSAGE= "dummy message";
+
+	private final Description description= createSuiteDescription("a description");
+
+	private final RuntimeException exception= new RuntimeException(
+			DUMMY_MESSAGE);
+
+	private final Failure failure= new Failure(description, exception);
+
+	@Test
+	public void matchWithMatcher() {
+		assertThat(failure, new HasMessage(equalTo(DUMMY_MESSAGE)));
+	}
+
+	@Test
+	public void matchWithString() {
+		assertThat(failure, new HasMessage(DUMMY_MESSAGE));
+	}
+
+	@Test
+	public void dontMatchWrongName() {
+		assertThat(failure, not(new HasMessage("wrong name")));
+	}
+
+	@Test
+	public void dontMatchNull() {
+		assertThat(null, not(new HasMessage("a name")));
+	}
+
+	@Test
+	public void hasMeaningfulDescription() {
+		HasMessage matcher= new HasMessage("a message");
+		StringDescription description= new StringDescription();
+		matcher.describeTo(description);
+		assertThat(description.toString(),
+				is(equalTo("message is \"a message\"")));
+	}
+}

--- a/src/test/java/org/junit/test/internal/NumberOfEventsTest.java
+++ b/src/test/java/org/junit/test/internal/NumberOfEventsTest.java
@@ -1,0 +1,45 @@
+package org.junit.test.internal;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+import org.hamcrest.StringDescription;
+import org.junit.Test;
+import org.junit.runner.notification.Failure;
+import org.junit.test.EventCollector;
+
+public class NumberOfEventsTest {
+	private static final Failure ARBITRARY_FAILURE= new Failure(null, null);
+
+	private final EventCollector collector= new EventCollector();
+
+	@Test
+	public void matchOneFailure() throws Exception {
+		collector.testFailure(ARBITRARY_FAILURE);
+		assertThat(collector, numberOfFailures(1));
+	}
+
+	@Test
+	public void dontMatchWrongNumberOfFailures() throws Exception {
+		assertThat(collector, not(numberOfFailures(1)));
+	}
+
+	@Test
+	public void dontMatchNull() {
+		assertThat(null, not(numberOfFailures(0)));
+	}
+
+	@Test
+	public void hasMeaningfulDescription() {
+		NumberOfEvents<Failure> matcher= numberOfFailures(2);
+		StringDescription description= new StringDescription();
+		matcher.describeTo(description);
+		assertThat(description.toString(), is(equalTo("2 failures")));
+	}
+
+	private NumberOfEvents<Failure> numberOfFailures(int numberOfFailures) {
+		return new NumberOfEvents<Failure>(new ReadFailuresCommand(),
+				numberOfFailures);
+	}
+}

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -5,6 +5,13 @@ import junit.framework.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+import org.junit.test.EventCollectorMatchersTest;
+import org.junit.test.EventCollectorTest;
+import org.junit.test.JUnitSelfTestRunnerTest;
+import org.junit.test.internal.AtLeastOneEventTest;
+import org.junit.test.internal.HasDisplayNameTest;
+import org.junit.test.internal.HasMessageTest;
+import org.junit.test.internal.NumberOfEventsTest;
 import org.junit.tests.assertion.AssertionTest;
 import org.junit.tests.assertion.BothTest;
 import org.junit.tests.assertion.EachTest;
@@ -29,8 +36,8 @@ import org.junit.tests.experimental.rules.ExpectedExceptionRuleTest;
 import org.junit.tests.experimental.rules.ExternalResourceRuleTest;
 import org.junit.tests.experimental.rules.MethodRulesTest;
 import org.junit.tests.experimental.rules.NameRulesTest;
-import org.junit.tests.experimental.rules.RuleFieldValidatorTest;
 import org.junit.tests.experimental.rules.RuleChainTest;
+import org.junit.tests.experimental.rules.RuleFieldValidatorTest;
 import org.junit.tests.experimental.rules.TempFolderRuleTest;
 import org.junit.tests.experimental.rules.TestRuleTest;
 import org.junit.tests.experimental.rules.TimeoutRuleTest;
@@ -156,7 +163,14 @@ import org.junit.tests.validation.ValidationTest;
 	BlockJUnit4ClassRunnerOverrideTest.class,
 	RuleFieldValidatorTest.class,
 	RuleChainTest.class,
-	BlockJUnit4ClassRunnerTest.class
+	BlockJUnit4ClassRunnerTest.class,
+	AtLeastOneEventTest.class,
+	HasDisplayNameTest.class,
+	HasMessageTest.class,
+	NumberOfEventsTest.class,
+	EventCollectorMatchersTest.class,
+	EventCollectorTest.class,
+	JUnitSelfTestRunnerTest.class
 })
 public class AllTests {
 	public static Test suite() {


### PR DESCRIPTION
JUnitSelfTestRunner is the test runner for declarative tests of JUnit
itself. It runs your test classes and verifies the JUnit events
(failure, test started, ...) according to your specification.

A test class using this runner has several static inner classes, which
are annotated with @JUnitSelfTest. Every such class is a single test and
the test specification is provided by a hamcrest matcher, which is an
additional field annotated with @ExpectedEvents. The
EventCollectorMatchers class provides some matchers.

Here is an example of a test class with two tests.

``` java
@RunWith(JUnitSelfTestRunner.class)
public class MySelfTests {
    @JUnitSelfTest
    public static class FirstSelfTest {
        @ExpectedEvents
        public static final Matcher<EventCollector> EXPECTED_EVENTS
            = onlySuccessfulTests();

        @Test
        public void successfulTest() {
            assertTrue(true);
        }
    }

    @JUnitSelfTest
    public static class SecondSelfTest {
        @ExpectedEvents
        public static final Matcher<EventCollector> EXPECTED_EVENTS
            = numberOfFailures(1);

        @Test
        public void successfulTest() {
            assertTrue(true);
        }

        @Test
        public void failingTest() {
            fail();
        }
    }
}
```
