### PR TITLE
Fix for MethodSorterTest so that coverage can be measured (issue #551)

### DIFF
--- a/src/test/java/org/junit/internal/MethodSorterTest.java
+++ b/src/test/java/org/junit/internal/MethodSorterTest.java
@@ -61,7 +61,7 @@ public class MethodSorterTest {
         List<String> names = new ArrayList<String>();
         for (Method m : actualMethods) {
             // Filter out synthetic methods from, e.g., coverage tools.
-        	if (!m.isSynthetic()) {
+            if (!m.isSynthetic()) {
                 names.add(m.toString().replace(clazz.getName() + '.', ""));
         	}
         }
@@ -85,7 +85,7 @@ public class MethodSorterTest {
     
     @Test
     public void testMethodsNullSorterSub() {
-        List<String> expected = Arrays.asList(new String[]{SUB_METHOD});
+        List<String> expected = Arrays.asList(SUB_METHOD);
         List<String> actual = getDeclaredMethodNames(Sub.class);
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
**The issue (#551):**
With [Jacoco](http://www.eclemma.org/jacoco/) (formerly eclemma) code coverage enabled in Eclipse, the `org.junit.internal.MethodSorterTest` failed on
- `getMethodsNullSorter`
- `testDefaultSorter`
- `testNameAsc`

The cause was that via reflection methods were collected from static classes. These included temporary methods generated by the coverage tool, which were not expected by the test causing the test to fail.

**The fix**
To fix this, I filter methods before comparison, to just the methods actually declared. This is done by the new `getDeclaredFilteredMethods` helper method. As a result, all tests pass both with and without coverage analysis enabled.

I also applied some small refactorings. I extracted separate test cases for method sorting on sub and superclasses (which were included in the null sorter test case). Furthermore, I based all equality checks directly on lists or arrays, instead of on the `toString` representation of objects.
