### PR TITLE
Documented the Deprecation of MethodRule

### DIFF
--- a/src/main/java/org/junit/rules/MethodRule.java
+++ b/src/main/java/org/junit/rules/MethodRule.java
@@ -23,6 +23,8 @@ import org.junit.runners.model.Statement;
  *   <li>{@link Timeout}: cause test to fail after a set time</li>
  *   <li>{@link Verifier}: fail test if object state ends up incorrect</li>
  * </ul>
+ * 
+ * This interface is deprecated in favour for {@link TestRule}.
  */
 @Deprecated
 public interface MethodRule {


### PR DESCRIPTION
Added a sentence to the MethodRule JavaDoc in order to guide the user to the new interface TestRule.
