### PR TITLE
Issue 478: Throw an IllegalArgumentException when the folder already exists

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -61,7 +61,7 @@ public class TemporaryFolder extends ExternalResource {
 	public File newFile(String fileName) throws IOException {
 		File file= new File(getRoot(), fileName);
 		if (!file.createNewFile())
-			throw new IllegalArgumentException(
+			throw new IOException(
 					"a file with the name \'" + fileName + "\' already exists in the test folder");
 		return file;
 	}
@@ -77,7 +77,7 @@ public class TemporaryFolder extends ExternalResource {
 	 * Returns a new fresh folder with the given name under the temporary
 	 * folder.
 	 */
-	public File newFolder(String folder) {
+	public File newFolder(String folder) throws IOException {
 		return newFolder(new String[]{folder});
 	}
 
@@ -85,13 +85,13 @@ public class TemporaryFolder extends ExternalResource {
 	 * Returns a new fresh folder with the given name(s) under the temporary
 	 * folder.
 	 */
-	public File newFolder(String... folderNames) {
+	public File newFolder(String... folderNames) throws IOException {
 		File file= getRoot();
 		for (int i = 0; i < folderNames.length; i++) {
 			String folderName = folderNames[i];
 			file = new File(file, folderName);
 			if (!file.mkdir() && isLastElementInArray(i, folderNames))
-				throw new IllegalArgumentException(
+				throw new IOException(
 						"a folder with the name \'" + folderName + "\' already exists");
 		}
 		return file;

--- a/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
@@ -217,7 +217,7 @@ public class TempFolderRuleTest {
 		}
 
 		@Test
-		public void testNewFolder() {
+		public void testNewFolder() throws IOException {
 			folder.newFolder(NEW_FOLDER_DUMMY);
 		}
 	}

--- a/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderUsageTest.java
@@ -59,7 +59,7 @@ public class TemporaryFolderUsageTest {
 		tempFolder.create();
 		tempFolder.newFile("MyFile.txt");
 
-		thrown.expect(IllegalArgumentException.class);
+		thrown.expect(IOException.class);
 		thrown.expectMessage("a file with the name 'MyFile.txt' already exists in the test folder");
 		tempFolder.newFile("MyFile.txt");
 	}
@@ -71,7 +71,7 @@ public class TemporaryFolderUsageTest {
 	}
 
 	@Test(expected= IllegalStateException.class)
-	public void newFolderWithGivenPathThrowsIllegalStateExceptionIfCreateWasNotInvoked() {
+	public void newFolderWithGivenPathThrowsIllegalStateExceptionIfCreateWasNotInvoked() throws IOException {
 		new TemporaryFolder().newFolder("level1", "level2", "level3");
 	}
 
@@ -80,7 +80,7 @@ public class TemporaryFolderUsageTest {
 		tempFolder.create();
 		tempFolder.newFolder("level1");
 
-		thrown.expect(IllegalArgumentException.class);
+		thrown.expect(IOException.class);
 		thrown.expectMessage("a folder with the name 'level1' already exists");
 		tempFolder.newFolder("level1");
 	}
@@ -90,7 +90,7 @@ public class TemporaryFolderUsageTest {
 		tempFolder.create();
 		tempFolder.newFolder("level1", "level2", "level3");
 
-		thrown.expect(IllegalArgumentException.class);
+		thrown.expect(IOException.class);
 		thrown.expectMessage("a folder with the name 'level3' already exists");
 		tempFolder.newFolder("level1", "level2", "level3");
 	}


### PR DESCRIPTION
Changed the code so it behaves like it is described in the documentation for #478.
