### PR TITLE
Fix #88

### DIFF
--- a/src/main/java/org/junit/experimental/theories/suppliers/TestedOnSupplier.java
+++ b/src/main/java/org/junit/experimental/theories/suppliers/TestedOnSupplier.java
@@ -1,14 +1,11 @@
 package org.junit.experimental.theories.suppliers;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.experimental.theories.ParameterSignature;
 import org.junit.experimental.theories.ParameterSupplier;
 import org.junit.experimental.theories.PotentialAssignment;
-
-
 
 public class TestedOnSupplier extends ParameterSupplier {
 	@Override public List<PotentialAssignment> getValueSources(ParameterSignature sig) {
@@ -16,7 +13,7 @@ public class TestedOnSupplier extends ParameterSupplier {
 		TestedOn testedOn = sig.getAnnotation(TestedOn.class);
 		int[] ints = testedOn.ints();
 		for (final int i : ints) {
-			list.add(PotentialAssignment.forValue(Arrays.asList(ints).toString(), i));
+			list.add(PotentialAssignment.forValue("ints", i));
 		}
 		return list;
 	}

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -38,6 +38,7 @@ import org.junit.tests.experimental.rules.TestRuleTest;
 import org.junit.tests.experimental.rules.TimeoutRuleTest;
 import org.junit.tests.experimental.rules.VerifierRuleTest;
 import org.junit.tests.experimental.theories.AllMembersSupplierTest;
+import org.junit.tests.experimental.theories.TestedOnSupplierTest;
 import org.junit.tests.experimental.theories.runner.TheoriesPerformanceTest;
 import org.junit.tests.junit3compatibility.AllTestsTest;
 import org.junit.tests.junit3compatibility.ClassRequestTest;
@@ -160,7 +161,8 @@ import org.junit.tests.validation.ValidationTest;
 	RuleFieldValidatorTest.class,
 	RuleChainTest.class,
 	BlockJUnit4ClassRunnerTest.class,
-	MethodSorterTest.class
+	MethodSorterTest.class,
+	TestedOnSupplierTest.class
 })
 public class AllTests {
 	public static Test suite() {

--- a/src/test/java/org/junit/tests/experimental/theories/TestedOnSupplierTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/TestedOnSupplierTest.java
@@ -1,0 +1,32 @@
+package org.junit.tests.experimental.theories;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.experimental.theories.ParameterSignature;
+import org.junit.experimental.theories.PotentialAssignment;
+import org.junit.experimental.theories.suppliers.TestedOn;
+import org.junit.experimental.theories.suppliers.TestedOnSupplier;
+
+public class TestedOnSupplierTest {
+
+	public void foo(@TestedOn(ints= { 1 }) int x) {
+	}
+
+	@Test
+	public void descriptionStatesParameterName() throws Exception {
+		TestedOnSupplier supplier= new TestedOnSupplier();
+		List<PotentialAssignment> assignments= supplier.getValueSources(signatureOfFoo());
+		assertThat(assignments.get(0).getDescription(), is("ints"));
+	}
+
+	private ParameterSignature signatureOfFoo() throws NoSuchMethodException {
+		Method method= getClass().getMethod("foo", int.class);
+		return ParameterSignature.signatures(method).get(0);
+	}
+
+}


### PR DESCRIPTION
TestedOnSupplier now simply uses "ints" to describe its assignments.

Fixes #88.
