### PR TITLE
identify Suite even before child is added

### DIFF
--- a/src/main/java/org/junit/runner/Description.java
+++ b/src/main/java/org/junit/runner/Description.java
@@ -179,7 +179,7 @@ public class Description implements Serializable {
 	 * @return <code>true</code> if the receiver is an atomic test
 	 */
 	public boolean isTest() {
-		return getChildren().isEmpty();
+		return getMethodName() != null;
 	}
 
 	/**

--- a/src/test/java/junit/tests/runner/DescriptionTest.java
+++ b/src/test/java/junit/tests/runner/DescriptionTest.java
@@ -1,0 +1,19 @@
+package junit.tests.runner;
+
+import java.text.Annotation;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+
+public class DescriptionTest {
+
+	@Test public void testIsSuite() {
+		Description d = Description.createSuiteDescription("SuiteName", new Annotation[0]);
+		Assert.assertTrue(d.isSuite());
+		Description m = Description.createTestDescription("TestClass", "testMethod", new Annotation[0]);
+		d.addChild(m);
+		Assert.assertTrue(d.isSuite());
+	}
+}


### PR DESCRIPTION
currently isTest() / isSuite() is based on children.isEmpty(), this may lead to a situation where a Description is created with createSuiteDescription but cannot be tested as such. only after addChild() will isSuite() return true.

this pull request is using a test based on getMethodName(). if method name is null a suite is assumed.
