### PR TITLE
TestWatcher javadoc was not correct for example method names

### DIFF
--- a/src/main/java/org/junit/rules/TestWatcher.java
+++ b/src/main/java/org/junit/rules/TestWatcher.java
@@ -16,13 +16,13 @@ import org.junit.runners.model.Statement;
  * 	&#064;Rule
  * 	public TestRule watchman= new TestWatcher() {
  * 		&#064;Override
- * 		protected void failed(Description d) {
- * 			watchedLog+= d + &quot;\n&quot;;
+ * 		protected void failed(Throwable e, Description description) {
+ * 			watchedLog+= description + &quot;\n&quot;;
  * 		}
  * 
  * 		&#064;Override
- * 		protected void succeeded(Description d) {
- * 			watchedLog+= d + &quot; &quot; + &quot;success!\n&quot;;
+ * 		protected void succeeded(Description description) {
+ * 			watchedLog+= description + &quot; &quot; + &quot;success!\n&quot;;
  * 		}
  * 	};
  * 


### PR DESCRIPTION
Redid the example in the javadoc to be in line with new method names
