### PR TITLE
Documentation fix: 'iff' becomes 'if and only if'

### DIFF
--- a/src/main/java/org/junit/Test.java
+++ b/src/main/java/org/junit/Test.java
@@ -59,8 +59,8 @@ public @interface Test {
     }
 
     /**
-     * Optionally specify <code>expected</code>, a Throwable, to cause a test method to succeed iff
-     * an exception of the specified class is thrown by the method.
+     * Optionally specify <code>expected</code>, a Throwable, to cause a test method to succeed if
+     * and only if an exception of the specified class is thrown by the method.
      */
     Class<? extends Throwable> expected() default None.class;
 


### PR DESCRIPTION
While clever jargon is always appreciated documentation should be understood by all audiences. This fix changes the questionable "iff" into its explicit value, "if and only if."
