### PR TITLE
Revert TemporaryFolder#newFolder(String) so it returns the created folder again

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -77,8 +77,10 @@ public class TemporaryFolder extends ExternalResource {
 	 * Returns a new fresh folder with the given name under the temporary
 	 * folder.
 	 */
-	public File newFolder(String folder) {
-		return newFolder(new String[]{folder});
+	public File newFolder(String folderName) {
+        File file= new File(getRoot(), folderName);
+        file.mkdir();
+		return file;
 	}
 
 	/**


### PR DESCRIPTION
Pull 283 changed newFolder(String) so that it no longer returns the file created, but the root.  This breaks existing tests.

This commit corrects that by returning newFolder(String) to its pre Pull 283 implementation.  It preserves newFolder(String...) which has a different purpose.
