### PR TITLE
Improved implementation of ParallelComputer

### DIFF
--- a/src/main/java/org/junit/experimental/ParallelComputer.java
+++ b/src/main/java/org/junit/experimental/ParallelComputer.java
@@ -1,11 +1,8 @@
 package org.junit.experimental;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.runner.Computer;
 import org.junit.runner.Runner;


### PR DESCRIPTION
Improved implementation using Executors.
No need to use thread unsafe ArrayList. Instead calling #awaitTermination() without Callable.
Behavior is the same as before but cleaner impl.
