### PR TITLE
Fix usage of actual/expected in #assertEquals

### DIFF
--- a/src/main/java/org/junit/rules/Stopwatch.java
+++ b/src/main/java/org/junit/rules/Stopwatch.java
@@ -64,9 +64,9 @@ import java.util.concurrent.TimeUnit;
  * public void performanceTest() throws InterruptedException {
  *     long delta= 30;
  *     Thread.sleep(300L);
- *     assertEquals(stopwatch.runtime(MILLISECONDS), 300d, delta);
+ *     assertEquals(300d, stopwatch.runtime(MILLISECONDS), delta);
  *     Thread.sleep(500L);
- *     assertEquals(stopwatch.runtime(MILLISECONDS), 800d, delta);
+ *     assertEquals(800d, stopwatch.runtime(MILLISECONDS), delta);
  * }
  * </pre>
  *

--- a/src/test/java/org/junit/tests/experimental/rules/StopwatchTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/StopwatchTest.java
@@ -105,9 +105,9 @@ public class StopwatchTest {
         @Test
         public void duration() throws InterruptedException {
             Thread.sleep(300L);
-            assertEquals(fStopwatch.runtime(MILLISECONDS), 300d, 100d);
+            assertEquals(300d, fStopwatch.runtime(MILLISECONDS), 100d);
             Thread.sleep(500L);
-            assertEquals(fStopwatch.runtime(MILLISECONDS), 800d, 250d);
+            assertEquals(800d, fStopwatch.runtime(MILLISECONDS), 250d);
         }
     }
 


### PR DESCRIPTION
This is a fix for javadoc in Stopwatch and tests which is using wrong order of actual/expected in #assertEquals.
