### PR TITLE
Measure runtime in Stopwatch rule for Performace tests

### DIFF
--- a/src/main/java/org/junit/rules/Stopwatch.java
+++ b/src/main/java/org/junit/rules/Stopwatch.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * The Stopwatch Rule notifies one of its own protected methods of the time spent by a test.<p/>
  * Override them to get the time in nanoseconds. For example, this class will keep logging the
- * time spent by each passing, failing and skipped test:
+ * time spent by each passed, failed, skipped, and finished test:
  *
  * <pre>
  * public static class StopwatchTest {
@@ -58,12 +58,32 @@ import java.util.concurrent.TimeUnit;
  * }
  * </pre>
  *
+ * An example to assert runtime:
+ * <pre>
+ * &#064;Test
+ * public void performanceTest() throws InterruptedException {
+ *     long delta= 30;
+ *     Thread.sleep(300L);
+ *     assertEquals(stopwatch.runtime(MILLISECONDS), 300d, delta);
+ *     Thread.sleep(500L);
+ *     assertEquals(stopwatch.runtime(MILLISECONDS), 800d, delta);
+ * }
+ * </pre>
+ *
  * @author tibor17
  * @since 4.12
  */
 public class Stopwatch extends TestWatcher {
     private long fStartNanos;
     private long fEndNanos;
+
+    /**
+     * @param unit time unit for returned runtime
+     * @return runtime measured during the test
+     */
+    public long runtime(TimeUnit unit) {
+        return unit.convert(currentNanoTime() - fStartNanos, TimeUnit.NANOSECONDS);
+    }
 
     /**
      * Invoked when a test succeeds
@@ -118,11 +138,15 @@ public class Stopwatch extends TestWatcher {
     }
 
     private void starting() {
-        fStartNanos= System.nanoTime();
+        fStartNanos= currentNanoTime();
     }
 
     private void stopping() {
-        fEndNanos= System.nanoTime();
+        fEndNanos= currentNanoTime();
+    }
+
+    private long currentNanoTime() {
+        return System.nanoTime();
     }
 
     @Override final protected void succeeded(Description description) {

--- a/src/test/java/org/junit/tests/experimental/rules/StopwatchTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/StopwatchTest.java
@@ -9,12 +9,14 @@ import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * @author tibor17
@@ -91,6 +93,24 @@ public class StopwatchTest {
         }
     }
 
+    public static class WrongDurationTest extends AbstractStopwatchTest {
+        @Test
+        public void wrongDuration() throws InterruptedException {
+            Thread.sleep(500L);
+            assertNotEquals(fStopwatch.runtime(MILLISECONDS), 300d, 100d);
+        }
+    }
+
+    public static class DurationTest extends AbstractStopwatchTest {
+        @Test
+        public void duration() throws InterruptedException {
+            Thread.sleep(300L);
+            assertEquals(fStopwatch.runtime(MILLISECONDS), 300d, 100d);
+            Thread.sleep(500L);
+            assertEquals(fStopwatch.runtime(MILLISECONDS), 800d, 250d);
+        }
+    }
+
     @Before
     public void init() {
         fRecord= new Record();
@@ -128,5 +148,17 @@ public class StopwatchTest {
         assertThat(fRecord.fStatus, is(TestStatus.SKIPPED));
         assertTrue("timeSpent > 0", fRecord.fDuration > 0);
         assertThat(fRecord.fDuration, is(fFinishedRecord.fDuration));
+    }
+
+    @Test
+    public void wrongDuration() {
+        Result result= JUnitCore.runClasses(WrongDurationTest.class);
+        assertTrue(result.wasSuccessful());
+    }
+
+    @Test
+    public void duration() {
+        Result result= JUnitCore.runClasses(DurationTest.class);
+        assertTrue(result.wasSuccessful());
     }
 }


### PR DESCRIPTION
Follows #552. We would be able assert runtime in performance tests:

`
long delta= 30;
Thread.sleep(300L);
assertEquals(fStopwatch.runtime(MILLISECONDS), 300d, delta);
Thread.sleep(500L);
assertEquals(fStopwatch.runtime(MILLISECONDS), 800d, delta);
`
