### PR TITLE
Declare the hamcrest-core dependency as "optional".

### DIFF
--- a/build/maven/junit-pom-template.xml
+++ b/build/maven/junit-pom-template.xml
@@ -60,6 +60,7 @@
           <artifactId>hamcrest-core</artifactId>
           <version>1.3</version>
           <scope>compile</scope>
+          <optional>true</optional>
         </dependency>
     </dependencies>
     <properties>


### PR DESCRIPTION
I suggest to declare the hamcrest maven dependency as `optional` (see [here](http://maven.apache.org/pom.html#Dependencies) for further details). This makes it easier for projects to use different hamcrest versions. Additionally, if a project does not use hamcrest at all, it won't get hamcrest into it's classpath when adding a dependency to JUnit.

If I had to use a different hamcrest version, the dependency declaration would look something like this:

```
<dependency>
  <groupId>junit</groupId>
  <artifactId>junit</artifactId>
  <version>4.11-beta-1</version>
  <scope>test</scope>
  <exclusions>
    <exclusion>
      <artifactId>hamcrest-core</artifactId>
      <groupId>org.hamcrest</groupId>
    </exclusion>
  </exclusions>
</dependency>
<!-- hamcrest-library depends on hamcrest-core -->
<dependency>
  <groupId>org.hamcrest</groupId>
  <artifactId>hamcrest-library</artifactId>
  <version>some-other-version</version>
  <scope>test</scope>
</dependency>
```

With the hamcrest dependency being optional, there is no need to exclude it from the JUnit dependency (*). If I don't want to use hamcrest at all, I can just omit the dependency to hamcrest-library. JUnit will still be fully functional with the exception that `assertThat()` cannot be called without getting a compile error.

A drawback to the `optional` declaration is that existing projects using hamcrest will not compile anymore if they don't explicitely declare a dependency to one of the hamcrest libraries. But since many projects using hamcrest have a dependency to other hamcrest libraries (e.g. hamcrest-all or hamcrest-library which all have a dependency to hamcrest-core), these compile errors should not occur very often.

(*) In simple single-module projects, there is no need for the exclusion since the "nearest" declared dependency wins. But in more complicated project setups there are some constellations where maven resolves the wrong hamcrest version.
