### PR TITLE
Improved Test: ParallelClassTest

### DIFF
--- a/src/test/java/org/junit/tests/experimental/parallel/ParallelClassTest.java
+++ b/src/test/java/org/junit/tests/experimental/parallel/ParallelClassTest.java
@@ -11,9 +11,11 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.Before;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 
 public class ParallelClassTest {
+	private static final long TIMEOUT= 15;
 	private static volatile Thread fExample1One= null;
 	private static volatile Thread fExample1Two= null;
 	private static volatile Thread fExample2One= null;
@@ -23,24 +25,24 @@ public class ParallelClassTest {
 	public static class Example1 {
 		@Test public void one() throws InterruptedException {
 			fSynchronizer.countDown();
-			fSynchronizer.await();
+			assertTrue(fSynchronizer.await(TIMEOUT, TimeUnit.SECONDS));
 			fExample1One= Thread.currentThread();
 		}
 		@Test public void two() throws InterruptedException {
 			fSynchronizer.countDown();
-			fSynchronizer.await();
+			assertTrue(fSynchronizer.await(TIMEOUT, TimeUnit.SECONDS));
 			fExample1Two= Thread.currentThread();
 		}
 	}
 	public static class Example2 {
 		@Test public void one() throws InterruptedException {
 			fSynchronizer.countDown();
-			fSynchronizer.await();
+			assertTrue(fSynchronizer.await(TIMEOUT, TimeUnit.SECONDS));
 			fExample2One= Thread.currentThread();
 		}
 		@Test public void two() throws InterruptedException {
 			fSynchronizer.countDown();
-			fSynchronizer.await();
+			assertTrue(fSynchronizer.await(TIMEOUT, TimeUnit.SECONDS));
 			fExample2Two= Thread.currentThread();
 		}
 	}


### PR DESCRIPTION
Delays are too weak test conditions.
Instead, we compare Thread references.

Additionally, this change did speed up the entire test suite.
