### PR TITLE
RuleChain.of(...)

### DIFF
--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -67,6 +67,20 @@ public class RuleChain implements TestRule {
         return emptyRuleChain().around(outerRule);
     }
 
+	/**
+	 * Returns a {@code RuleChain} containing the specified rules in the
+	 * specified order.
+	 */
+	public static RuleChain of(TestRule first, TestRule second,
+			TestRule... rest) {
+		final List<TestRule> rules= new ArrayList<TestRule>(2 + rest.length);
+		rules.add(first);
+		rules.add(second);
+		Collections.addAll(rules, rest);
+		Collections.reverse(rules);
+		return new RuleChain(rules);
+	}
+
     private RuleChain(List<TestRule> rules) {
         this.rulesStartingWithInnerMost = rules;
     }

--- a/src/test/java/org/junit/tests/experimental/rules/RuleChainTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/RuleChainTest.java
@@ -9,6 +9,7 @@ import static org.junit.rules.RuleChain.outerRule;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -17,6 +18,11 @@ import org.junit.runner.Description;
 
 public class RuleChainTest {
     private static final List<String> LOG = new ArrayList<String>();
+
+	@Before
+	public void clearLog() {
+		LOG.clear();
+	}
 
     private static class LoggingRule extends TestWatcher {
         private final String label;
@@ -57,4 +63,26 @@ public class RuleChainTest {
                 "finished outer rule");
         assertEquals(expectedLog, LOG);
     }
+
+	public static class UseRuleChainOf {
+		@Rule
+		public final RuleChain chain= RuleChain.of(
+				new LoggingRule("outer rule"), new LoggingRule("middle rule"),
+				new LoggingRule("inner rule"));
+
+		@Test
+		public void example() {
+			assertTrue(true);
+		}
+	}
+
+	@Test
+	public void executeRuleChainOfInCorrectOrder() throws Exception {
+		testResult(UseRuleChainOf.class);
+		List<String> expectedLog= asList("starting outer rule",
+				"starting middle rule", "starting inner rule",
+				"finished inner rule", "finished middle rule",
+				"finished outer rule");
+		assertEquals(expectedLog, LOG);
+	}
 }


### PR DESCRIPTION
The existing way of constructing RuleChain using outerRule() and around() calls seems too verbose without any additional benefits.
I would like to have simpler way of constructing a chain. From my point of view the most logical way is  passing them all as parameters of the single method call.
