### PR TITLE
Adjust testwatcher skipped to handle failures correctly

### DIFF
--- a/src/main/java/org/junit/rules/TestWatcher.java
+++ b/src/main/java/org/junit/rules/TestWatcher.java
@@ -1,42 +1,42 @@
 package org.junit.rules;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * TestWatcher is a base class for Rules that take note of the testing
  * action, without modifying it. For example, this class will keep a log of each
  * passing and failing test:
- * <p/>
+ *
  * <pre>
  * public static class WatchmanTest {
- * 	private static String watchedLog;
+ *  private static String watchedLog;
  *
- * 	&#064;Rule
- * 	public TestWatcher watchman= new TestWatcher() {
- * 		&#064;Override
- * 		protected void failed(Throwable e, Description description) {
- * 			watchedLog+= description + &quot;\n&quot;;
- *         }
+ *  &#064;Rule
+ *  public TestWatcher watchman= new TestWatcher() {
+ *      &#064;Override
+ *      protected void failed(Throwable e, Description description) {
+ *          watchedLog+= description + &quot;\n&quot;;
+ *      }
  *
- * 		&#064;Override
- * 		protected void succeeded(Description description) {
- * 			watchedLog+= description + &quot; &quot; + &quot;success!\n&quot;;
+ *      &#064;Override
+ *      protected void succeeded(Description description) {
+ *          watchedLog+= description + &quot; &quot; + &quot;success!\n&quot;;
  *         }
  *     };
  *
- * 	&#064;Test
- * 	public void fails() {
- * 		fail();
- *     }
+ *  &#064;Test
+ *  public void fails() {
+ *      fail();
+ *  }
  *
- * 	&#064;Test
- * 	public void succeeds() {
+ *  &#064;Test
+ *  public void succeeds() {
  *     }
  * }
  * </pre>
@@ -70,7 +70,7 @@ public abstract class TestWatcher implements TestRule {
     }
 
     private void succeededQuietly(Description description,
-                                  List<Throwable> errors) {
+            List<Throwable> errors) {
         try {
             succeeded(description);
         } catch (Throwable t) {
@@ -79,7 +79,7 @@ public abstract class TestWatcher implements TestRule {
     }
 
     private void failedQuietly(Throwable t, Description description,
-                               List<Throwable> errors) {
+            List<Throwable> errors) {
         try {
             failed(t, description);
         } catch (Throwable t1) {
@@ -88,7 +88,7 @@ public abstract class TestWatcher implements TestRule {
     }
 
     private void skippedQuietly(AssumptionViolatedException e, Description description,
-                                List<Throwable> errors) {
+            List<Throwable> errors) {
         try {
             skipped(e, description);
         } catch (Throwable t) {
@@ -97,7 +97,7 @@ public abstract class TestWatcher implements TestRule {
     }
 
     private void startingQuietly(Description description,
-                                 List<Throwable> errors) {
+            List<Throwable> errors) {
         try {
             starting(description);
         } catch (Throwable t) {
@@ -106,7 +106,7 @@ public abstract class TestWatcher implements TestRule {
     }
 
     private void finishedQuietly(Description description,
-                                 List<Throwable> errors) {
+            List<Throwable> errors) {
         try {
             finished(description);
         } catch (Throwable t) {

--- a/src/test/java/org/junit/tests/experimental/rules/TestWatcherTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TestWatcherTest.java
@@ -1,13 +1,5 @@
 package org.junit.tests.experimental.rules;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.results.PrintableResult;
-import org.junit.internal.AssumptionViolatedException;
-import org.junit.rules.TestRule;
-import org.junit.rules.TestWatcher;
-import org.junit.runner.Description;
-
 import static junit.framework.Assert.fail;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -16,6 +8,14 @@ import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.failureCountIs;
 import static org.junit.experimental.results.ResultMatchers.hasFailureContaining;
 import static org.junit.runner.JUnitCore.runClasses;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.rules.TestRule;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
 
 public class TestWatcherTest {
     public static class ViolatedAssumptionTest {


### PR DESCRIPTION
As a result of the recent merge of the changes by davidhart82 and me the skipped() method I introduced now misses a failure handling if the skipped() method itself fails. In parallel to the failure handling introduced by davidhart82 I adjusted the call to skipped() and also added a test for it.
