### PR TITLE
Added validation that all datapoint methods and fields are public and static to theory initialization

### DIFF
--- a/src/main/java/org/junit/experimental/theories/Theories.java
+++ b/src/main/java/org/junit/experimental/theories/Theories.java
@@ -2,6 +2,7 @@ package org.junit.experimental.theories;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,13 +27,14 @@ public class Theories extends BlockJUnit4ClassRunner {
     protected void collectInitializationErrors(List<Throwable> errors) {
         super.collectInitializationErrors(errors);
         validateDataPointFields(errors);
+        validateDataPointMethods(errors);
     }
 
     private void validateDataPointFields(List<Throwable> errors) {
         Field[] fields = getTestClass().getJavaClass().getDeclaredFields();
 
         for (Field field : fields) {
-            if (field.getAnnotation(DataPoint.class) == null) {
+            if (field.getAnnotation(DataPoint.class) == null && field.getAnnotation(DataPoints.class) == null) {
                 continue;
             }
             if (!Modifier.isStatic(field.getModifiers())) {
@@ -40,6 +42,22 @@ public class Theories extends BlockJUnit4ClassRunner {
             }
             if (!Modifier.isPublic(field.getModifiers())) {
                 errors.add(new Error("DataPoint field " + field.getName() + " must be public"));
+            }
+        }
+    }
+
+    private void validateDataPointMethods(List<Throwable> errors) {
+        Method[] methods = getTestClass().getJavaClass().getDeclaredMethods();
+        
+        for (Method method : methods) {
+            if (method.getAnnotation(DataPoint.class) == null && method.getAnnotation(DataPoints.class) == null) {
+                continue;
+            }
+            if (!Modifier.isStatic(method.getModifiers())) {
+                errors.add(new Error("DataPoint method " + method.getName() + " must be static"));
+            }
+            if (!Modifier.isPublic(method.getModifiers())) {
+                errors.add(new Error("DataPoint method " + method.getName() + " must be public"));
             }
         }
     }


### PR DESCRIPTION
This fixes #125. In that issue, tests with non-static or non-public datapoint methods are ignored because they're not checked for when constructing the instance, and when the values are retrieved for theory parameters in getValue() in MethodParameterValue (in AllMembersSupplier) an exception is thrown, but then swallowed in addMultiPointMethods/addSinglePointMethods in AllMembersSupplier. 

There's another abandoned pull request trying fixing this in #328, which rethrows all exceptions thrown in datapoint methods, including this one. This is arguably dubious since you could potentially have other exceptions coming from datapoint methods, and it's not clear whether those should actually fail tests. This commit does not affect issue 137 (caused by the exception hiding), which #328 does try to solve.

On the other hand, datapoint methods that are definitely being entirely ignored are a legitimately incorrect use of the datapoints annotation, and that should actually fail, I think.

While there was no error before this for non-static datapoint methods, there was an initialization error for non-static/non-public `@DataPoint` fields. There wasn't an error for `@DataPoints` array fields though, for no possible good reason I can see, since this doesn't have any of the same exception hiding issues as the methods do.

With this commit all of the above is fixed, by adding checks on test initialization that look at all the datapoint methods and fields, and confirms that they're public and static. This already existed for fields annotated with `@DataPoint`, but now also covers array fields annotated with `@DataPoints` and array and singleton annotated datapoint methods.
