### PR TITLE
Fixes #427 inconsistent javadoc for test rules

### DIFF
--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -18,7 +18,7 @@ import org.junit.runners.model.Statement;
  * <pre>
  * public static class UseRuleChain {
  * 	&#064;Rule
- * 	public TestRule chain= RuleChain
+ * 	public RuleChain chain= RuleChain
  * 	                       .outerRule(new LoggingRule("outer rule")
  * 	                       .around(new LoggingRule("middle rule")
  * 	                       .around(new LoggingRule("inner rule");

--- a/src/main/java/org/junit/rules/TestWatcher.java
+++ b/src/main/java/org/junit/rules/TestWatcher.java
@@ -14,7 +14,7 @@ import org.junit.runners.model.Statement;
  * 	private static String watchedLog;
  * 
  * 	&#064;Rule
- * 	public TestRule watchman= new TestWatcher() {
+ * 	public TestWatcher watchman= new TestWatcher() {
  * 		&#064;Override
  * 		protected void failed(Throwable e, Description description) {
  * 			watchedLog+= description + &quot;\n&quot;;

--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -15,7 +15,7 @@ import org.junit.runners.model.Statement;
  * 	public static String log;
  * 
  * 	&#064;Rule
- * 	public TestRule globalTimeout= new Timeout(20);
+ * 	public Timeout globalTimeout= new Timeout(20);
  * 
  * 	&#064;Test
  * 	public void testInfiniteLoop1() {

--- a/src/main/java/org/junit/rules/Verifier.java
+++ b/src/main/java/org/junit/rules/Verifier.java
@@ -13,7 +13,7 @@ import org.junit.runners.model.Statement;
  *        private ErrorLog errorLog = new ErrorLog();
  *     
  *        &#064;Rule
- *        public TestRule verifier = new Verifier() {
+ *        public Verifier verifier = new Verifier() {
  *           &#064;Override public void verify() {
  *              assertTrue(errorLog.isEmpty());
  *           }


### PR DESCRIPTION
The examples for some test rules used

public TestRule chain= RuleChain...

whereas others did not refer to TestRule, they used the class name.
Changed all of those who refered to TestRule to use the class name.

The other part is fixed by #372.
