### PR TITLE
Make TemporaryFolder.createFile fail if the file already exists (Fixes #413)

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -50,7 +50,9 @@ public class TemporaryFolder extends ExternalResource {
 	 */
 	public File newFile(String fileName) throws IOException {
 		File file= new File(getRoot(), fileName);
-		file.createNewFile();
+		if (!file.createNewFile())
+			throw new IllegalStateException(
+					"a file with the name \'" + fileName + "\' already exists in the test folder");
 		return file;
 	}
 

--- a/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
@@ -158,6 +158,28 @@ public class TempFolderRuleTest {
 		assertFalse(folder.getRoot().exists());
 	}
 
+	public static class NameClashes {
+		@Rule
+		public TemporaryFolder folder= new TemporaryFolder();
+		
+		@Test
+		public void fileWithFileClash() throws IOException {
+			folder.newFile("something.txt");
+			folder.newFile("something.txt");
+		}
+		
+		@Test
+		public void fileWithFolderTest() throws IOException {
+			folder.newFolder("dummy");
+			folder.newFile("dummy");
+		}
+	}
+	
+	@Test
+	public void nameClashesResultInTestFailures() {
+		assertThat(testResult(NameClashes.class), failureCountIs(2));
+	}
+	
 	private static final String GET_ROOT_DUMMY= "dummy-getRoot";
 
 	private static final String NEW_FILE_DUMMY= "dummy-newFile";


### PR DESCRIPTION
I've added a check on the return code of File.createNewFile to throw an IllegalStateException if the file already exists. I believe this is the smallest change that fixes the original issue. Some tests are included to verify the new behaviour.
