### PR TITLE
Removed "GENERATOR" meta for "Microsoft FrontPage 4.0" from index.html

### DIFF
--- a/README.html
+++ b/README.html
@@ -2,7 +2,6 @@
 <html>
 <head>
    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-   <meta name="GENERATOR" content="Microsoft FrontPage 4.0">
    <meta name="Author" content="Erich Gamma, Kent Beck, and David Saff">
    <title>JUnit 4.6</title>
 </head>


### PR DESCRIPTION
I understand that this file was generated long back using Frontpage, but I think we don't need this meta tag anymore. What do you think? Does it serve any purpose?
