### PR TITLE
Fixes #441 fix for issue 283 (recursive temp folders) caused incompatibility

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -52,7 +52,7 @@ public class TemporaryFolder extends ExternalResource {
 	 * for testing purposes only. Do not use.
 	 */
 	public void create() throws IOException {
-	        folder = createTemporaryFolderIn(parentFolder);
+	        folder= createTemporaryFolderIn(parentFolder);
 	}
 
 	/**
@@ -75,6 +75,14 @@ public class TemporaryFolder extends ExternalResource {
 
 	/**
 	 * Returns a new fresh folder with the given name under the temporary
+	 * folder.
+	 */
+	public File newFolder(String folder) {
+		return newFolder(new String[]{folder});
+	}
+
+	/**
+	 * Returns a new fresh folder with the given name(s) under the temporary
 	 * folder.
 	 */
 	public File newFolder(String... folderNames) {

--- a/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
@@ -11,6 +11,7 @@ import static org.junit.internal.matchers.IsCollectionContaining.hasItem;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.junit.After;
@@ -43,14 +44,30 @@ public class TempFolderRuleTest {
 		public TemporaryFolder folder= new TemporaryFolder();
 
 		@Test
-		public void testUsingTempFolder() throws IOException {
+		public void testUsingTempFolderStringReflection() throws Exception {
 			String subfolder = "subfolder";
 			String filename = "a.txt";
+			// force usage of folder.newFolder(String),
+			// check is available and works, to avoid a potential NoSuchMethodError with non-recompiled code.
+			Method method = folder.getClass().getMethod("newFolder", new Class<?>[] {String.class});
+			createdFiles[0]= (File) method.invoke(folder, subfolder);
+			new File(createdFiles[0], filename).createNewFile();
+
+			File expectedFile = new File(folder.getRoot(), join(subfolder, filename));
+
+			assertTrue(expectedFile.exists());
+		}
+
+		@Test
+		public void testUsingTempFolderString() throws IOException {
+			String subfolder = "subfolder";
+			String filename = "a.txt";
+			// this uses newFolder(String), ensure that a single String works
 			createdFiles[0]= folder.newFolder(subfolder);
 			new File(createdFiles[0], filename).createNewFile();
-			
+
 			File expectedFile = new File(folder.getRoot(), join(subfolder, filename));
-			
+
 			assertTrue(expectedFile.exists());
 		}
 


### PR DESCRIPTION
Put back in the method folder.newFolder(String) that
was removed in #283. Tests that the method is there using
reflection.
