### PR TITLE
handling null in error messages

### DIFF
--- a/src/main/java/junit/framework/Assert.java
+++ b/src/main/java/junit/framework/Assert.java
@@ -226,7 +226,7 @@ public class Assert {
 	 *            Object to check or <code>null</code>
 	 */
 	static public void assertNull(Object object) {
-		String message = "Expected: <null> but was: " + String.valueOf(object);
+		String message = object != null ? "Expected: <null> but was: " + object.toString() : "";
 		assertNull(message, object);
 	}
 	/**
@@ -270,16 +270,12 @@ public class Assert {
 	}
 
 	static public void failSame(String message) {
-		String formatted= "";
- 		if (message != null)
- 			formatted= message+" ";
+ 		String formatted= (message != null) ? message+" " : "";
  		fail(formatted+"expected not same");
 	}
 
 	static public void failNotSame(String message, Object expected, Object actual) {
-		String formatted= "";
-		if (message != null)
-			formatted= message+" ";
+		String formatted= (message != null) ? message+" " : "";
 		fail(formatted+"expected same:<"+expected+"> was not:<"+actual+">");
 	}
 


### PR DESCRIPTION
1. Style issues in the "failSame" and "failNotSame" methods: in each method three code lines can be replaced with one line. (The proposed change doesn't address an inconsistency in appending space to empty messages in "failSame" and "failNotSame" but not in "format".)
2. A small performance issue in "assertNull": there's no need to append strings when the object is null. (We found several tests to run slow because of unnecessary string appending.)
