### PR TITLE
Implement new feature to allow shuffling of Tests.

### DIFF
--- a/src/main/java/junit/framework/JUnit4TestAdapter.java
+++ b/src/main/java/junit/framework/JUnit4TestAdapter.java
@@ -1,8 +1,10 @@
 package junit.framework;
 
 import java.util.List;
+import java.util.Random;
 
 import org.junit.Ignore;
+import org.junit.internal.Shuffler;
 import org.junit.runner.Describable;
 import org.junit.runner.Description;
 import org.junit.runner.Request;
@@ -10,10 +12,11 @@ import org.junit.runner.Runner;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.Filterable;
 import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.manipulation.Shufflable;
 import org.junit.runner.manipulation.Sortable;
 import org.junit.runner.manipulation.Sorter;
 
-public class JUnit4TestAdapter implements Test, Filterable, Sortable, Describable {
+public class JUnit4TestAdapter implements Test, Filterable, Sortable, Shufflable, Describable {
     private final Class<?> fNewTestClass;
 
     private final Runner fRunner;
@@ -82,5 +85,9 @@ public class JUnit4TestAdapter implements Test, Filterable, Sortable, Describabl
 
     public void sort(Sorter sorter) {
         sorter.apply(fRunner);
+    }
+
+    public void shuffle(Random random) {
+        new Shuffler(random).apply(fRunner);
     }
 }

--- a/src/main/java/org/junit/internal/Shuffler.java
+++ b/src/main/java/org/junit/internal/Shuffler.java
@@ -1,0 +1,20 @@
+package org.junit.internal;
+
+import java.util.Random;
+
+import org.junit.runner.manipulation.Shufflable;
+
+public class Shuffler {
+	private final Random random;
+
+	public Shuffler(Random random) {
+		this.random= random;
+	}
+
+	public void apply(Object object) {
+		if (object instanceof Shufflable) {
+			Shufflable shufflable= (Shufflable) object;
+			shufflable.shuffle(random);
+		}
+	}
+}

--- a/src/main/java/org/junit/internal/requests/ShufflingRequest.java
+++ b/src/main/java/org/junit/internal/requests/ShufflingRequest.java
@@ -1,0 +1,25 @@
+package org.junit.internal.requests;
+
+import java.util.Random;
+
+import org.junit.internal.Shuffler;
+import org.junit.runner.Request;
+import org.junit.runner.Runner;
+
+public class ShufflingRequest extends Request {
+	private final Request fRequest;
+
+	private final Random fRandom;
+
+	public ShufflingRequest(Request request, Random random) {
+		fRequest= request;
+		fRandom= random;
+	}
+
+	@Override
+	public Runner getRunner() {
+		Runner runner= fRequest.getRunner();
+		new Shuffler(fRandom).apply(runner);
+		return runner;
+	}
+}

--- a/src/main/java/org/junit/internal/runners/JUnit38ClassRunner.java
+++ b/src/main/java/org/junit/internal/runners/JUnit38ClassRunner.java
@@ -1,5 +1,7 @@
 package org.junit.internal.runners;
 
+import java.util.Random;
+
 import junit.extensions.TestDecorator;
 import junit.framework.AssertionFailedError;
 import junit.framework.Test;
@@ -13,12 +15,13 @@ import org.junit.runner.Runner;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.Filterable;
 import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.manipulation.Shufflable;
 import org.junit.runner.manipulation.Sortable;
 import org.junit.runner.manipulation.Sorter;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 
-public class JUnit38ClassRunner extends Runner implements Filterable, Sortable {
+public class JUnit38ClassRunner extends Runner implements Filterable, Sortable, Shufflable {
     private final class OldTestClassAdaptingListener implements
             TestListener {
         private final RunNotifier fNotifier;
@@ -147,6 +150,13 @@ public class JUnit38ClassRunner extends Runner implements Filterable, Sortable {
         if (getTest() instanceof Sortable) {
             Sortable adapter = (Sortable) getTest();
             adapter.sort(sorter);
+        }
+    }
+
+    public void shuffle(Random random) {
+        if (getTest() instanceof Shufflable) {
+            Shufflable adapter = (Shufflable) getTest();
+            adapter.shuffle(random);
         }
     }
 

--- a/src/main/java/org/junit/runner/Request.java
+++ b/src/main/java/org/junit/runner/Request.java
@@ -1,11 +1,13 @@
 package org.junit.runner;
 
 import java.util.Comparator;
+import java.util.Random;
 
 import org.junit.internal.builders.AllDefaultPossibilitiesBuilder;
 import org.junit.internal.requests.ClassRequest;
 import org.junit.internal.requests.FilterRequest;
 import org.junit.internal.requests.SortingRequest;
+import org.junit.internal.requests.ShufflingRequest;
 import org.junit.internal.runners.ErrorReportingRunner;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runners.model.InitializationError;
@@ -167,5 +169,27 @@ public abstract class Request {
      */
     public Request sortWith(Comparator<Description> comparator) {
         return new SortingRequest(this, comparator);
+    }
+
+    /**
+     * Returns a Request whose Tests are shuffled in a random order using a
+     * default source of randomness
+     * 
+     * @return a Request with shuffled Tests
+     */
+    public Request shuffled() {
+        return new ShufflingRequest(this, null);
+    }
+
+    /**
+     * Returns a Request whose Tests are shuffled in a random order using a
+     * given Random as a source of randomness.
+     * 
+     * @param source
+     *            of randomness
+     * @return a Request with shuffled Tests
+     */
+    public Request shuffled(Random random) {
+        return new ShufflingRequest(this, random);
     }
 }

--- a/src/main/java/org/junit/runner/manipulation/Shufflable.java
+++ b/src/main/java/org/junit/runner/manipulation/Shufflable.java
@@ -1,0 +1,18 @@
+package org.junit.runner.manipulation;
+
+import java.util.Random;
+
+/**
+ * Interface for runners that allow shuffling of tests.
+ */
+public interface Shufflable {
+	/**
+	 * Shuffle the tests using the specified source of randomness. If
+	 * <code>random</code> is <code>null</code>, then a default source of
+	 * randomness is used.
+	 * 
+	 * @param random
+	 *            the {@link Random} source of randomness
+	 */
+	public void shuffle(Random random);
+}

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -10,12 +10,14 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Random;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.internal.AssumptionViolatedException;
+import org.junit.internal.Shuffler;
 import org.junit.internal.runners.model.EachTestNotifier;
 import org.junit.internal.runners.statements.RunAfters;
 import org.junit.internal.runners.statements.RunBefores;
@@ -26,6 +28,7 @@ import org.junit.runner.Runner;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.Filterable;
 import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.manipulation.Shufflable;
 import org.junit.runner.manipulation.Sortable;
 import org.junit.runner.manipulation.Sorter;
 import org.junit.runner.notification.RunNotifier;
@@ -51,10 +54,12 @@ import org.junit.runners.model.TestClass;
  * @since 4.5
  */
 public abstract class ParentRunner<T> extends Runner implements Filterable,
-        Sortable {
+        Sortable, Shufflable {
     private final TestClass fTestClass;
 
     private Sorter fSorter = Sorter.NULL;
+    
+    private Shuffler fShuffler = null;
 
     private List<T> fFilteredChildren = null;
 
@@ -345,6 +350,18 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
         }
         Collections.sort(getFilteredChildren(), comparator());
     }
+    
+    public void shuffle(Random random) {
+    	fShuffler = new Shuffler(random);
+    	for (T each : getFilteredChildren()) {
+    		shuffleChild(each);
+    	}
+    	if (random == null) {
+        	Collections.shuffle(getFilteredChildren());
+    	} else {
+        	Collections.shuffle(getFilteredChildren(), random);
+    	}
+    }
 
     //
     // Private implementation
@@ -367,6 +384,10 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
 
     private void sortChild(T child) {
         fSorter.apply(child);
+    }
+    
+    private void shuffleChild(T child) {
+    	fShuffler.apply(child);
     }
 
     private boolean shouldRun(Filter filter, T each) {

--- a/src/test/java/org/junit/tests/manipulation/ShufflableTest.java
+++ b/src/test/java/org/junit/tests/manipulation/ShufflableTest.java
@@ -1,0 +1,320 @@
+package org.junit.tests.manipulation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import java.util.Random;
+
+import junit.framework.JUnit4TestAdapter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
+import org.junit.runner.RunWith;
+
+@RunWith(Enclosed.class)
+public class ShufflableTest {
+	public static class TestClassRunnerIsShufflable {
+		private static String log= "";
+
+		public static class ShuffleMe {
+			@Test
+			public void a() {
+				log+= "a";
+			}
+
+			@Test
+			public void b() {
+				log+= "b";
+			}
+
+			@Test
+			public void c() {
+				log+= "c";
+			}
+
+			@Test
+			public void d() {
+				log+= "d";
+			}
+
+			@Test
+			public void e() {
+				log+= "e";
+			}
+
+		}
+
+		@Before
+		public void resetLog() {
+			log= "";
+		}
+
+		@Test
+		public void shuffledMethodWorksOnTestClassRunner() {
+			Request randomly= Request.aClass(ShuffleMe.class).shuffled();
+
+			new JUnitCore().run(randomly);
+			String s= log;
+			do {
+				log= "";
+				new JUnitCore().run(randomly);
+			} while (s.equals(log));
+			assertNotEquals(s, log);
+		}
+
+		@Test
+		public void shuffledWithRandomMethodWorksOnTestClassRunner() {
+			Random random1= new Random(0L);
+			Random random2= new Random(1L);
+			Request randomly1= Request.aClass(ShuffleMe.class).shuffled(
+					random1);
+			Request randomly2= Request.aClass(ShuffleMe.class).shuffled(
+					random2);
+
+			new JUnitCore().run(randomly1);
+			assertEquals("ecbda", log);
+			log= "";
+			new JUnitCore().run(randomly2);
+			assertEquals("cdbea", log);
+		}
+
+		@RunWith(Enclosed.class)
+		public static class Enclosing {
+			public static class A {
+				@Test
+				public void a() {
+					log+= "Aa";
+				}
+
+				@Test
+				public void b() {
+					log+= "Ab";
+				}
+
+				@Test
+				public void c() {
+					log+= "Ac";
+				}
+
+				@Test
+				public void d() {
+					log+= "Ad";
+				}
+
+				@Test
+				public void e() {
+					log+= "Ae";
+				}
+			}
+
+			public static class B {
+				@Test
+				public void a() {
+					log+= "Ba";
+				}
+
+				@Test
+				public void b() {
+					log+= "Bb";
+				}
+
+				@Test
+				public void c() {
+					log+= "Bc";
+				}
+
+				@Test
+				public void d() {
+					log+= "Bd";
+				}
+
+				@Test
+				public void e() {
+					log+= "Be";
+				}
+			}
+
+			public static class C {
+				@Test
+				public void a() {
+					log+= "Ca";
+				}
+
+				@Test
+				public void b() {
+					log+= "Cb";
+				}
+
+				@Test
+				public void c() {
+					log+= "Cc";
+				}
+
+				@Test
+				public void d() {
+					log+= "Cd";
+				}
+
+				@Test
+				public void e() {
+					log+= "Ce";
+				}
+			}
+
+			public static class D {
+				@Test
+				public void a() {
+					log+= "Da";
+				}
+
+				@Test
+				public void b() {
+					log+= "Db";
+				}
+
+				@Test
+				public void c() {
+					log+= "Dc";
+				}
+
+				@Test
+				public void d() {
+					log+= "Dd";
+				}
+
+				@Test
+				public void e() {
+					log+= "De";
+				}
+			}
+
+			public static class E {
+				@Test
+				public void a() {
+					log+= "Ea";
+				}
+
+				@Test
+				public void b() {
+					log+= "Eb";
+				}
+
+				@Test
+				public void c() {
+					log+= "Ec";
+				}
+
+				@Test
+				public void d() {
+					log+= "Ed";
+				}
+
+				@Test
+				public void e() {
+					log+= "Ee";
+				}
+			}
+		}
+
+		@Test
+		public void shuffledMethodWorksOnSuite() {
+			Request randomly= Request.aClass(Enclosing.class).shuffled();
+
+			new JUnitCore().run(randomly);
+			String s= log;
+			do {
+				log= "";
+				new JUnitCore().run(randomly);
+			} while (s.equals(log));
+			assertNotEquals(s, log);
+		}
+
+		@Test
+		public void shuffledWithRandomMethodWorksOnSuite() {
+			Random random1= new Random(0L);
+			Random random2= new Random(1L);
+			Request randomly1= Request.aClass(Enclosing.class).shuffled(
+					random1);
+			Request randomly2= Request.aClass(Enclosing.class).shuffled(
+					random2);
+
+			new JUnitCore().run(randomly1);
+			assertEquals("EbEdEcEaEeAeAcAbAdAaCbCaCcCdCeBdBeBcBbBaDaDbDeDcDd",
+					log);
+			log= "";
+			new JUnitCore().run(randomly2);
+			assertEquals("CeCaCbCcCdAcAdAbAeAaEbEeEaEdEcDeDbDdDaDcBdBbBcBaBe",
+					log);
+		}
+	}
+
+	public static class TestClassRunnerIsShufflableWithSuiteMethod {
+		private static String log= "";
+
+		public static class ShuffleMe {
+			@Test
+			public void a() {
+				log+= "a";
+			}
+
+			@Test
+			public void b() {
+				log+= "b";
+			}
+
+			@Test
+			public void c() {
+				log+= "c";
+			}
+
+			@Test
+			public void d() {
+				log+= "d";
+			}
+
+			@Test
+			public void e() {
+				log+= "e";
+			}
+
+			public static junit.framework.Test suite() {
+				return new JUnit4TestAdapter(ShuffleMe.class);
+			}
+		}
+
+		@Before
+		public void resetLog() {
+			log= "";
+		}
+
+		@Test
+		public void shuffledMethodWorksOnTestClassRunner() {
+			Request randomly= Request.aClass(ShuffleMe.class).shuffled();
+
+			new JUnitCore().run(randomly);
+			String s= log;
+			do {
+				log= "";
+				new JUnitCore().run(randomly);
+			} while (s.equals(log));
+			assertNotEquals(s, log);
+		}
+
+		@Test
+		public void shuffledWithRandomMethodWorksOnTestClassRunner() {
+			Random random1= new Random(0L);
+			Random random2= new Random(1L);
+			Request randomly1= Request.aClass(ShuffleMe.class).shuffled(
+					random1);
+			Request randomly2= Request.aClass(ShuffleMe.class).shuffled(
+					random2);
+
+			new JUnitCore().run(randomly1);
+			assertEquals("ecbda", log);
+			log= "";
+			new JUnitCore().run(randomly2);
+			assertEquals("cdbea", log);
+		}
+	}
+}


### PR DESCRIPTION
This adds new methods to Request class shuffled() and shuffledWith() which will
give a Request whose Tests will be shuffled.

This is meant as a do over for what I intended with PR #584. I believe the concerns raised in the other PR should be addressed with this new patch. The new methods shuffled() and shuffledWith() more accurately represent what is intended to happen with the Tests, as I was implementing in the other PR. Also, the shuffledWith() takes a Random which can constructed with a set seed.

Some core classes are modified, but they only add methods and do not modify any other existing code.
