### PR TITLE
Prepare for a release of new version under Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.0</version>
+            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
The GitHub is using snapshot versions -been in development.

For deploying release, beta, or snapshot verions:
- Jenkins' Job can start a pre-build command `mvn -DnewVersion=4.12 versions:set`.
- threafter the same job starts main build `mvn -Dgpg.passphrase="..." -Psign clean deploy`

The first cmd modifies version in pom.xml, the next cmd is the build itself.
You update the configuration on CloudBees due to a newVersion, but not necessarily in GitHub.

Changing the version does not work in one step, and Jenkins does not support interactive release version update.

We may update wiki and #608 accordingly when this process clearly works on CloudBees
https://github.com/KentBeck/junit/wiki/Releasing
