### PR TITLE
Add 'test' rule to build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -174,7 +174,8 @@
     <copy file="build.xml" tofile="${dist}/build.xml" />
   </target>
 
-  <macrodef name="run-tests">
+  <macrodef name="run-dist-tests">
+    <!-- Runs the tests against the built jar files -->
     <element name="extra-args" implicit="yes" />
     <sequential>
       <java classname="org.junit.runner.JUnitCore" fork="yes" failonerror="true">
@@ -188,16 +189,34 @@
     </sequential>
   </macrodef>
 
+  <macrodef name="run-local-tests">
+    <!-- Runs the tests against the local class files -->
+    <sequential>
+      <java classname="org.junit.runner.JUnitCore" fork="yes" failonerror="true">
+        <arg value="org.junit.tests.AllTests"/>
+        <classpath>
+          <pathelement location="${bin}" />
+          <pathelement location="${testbin}" />
+          <pathelement location="${hamcrestlib}" />
+        </classpath>
+      </java>    
+    </sequential>
+  </macrodef>
+
+  <target name="test" depends="build">
+    <run-local-tests />
+  </target>
+
   <target name="dist" depends="populate-dist">
-    <run-tests>
-      <jvmarg value="-Dignore.this=ignored" />
-    </run-tests>
+    <run-dist-tests>
+      <jvmarg value="-Dignore.this=ignored"/>
+    </run-dist-tests>
   </target>
 
   <target name="profile" depends="populate-dist">
-    <run-tests>
+    <run-dist-tests>
       <jvmarg value="-agentlib:hprof=cpu=samples"/>
-    </run-tests>
+    </run-dist-tests>
   </target>
 
   <target name="zip" depends="dist">


### PR DESCRIPTION
The new Ant 'test' rule is for running the tests quickly
It will run the tests without doing a clean or creating jars.
