### PR TITLE
Added specific targetting for the various theory annotations

### DIFF
--- a/src/main/java/org/junit/experimental/theories/DataPoint.java
+++ b/src/main/java/org/junit/experimental/theories/DataPoint.java
@@ -1,9 +1,14 @@
 package org.junit.experimental.theories;
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
+@Target({FIELD, METHOD})
 public @interface DataPoint {
 
 }

--- a/src/main/java/org/junit/experimental/theories/DataPoints.java
+++ b/src/main/java/org/junit/experimental/theories/DataPoints.java
@@ -1,9 +1,14 @@
 package org.junit.experimental.theories;
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
+@Target({FIELD, METHOD})
 public @interface DataPoints {
 
 }

--- a/src/main/java/org/junit/experimental/theories/ParametersSuppliedBy.java
+++ b/src/main/java/org/junit/experimental/theories/ParametersSuppliedBy.java
@@ -1,10 +1,15 @@
 package org.junit.experimental.theories;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.PARAMETER;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ANNOTATION_TYPE, PARAMETER})
 public @interface ParametersSuppliedBy {
 
     Class<? extends ParameterSupplier> value();

--- a/src/main/java/org/junit/experimental/theories/Theory.java
+++ b/src/main/java/org/junit/experimental/theories/Theory.java
@@ -1,9 +1,13 @@
 package org.junit.experimental.theories;
 
+import static java.lang.annotation.ElementType.METHOD;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
+@Target(METHOD)
 public @interface Theory {
     boolean nullsAccepted() default true;
 }

--- a/src/main/java/org/junit/experimental/theories/suppliers/TestedOn.java
+++ b/src/main/java/org/junit/experimental/theories/suppliers/TestedOn.java
@@ -1,12 +1,16 @@
 package org.junit.experimental.theories.suppliers;
 
+import static java.lang.annotation.ElementType.PARAMETER;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 import org.junit.experimental.theories.ParametersSuppliedBy;
 
 @ParametersSuppliedBy(TestedOnSupplier.class)
 @Retention(RetentionPolicy.RUNTIME)
+@Target(PARAMETER)
 public @interface TestedOn {
     int[] ints();
 }


### PR DESCRIPTION
None of the theory annotations currently specify specific targets, making entirely meaningless constructions like:

``` java
@ParametersSuppliedBy(Supplier.class) 
public void int one = 1;

public String method(@Theory int param) {
   ...
}

@DataPoints
public class X {
  ...
}
```

all compile, but silently do nothing. This fixes that (each of these will fail to build).
