### PR TITLE
Only @Category tests should be a subject to run in Categories runner

### DIFF
--- a/src/main/java/org/junit/experimental/categories/Categories.java
+++ b/src/main/java/org/junit/experimental/categories/Categories.java
@@ -110,7 +110,7 @@ public class Categories extends Suite {
         private boolean hasCorrectCategoryAnnotation(Description description) {
             List<Class<?>> categories = categories(description);
             if (categories.isEmpty()) {
-                return fIncluded == null;
+                return false;
             }
             for (Class<?> each : categories) {
                 if (fExcluded != null && fExcluded.isAssignableFrom(each)) {

--- a/src/test/java/org/junit/tests/experimental/categories/CategoryTest.java
+++ b/src/test/java/org/junit/tests/experimental/categories/CategoryTest.java
@@ -122,7 +122,7 @@ public class CategoryTest {
     @Test
     public void testCountOnAWithoutSlowTests() {
         Result result = JUnitCore.runClasses(SomeAreSlowSuite.class);
-        assertEquals(2, result.getRunCount());
+        assertEquals(1, result.getRunCount());
         assertTrue(result.wasSuccessful());
     }
 


### PR DESCRIPTION
When only @ExcludeCategory is used on the suite and test case has a test without Category annotation, this test is executed.

It should not, which is mentioned in Categories Javadoc having sample code -only @Test should fail.

See our internal test:

CategoryTest#testCountOnAWithoutSlowTests()

There the test noCategory() should not be running. Thus getRunCount should return 1.

Result result = JUnitCore.runClasses(SomeAreSlowSuite.class);
assertEquals(2, result.getRunCount());

@RunWith(Categories.class)
@ExcludeCategory(Category1.class)
@SuiteClasses({SomeAreSlow.class})
public static class SomeAreSlowSuite {}

public static class SomeAreSlow {
        @Test
        public void noCategory() {
        }

```
    @Category(Category1.class)
    @Test
    public void justCategory1() {
    }

    @Category(Category2.class)
    @Test
    public void justCategory2() {
    }

    @Category({Category1.class, Category2.class})
    @Test
    public void both() {
    }

    @Category({Category2.class, Category1.class})
    @Test
    public void bothReversed() {
    }
}
```
