### PR TITLE
Pull Request -- Issue #144

### DIFF
--- a/src/main/java/org/junit/Test.java
+++ b/src/main/java/org/junit/Test.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
  * </pre>
  * </p>
  *
- * <p>The <code>Test</code> annotation supports two optional parameters.
+ * <p>The <code>Test</code> annotation supports three optional parameters.
  * The first, <code>expected</code>, declares that a test method should throw
  * an exception. If it doesn't throw an exception or if it throws a different exception
  * than the one declared, the test fails. For example, the following test succeeds:
@@ -34,7 +34,10 @@ import java.lang.annotation.Target;
  *    }
  * </pre></p>
  *
- * <p>The second optional parameter, <code>timeout</code>, causes a test to fail if it takes
+ * <p>The second, <code>message</code>, only valid in the context of providing <code>expected</code>,
+ * declares a <code>String</code> to be returned if the test fails.</p>
+ * 
+ * <p>The third optional parameter, <code>timeout</code>, causes a test to fail if it takes
  * longer than a specified amount of clock time (measured in milliseconds). The following test fails:
  * <pre>
  *    &#064;Test(<b>timeout=100</b>) public void infinity() {
@@ -59,10 +62,16 @@ public @interface Test {
     }
 
     /**
-     * Optionally specify <code>expected</code>, a Throwable, to cause a test method to succeed iff
+     * Optionally specify <code>expected</code>, a Throwable, to cause a test method to succeed if
      * an exception of the specified class is thrown by the method.
      */
     Class<? extends Throwable> expected() default None.class;
+    
+    /**
+     * Optionally specify <code>message</code>, a String, to be returned if the method does not throw
+     * <code>expected</code>
+     */
+    String message() default "";
 
     /**
      * Optionally specify <code>timeout</code> in milliseconds to cause a test method to fail if it

--- a/src/main/java/org/junit/internal/runners/statements/ExpectException.java
+++ b/src/main/java/org/junit/internal/runners/statements/ExpectException.java
@@ -6,10 +6,12 @@ import org.junit.runners.model.Statement;
 public class ExpectException extends Statement {
     private Statement fNext;
     private final Class<? extends Throwable> fExpected;
+    private String fMessage;
 
-    public ExpectException(Statement next, Class<? extends Throwable> expected) {
+    public ExpectException(Statement next, Class<? extends Throwable> expected, String message) {
         fNext = next;
         fExpected = expected;
+        fMessage = message;
     }
 
     @Override
@@ -22,15 +24,33 @@ public class ExpectException extends Statement {
             throw e;
         } catch (Throwable e) {
             if (!fExpected.isAssignableFrom(e.getClass())) {
-                String message = "Unexpected exception, expected<"
-                        + fExpected.getName() + "> but was<"
-                        + e.getClass().getName() + ">";
+            	String message;
+            	
+            	if ( isMessageEmpty() ) {
+            		message = "Unexpected exception, expected<"
+                            + fExpected.getName() + "> but was<"
+                            + e.getClass().getName() + ">";
+            	} else {
+            		message = fMessage;
+            	}
+
                 throw new Exception(message, e);
             }
         }
         if (complete) {
-            throw new AssertionError("Expected exception: "
-                    + fExpected.getName());
+        	String message;
+        	if ( isMessageEmpty() ) {
+        		message = "Expected exception: "
+        				+ fExpected.getName();
+        	} else {
+        		message = fMessage;
+        	}
+        	
+            throw new AssertionError(message);
         }
+    }
+    
+    private boolean isMessageEmpty() {
+        return fMessage == null || fMessage.isEmpty();
     }
 }

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -281,7 +281,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
             Object test, Statement next) {
         Test annotation = method.getAnnotation(Test.class);
         return expectsException(annotation) ? new ExpectException(next,
-                getExpectedException(annotation)) : next;
+                getExpectedException(annotation), getExpectedMessage(annotation)) : next;
     }
 
     /**
@@ -403,6 +403,14 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         }
     }
 
+    private String getExpectedMessage(Test annotation) {
+        if ( annotation == null ) {
+            return null;
+        } else {
+            return annotation.message();
+        }
+    }
+    
     private boolean expectsException(Test annotation) {
         return getExpectedException(annotation) != null;
     }

--- a/src/test/java/org/junit/tests/running/methods/ExpectedTest.java
+++ b/src/test/java/org/junit/tests/running/methods/ExpectedTest.java
@@ -67,4 +67,35 @@ public class ExpectedTest {
     public void expectsSuperclass() {
         assertTrue(new JUnitCore().run(ExpectSuperclass.class).wasSuccessful());
     }
+
+    public static class ExpectNotSuperClassMessage {
+    	@Test(expected = RuntimeException.class, message = "Test Message")
+    	public void throwsSuperClass () throws Exception {
+    		throw new Exception();
+    	}
+    }
+    
+    @Test
+    public void expectsNotSuperclassMessage() {
+    	JUnitCore core = new JUnitCore();
+    	Result result = core.run(ExpectNotSuperClassMessage.class);
+    	assertFalse(result.wasSuccessful());
+    	String message = result.getFailures().get(0).getMessage();
+    	assertTrue("Test Message".equals(message));
+    }
+    
+    public static class ExpectMessage {
+    	@Test(expected = Exception.class, message = "Test Message")
+    	public void throwsNone() {
+    	}
+    }
+    
+    @Test
+    public void expectsMessage() {
+    	JUnitCore core = new JUnitCore();
+    	Result result = core.run(ExpectMessage.class);
+    	assertFalse(result.wasSuccessful());
+    	String message = result.getFailures().get(0).getMessage();
+    	assertTrue("Test Message".equals(message));
+    }    
 }


### PR DESCRIPTION
Added additional annotation attribute, message, to org.junit.Test to
allow for custom messages to be returned from failed tests with expected
exceptions.

I left existing messages in place if the annotation attribute was not provided.

I did not change nearly as much of the code as identified. I suspect it may be a tab -> space conversion .
