### PR TITLE
closed method assertEquals with }

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -585,6 +585,7 @@ public class Assert {
 			return;
 		if (!(Math.abs(expected - actual) <= delta))
 			failNotEquals(message, new Float(expected), new Float(actual));
+		}
 	static private boolean doubleIsDifferent(double d1, double d2, double delta) {
 		if (Double.compare(d1, d2) == 0)
 			return false;


### PR DESCRIPTION
The assertEquals method in assert.java was not closed with a curly brace, which prevented building from source.
