### PR TITLE
Revert TemporaryFolder#newFolder(String) so it returns the created folder again

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -2,6 +2,8 @@ package org.junit.rules;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import org.junit.Rule;
 
@@ -77,8 +79,10 @@ public class TemporaryFolder extends ExternalResource {
 	 * Returns a new fresh folder with the given name under the temporary
 	 * folder.
 	 */
-	public File newFolder(String folder) {
-		return newFolder(new String[]{folder});
+	public File newFolder(String folderName) {
+        File file= new File(getRoot(), folderName);
+        file.mkdir();
+		return file;
 	}
 
 	/**


### PR DESCRIPTION
Pull 283 changed newFolder(String) so that it now returns the root instead of the created folder.  This makes no sense and is an API regression.  It breaks tests that relied on the original return value being the created folder.

This pull request corrects that by returning newFolder(String) to its pre Pull 283 implementation.
