### PR TITLE
Implementation for Issue #45

### DIFF
--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -326,7 +326,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
                 target);
     }
 
-    protected Statement withRules(FrameworkMethod method, Object target,
+    private Statement withRules(FrameworkMethod method, Object target,
             Statement statement) {
         List<TestRule> testRules = getTestRules(target);
         Statement result = statement;
@@ -336,7 +336,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         return result;
     }
 
-    protected Statement withMethodRules(FrameworkMethod method, List<TestRule> testRules,
+    private Statement withMethodRules(FrameworkMethod method, List<TestRule> testRules,
             Object target, Statement result) {
         for (org.junit.rules.MethodRule each : getMethodRules(target)) {
             if (!testRules.contains(each)) {
@@ -346,7 +346,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         return result;
     }
 
-    protected List<org.junit.rules.MethodRule> getMethodRules(Object target) {
+    private List<org.junit.rules.MethodRule> getMethodRules(Object target) {
         return rules(target);
     }
 
@@ -368,7 +368,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
      * @return a RunRules statement if any class-level {@link Rule}s are
      *         found, or the base statement
      */
-    protected Statement withTestRules(FrameworkMethod method, List<TestRule> testRules,
+    private Statement withTestRules(FrameworkMethod method, List<TestRule> testRules,
             Statement statement) {
         return testRules.isEmpty() ? statement :
                 new RunRules(statement, testRules, describeChild(method));

--- a/src/main/java/org/junit/runners/Parameterized.java
+++ b/src/main/java/org/junit/runners/Parameterized.java
@@ -307,30 +307,24 @@ public class Parameterized extends Suite {
             Statement statement = childrenInvoker(notifier);
             
             try {
-                fTestInstance = new ReflectiveCallable() {
-                    @Override
-                    protected Object runReflectiveCall() throws Throwable {
-                        return createTest();
-                    }
-                }.run();
-            } catch (Throwable e) {
-                return new Fail(e);
-            }
+				fTestInstance = superCreateTest();
+			} catch (Throwable e) {
+				return new Fail(e);
+			}
             
             statement = withParameterRules(statement,fTestInstance);
             
             return statement;
         }
         
+
         @Override
-        protected Statement methodBlock(FrameworkMethod method) {
-            Statement statement = methodInvoker(method, fTestInstance);
-            statement = possiblyExpectingExceptions(method, fTestInstance, statement);
-            statement = withPotentialTimeout(method, fTestInstance, statement);
-            statement = withBefores(method, fTestInstance, statement);
-            statement = withAfters(method, fTestInstance, statement);
-            statement = withRules(method, fTestInstance, statement);
-            return statement;
+        public Object createTest() throws Exception {
+        	return fTestInstance;
+        }
+        
+        private Object superCreateTest() throws Exception {
+        	return super.createTest();
         }
         
         private List<TestRule> getParameterRules(Object target) {


### PR DESCRIPTION
- Add a new annotation named `ParameterRule`.
- Add a new protected inner class that extends
  `TestClassRunnerForParameters` named `SingleInstanceRunnerForParameters`.
- Instantiates TestClassRunnerForParameters or
  SingleInstanceRunnerForParameters depending if ParameterRule exists or
  not.
- Modified `BlockJUnit4ClassRunner` by converting some methods from
  private to protected.
