### PR TITLE
Fix for issue #587. Simple javadoc correction.

### DIFF
--- a/src/main/java/org/junit/rules/Verifier.java
+++ b/src/main/java/org/junit/rules/Verifier.java
@@ -9,7 +9,7 @@ import org.junit.runners.model.Statement;
  * failed
  *
  * <pre>
- *     public static class ErrorLogVerifier() {
+ *     public static class ErrorLogVerifier {
  *        private ErrorLog errorLog = new ErrorLog();
  *
  *        &#064;Rule


### PR DESCRIPTION
Although part of the issue was already solved, there was still a pair of round brackets on the first line of the code sample that needed to be removed.
