### PR TITLE
Fix for issue #487

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -29,6 +29,7 @@
   <property name="javadocdir" location="${dist}/javadoc" />
   <property name="javadoczip" location="${dist}-javadoc.zip" />
   <property name="hamcrestlib" location="lib/hamcrest-core-1.3.jar" />
+  <property name="hamcrestlibsources" location="lib/hamcrest-core-1.3-sources.jar" />
   <property name="hamcrestsrc" location="${dist}/temp.hamcrest.source" />
 
   <property name="maven.deploy.goal" value="org.apache.maven.plugins:maven-gpg-plugin:1.1:sign-and-deploy-file" />
@@ -125,7 +126,7 @@
   </target>
 
   <target name="unjar.hamcrest">
-    <unjar src="${hamcrestlib}" dest="${hamcrestsrc}" />
+    <unjar src="${hamcrestlibsources}" dest="${hamcrestsrc}" />
   </target>
   
   <target name="release-notes">


### PR DESCRIPTION
The wrong Harmcrest jar was used in the build.xml for generating the
javadoc.
