### PR TITLE
SortMethodsWith allows the user to choose the order of execution of the methods within a test class

### DIFF
--- a/src/main/java/org/junit/FixMethodOrder.java
+++ b/src/main/java/org/junit/FixMethodOrder.java
@@ -24,7 +24,7 @@ import org.junit.runners.MethodSorters;
  * Here is an example:
  * 
  * <pre>
- * &#064;SortMethodsWith(MethodSorters.NAME_ASC)
+ * &#064;FixMethodOrder(MethodSorters.NAME_ASCENDING)
  * public class MyTest {
  * }
  * </pre>
@@ -33,7 +33,7 @@ import org.junit.runners.MethodSorters;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
-public @interface SortMethodsWith {
+public @interface FixMethodOrder {
 	/**
 	 * Optionally specify <code>value</code> to have the methods executed in a particular order
 	 */

--- a/src/main/java/org/junit/internal/MethodSorter.java
+++ b/src/main/java/org/junit/internal/MethodSorter.java
@@ -4,7 +4,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Comparator;
 
-import org.junit.SortMethodsWith;
+import org.junit.FixMethodOrder;
 
 public class MethodSorter {
     /**
@@ -19,7 +19,7 @@ public class MethodSorter {
     };
     
     /**
-     * Method name ascending sort order
+     * Method name ascending lexicograhic sort order
      */
     public static Comparator<Method> NAME_ASCENDING= new Comparator<Method>() {
         public int compare(Method m1, Method m2) {
@@ -32,16 +32,7 @@ public class MethodSorter {
     }
     
     /**
-     * Method name descending sort order
-     */
-    public static Comparator<Method> NAME_DESCENDING= new Comparator<Method>() {
-        public int compare(Method m1, Method m2) {
-            return MethodSorter.compare(m1.getName(), m2.getName()) * -1;
-        }
-    };
-    
-    /**
-     * Gets declared methods of a class in a predictable order, unless @SortMethodsWith(MethodSorters.JVM) is specified.
+     * Gets declared methods of a class in a predictable order, unless @FixMethodOrder(MethodSorters.JVM) is specified.
      * 
      * Using the JVM order is unwise since the Java platform does not
      * specify any particular order, and in fact JDK 7 returns a more or less
@@ -54,7 +45,7 @@ public class MethodSorter {
      *       (non-)bug #7023180</a>
      */
     public static Method[] getDeclaredMethods(Class<?> clazz) {
-        Comparator<Method> comparator= getSorter(clazz.getAnnotation(SortMethodsWith.class));
+        Comparator<Method> comparator= getSorter(clazz.getAnnotation(FixMethodOrder.class));
         
         Method[] methods= clazz.getDeclaredMethods();
         if (comparator != null) {
@@ -66,11 +57,11 @@ public class MethodSorter {
 
     private MethodSorter() {}
 
-    private static Comparator<Method> getSorter(SortMethodsWith sortMethodsWith) {
-        if (sortMethodsWith == null) {
+    private static Comparator<Method> getSorter(FixMethodOrder fixMethodOrder) {
+        if (fixMethodOrder == null) {
             return DEFAULT;
         }
 
-        return sortMethodsWith.value().getComparator();
+        return fixMethodOrder.value().getComparator();
     }
 }

--- a/src/main/java/org/junit/runners/MethodSorters.java
+++ b/src/main/java/org/junit/runners/MethodSorters.java
@@ -10,22 +10,20 @@ import org.junit.internal.MethodSorter;
  * Defines common {@link MethodSorter} implementations.
  */
 public enum MethodSorters {
-	/** Sorts the test methods by the method name, in lexicographic order */
-	NAME_ASCENDING(MethodSorter.NAME_ASCENDING),
-	/** Sorts the test methods by the method name, in reverse lexicographic order */
-	NAME_DESCENDING(MethodSorter.NAME_DESCENDING),
-	/** the order in which the tests are returned by the JVM, i.e. there is no sorting done */
-	JVM(null),
-	/** the default value, deterministic, but not predictable */
-	DEFAULT(MethodSorter.DEFAULT);
-	
-	private final Comparator<Method> fComparator;
+    /** Sorts the test methods by the method name, in lexicographic order */
+    NAME_ASCENDING(MethodSorter.NAME_ASCENDING),
+    /** Sorts the test methods by the method name, in reverse lexicographic order */
+    JVM(null),
+    /** the default value, deterministic, but not predictable */
+    DEFAULT(MethodSorter.DEFAULT);
+    
+    private final Comparator<Method> fComparator;
 
-	private MethodSorters(Comparator<Method> comparator) {
-		this.fComparator= comparator;
-	}
+    private MethodSorters(Comparator<Method> comparator) {
+        this.fComparator= comparator;
+    }
 
-	public Comparator<Method> getComparator() {
-		return fComparator;
-	}
+    public Comparator<Method> getComparator() {
+        return fComparator;
+    }
 }

--- a/src/test/java/org/junit/internal/MethodSorterTest.java
+++ b/src/test/java/org/junit/internal/MethodSorterTest.java
@@ -3,12 +3,19 @@ package org.junit.internal;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 
-import org.junit.SortMethodsWith;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import static org.junit.Assert.*;
 
 public class MethodSorterTest {
+    private static final String ALPHA= "java.lang.Object alpha(int,double,java.lang.Thread)";
+    private static final String BETA= "void beta(int[][])";
+    private static final String GAMMA_VOID= "int gamma()";
+    private static final String GAMMA_BOOLEAN= "void gamma(boolean)";
+    private static final String DELTA= "void delta()";
+    private static final String EPSILON= "void epsilon()";
+    
     private static class Dummy {
         Object alpha(int i, double d, Thread t) {return null;}
         void beta(int[][] x) {}
@@ -33,12 +40,13 @@ public class MethodSorterTest {
     }
 
     @Test public void getMethodsNullSorter() throws Exception {
-        assertEquals("[void epsilon(), void beta(int[][]), java.lang.Object alpha(int,double,java.lang.Thread), void delta(), int gamma(), void gamma(boolean)]", declaredMethods(Dummy.class));
+        String[] expected= new String[] { EPSILON, BETA, ALPHA, DELTA, GAMMA_VOID, GAMMA_BOOLEAN };
+        assertEquals(Arrays.asList(expected).toString(), declaredMethods(Dummy.class));
         assertEquals("[void testOne()]", declaredMethods(Super.class));
         assertEquals("[void testTwo()]", declaredMethods(Sub.class));
     }
     
-    @SortMethodsWith(MethodSorters.DEFAULT)
+    @FixMethodOrder(MethodSorters.DEFAULT)
     private static class DummySortWithDefault {
         Object alpha(int i, double d, Thread t) {return null;}
         void beta(int[][] x) {}
@@ -49,10 +57,11 @@ public class MethodSorterTest {
     }
 
     @Test public void testDefaultSorter() {
-        assertEquals("[void epsilon(), void beta(int[][]), java.lang.Object alpha(int,double,java.lang.Thread), void delta(), int gamma(), void gamma(boolean)]", declaredMethods(DummySortWithDefault.class));
+        String[] expected= new String[] { EPSILON, BETA, ALPHA, DELTA, GAMMA_VOID, GAMMA_BOOLEAN };
+        assertEquals(Arrays.asList(expected).toString(), declaredMethods(DummySortWithDefault.class));
     }
     
-    @SortMethodsWith(MethodSorters.JVM)
+    @FixMethodOrder(MethodSorters.JVM)
     private static class DummySortJvm {
         Object alpha(int i, double d, Thread t) {return null;}
         void beta(int[][] x) {}
@@ -63,13 +72,13 @@ public class MethodSorterTest {
     }
 
     @Test public void testSortWithJvm() {
-        Class<?> clazz = DummySortJvm.class;
-        String actual = toString(clazz, clazz.getDeclaredMethods());
+        Class<?> clazz= DummySortJvm.class;
+        String actual= toString(clazz, clazz.getDeclaredMethods());
 
         assertEquals(actual, declaredMethods(clazz));
     }
 
-    @SortMethodsWith(MethodSorters.NAME_ASCENDING)
+    @FixMethodOrder(MethodSorters.NAME_ASCENDING)
     private static class DummySortWithNameAsc {
         Object alpha(int i, double d, Thread t) {return null;}
         void beta(int[][] x) {}
@@ -80,20 +89,7 @@ public class MethodSorterTest {
     }
 
     @Test public void testNameAsc() {
-        assertEquals("[java.lang.Object alpha(int,double,java.lang.Thread), void beta(int[][]), void delta(), void epsilon(), int gamma(), void gamma(boolean)]", declaredMethods(DummySortWithNameAsc.class));
-    }
-
-    @SortMethodsWith(MethodSorters.NAME_DESCENDING)
-    private static class DummySortWithNameDesc {
-        Object alpha(int i, double d, Thread t) {return null;}
-        void beta(int[][] x) {}
-        int gamma() {return 0;}
-        void gamma(boolean b) {}
-        void delta() {}
-        void epsilon() {}
-    }
-
-    @Test public void testNameDesc() {
-        assertEquals("[int gamma(), void gamma(boolean), void epsilon(), void delta(), void beta(int[][]), java.lang.Object alpha(int,double,java.lang.Thread)]", declaredMethods(DummySortWithNameDesc.class));
+        String[] expected= new String[] { ALPHA, BETA, DELTA, EPSILON, GAMMA_VOID, GAMMA_BOOLEAN };
+        assertEquals(Arrays.asList(expected).toString(), declaredMethods(DummySortWithNameAsc.class));
     }
 }

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -2,6 +2,7 @@ package org.junit.tests;
 
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
+import org.junit.internal.MethodSorterTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -158,7 +159,8 @@ import org.junit.tests.validation.ValidationTest;
 	BlockJUnit4ClassRunnerOverrideTest.class,
 	RuleFieldValidatorTest.class,
 	RuleChainTest.class,
-	BlockJUnit4ClassRunnerTest.class
+	BlockJUnit4ClassRunnerTest.class,
+	MethodSorterTest.class
 })
 public class AllTests {
 	public static Test suite() {


### PR DESCRIPTION
The default order of execution of JUnit tests within a class
is deterministic but not predictable. Before 4.11, the
behaviour was to run the test methods in byte code order,
which pre-Java 7 was mostly predictable. Java 7 (and some
previous versions), does not guaranteee the order of execution,
which can change from run to run, so a deterministic sort was introduced.
As a rule, test method execution should be independent of
one another. However, there may be a number of dependent
tests either through error or by design. This class
allows the user to specify the order of execution of test methods.

There are four possibilities:

MethodSorters.DEFAULT: the default value, deterministic, but not predictable
MethodSorters.JVM: the order in which the tests are returned by the JVM, i.e. there is no sorting done
MethodSorters.NAME_ASC: sorted in order of method name, ascending
MethodSorters.NAME_DESC: sorter in order of method name, descending

This is an enhancement to the solution for #293 Sort test methods for predictability, in order that users can temporarily 'fix' their broken tests, from https://github.com/KentBeck/junit/pull/293#issuecomment-2095777
