### PR TITLE
Fix for #359

### DIFF
--- a/src/main/java/org/junit/runner/Description.java
+++ b/src/main/java/org/junit/runner/Description.java
@@ -204,7 +204,7 @@ public class Description implements Serializable {
 		if (name == null)
 			return null;
 		try {
-			return Class.forName(name);
+			return Class.forName(name, false, getClass().getClassLoader());
 		} catch (ClassNotFoundException e) {
 			return null;
 		}


### PR DESCRIPTION
Tests ok, both on 4.11 trunk & on 4.10 final

Implementation uses getClass().getClassLoader() vs. Thread.currentThread().getContextClassLoader() because some third parties (in my case: maven/surefire in JUnit47 provider) rely on it.

With this fix you keep exactly the same behavior as before so there should be no impact for anyone.
