### PR TITLE
TestWatcher exceptions hide test exceptions

### DIFF
--- a/src/main/java/org/junit/rules/TestWatcher.java
+++ b/src/main/java/org/junit/rules/TestWatcher.java
@@ -48,28 +48,59 @@ public abstract class TestWatcher implements TestRule {
 			@Override
 			public void evaluate() throws Throwable {
 				List<Throwable> errors = new ArrayList<Throwable>();
+
+				startingQuietly(description, errors);
 				try {
-					starting(description);
-					try {
-						base.evaluate();
-						succeeded(description);
-					} catch (AssumptionViolatedException e) {
-						throw e;
-					} catch (Throwable t) {
-						errors.add(t);
-						failed(t, description);
-					} finally {
-						finished(description);
-					}
+					base.evaluate();
+					succeededQuietly(description, errors);
 				} catch (AssumptionViolatedException e) {
 					throw e;
 				} catch (Throwable t) {
 					errors.add(t);
+					failedQuietly(t, description, errors);
+				} finally {
+					finishedQuietly(description, errors);
 				}
-				if (!errors.isEmpty())
-					throw new MultipleFailureException(errors);
+				
+				MultipleFailureException.assertEmpty(errors);
 			}
 		};
+	}
+
+	private void succeededQuietly(Description description,
+			List<Throwable> errors) {
+		try {
+			succeeded(description);
+		} catch (Throwable t) {
+			errors.add(t);
+		}
+	}
+	
+	private void failedQuietly(Throwable t, Description description,
+			List<Throwable> errors) {
+		try {
+			failed(t, description);
+		} catch (Throwable t1) {
+			errors.add(t1);
+		}
+	}
+
+	private void startingQuietly(Description description, 
+			List<Throwable> errors) {
+		try {
+			starting(description);
+		} catch (Throwable t) {
+			errors.add(t);
+		}
+	}
+	
+	private void finishedQuietly(Description description,
+			List<Throwable> errors) {
+		try {
+			finished(description);
+		} catch (Throwable t) {
+			errors.add(t);
+		}
 	}
 	
 	/**
@@ -96,7 +127,6 @@ public abstract class TestWatcher implements TestRule {
 	 */
 	protected void starting(Description description) {
 	}
-
 
 	/**
 	 * Invoked when a test method finishes (whether passing or failing)

--- a/src/test/java/org/junit/tests/experimental/rules/TestWatcherTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TestWatcherTest.java
@@ -55,7 +55,7 @@ public class TestWatcherTest {
 				is("starting failed finished "));
 	}
 	
-	public static class TestWatcherThrowsExceptionTest {
+	public static class TestWatcherFailedThrowsExceptionTest {
 		@Rule
 		public TestRule watcher= new TestWatcher() {
 			@Override
@@ -71,11 +71,62 @@ public class TestWatcherTest {
 	}
 	
 	@Test
-	public void testWatcherThrowsException() {
-		PrintableResult result= testResult(TestWatcherThrowsExceptionTest.class);
+	public void testWatcherFailedThrowsException() {
+		PrintableResult result= testResult(TestWatcherFailedThrowsExceptionTest.class);
 		assertThat(result, failureCountIs(2));
 		assertThat(result, hasFailureContaining("test failure"));
 		assertThat(result, hasFailureContaining("watcher failure"));
-		
 	}
+	
+	public static class TestWatcherStartingThrowsExceptionTest {
+		@Rule
+		public TestRule watcher= new TestWatcher() {
+			@Override
+			protected void starting(Description description) {
+				throw new RuntimeException("watcher failure");
+			}
+		};
+
+		@Test
+		public void fails() {
+			throw new IllegalArgumentException("test failure");
+		}
+	}
+	
+	@Test
+	public void testWatcherStartingThrowsException() {
+		PrintableResult result= testResult(TestWatcherStartingThrowsExceptionTest.class);
+		assertThat(result, failureCountIs(2));
+		assertThat(result, hasFailureContaining("test failure"));
+		assertThat(result, hasFailureContaining("watcher failure"));
+	}
+	
+	public static class TestWatcherFailedAndFinishedThrowsExceptionTest {
+		@Rule
+		public TestRule watcher= new TestWatcher() {
+			@Override
+			protected void failed(Throwable t, Description description) {
+				throw new RuntimeException("watcher failed failure");
+			}
+			
+			@Override
+			protected void finished(Description description) {
+				throw new RuntimeException("watcher finished failure");
+			}
+		};
+
+		@Test
+		public void fails() {
+			throw new IllegalArgumentException("test failure");
+		}
+	}
+	
+	@Test
+	public void testWatcherFailedAndFinishedThrowsException() {
+		PrintableResult result= testResult(TestWatcherFailedAndFinishedThrowsExceptionTest.class);
+		assertThat(result, failureCountIs(3));
+		assertThat(result, hasFailureContaining("test failure"));
+		assertThat(result, hasFailureContaining("watcher failed failure"));
+		assertThat(result, hasFailureContaining("watcher finished failure"));
+	}	
 }


### PR DESCRIPTION
Throw MultipleFailureException, so that errors in both test and test watcher are reported
