### PR TITLE
Twaeks on pull requests # 625 and # 578

### DIFF
--- a/src/main/java/org/junit/runner/notification/RunListener.java
+++ b/src/main/java/org/junit/runner/notification/RunListener.java
@@ -4,6 +4,12 @@ import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
  * <p>If you need to respond to the events during a test run, extend <code>RunListener</code>
  * and override the appropriate methods. If a listener throws an exception while processing a
@@ -28,12 +34,30 @@ import org.junit.runner.Result;
  *    core.run(MyTestClass.class);
  * }
  * </pre>
- * </p>
+ *
+ * </p> By default, listeners are synchronized in {@link RunNotifier}.
+ * </p> If your listener is thread-safe and all methods can be called asynchronously in
+ * multiple threads (e.g. tests are run in parallel), you can annotate the class of your
+ * listener with {@link RunListener.ThreadSafe}.
  *
  * @see org.junit.runner.JUnitCore
  * @since 4.0
  */
 public class RunListener {
+
+    /**
+     * Indicates a {@code RunListener} that can have its methods called
+     * concurrently. This implies that the class is thread-safe (i.e. no set of
+     * listener calls can put the listener into an invalid state, even if those
+     * listener calls are being made by multiple threads without synchronization).
+     *
+     * @since 4.12
+     */
+    @Documented
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public static @interface ThreadSafe {
+    }
 
     /**
      * Called before any tests have been run.

--- a/src/main/java/org/junit/runner/notification/SynchronizedRunListener.java
+++ b/src/main/java/org/junit/runner/notification/SynchronizedRunListener.java
@@ -1,0 +1,81 @@
+package org.junit.runner.notification;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+
+/**
+ * Decorator for {@link RunListener} that synchronizes calls to the delegate.
+ * Only as an internal patch.
+ *
+ * @author Tibor Digana (tibor17)
+ * @author Kevin Cooney (kcooney)
+ * @since 4.12
+ *
+ * @see RunNotifier
+ */
+final class SynchronizedRunListener extends RunListener {
+    private final RunListener listener;
+
+    SynchronizedRunListener(RunListener listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public synchronized void testRunStarted(Description description) throws Exception {
+        listener.testRunStarted(description);
+    }
+
+    @Override
+    public synchronized void testRunFinished(Result result) throws Exception {
+        listener.testRunFinished(result);
+    }
+
+    @Override
+    public synchronized void testStarted(Description description) throws Exception {
+        listener.testStarted(description);
+    }
+
+    @Override
+    public synchronized void testFinished(Description description) throws Exception {
+        listener.testFinished(description);
+    }
+
+    @Override
+    public synchronized void testFailure(Failure failure) throws Exception {
+        listener.testFailure(failure);
+    }
+
+    @Override
+    public synchronized void testAssumptionFailure(Failure failure) {
+        listener.testAssumptionFailure(failure);
+    }
+
+    @Override
+    public synchronized void testIgnored(Description description) throws Exception {
+        listener.testIgnored(description);
+    }
+
+    @Override
+    public int hashCode() {
+        return listener.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+
+        if (o instanceof SynchronizedRunListener) {
+            SynchronizedRunListener other = (SynchronizedRunListener) o;
+            return listener.equals(other.listener);
+        } else {
+            return listener.equals(o);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return listener.toString();
+    }
+}

--- a/src/test/java/org/junit/runner/notification/ConcurrentRunNotifierTest.java
+++ b/src/test/java/org/junit/runner/notification/ConcurrentRunNotifierTest.java
@@ -1,0 +1,188 @@
+package org.junit.runner.notification;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Testing RunNotifier in concurrent access.
+ *
+ * @author Tibor Digana (tibor17)
+ * @version 4.12
+ * @since 4.12
+ */
+public final class ConcurrentRunNotifierTest {
+    private static final long TIMEOUT = 3;
+
+    private static class ConcurrentRunListener extends RunListener {
+        final AtomicInteger testStarted = new AtomicInteger(0);
+
+        public void testStarted(Description description) throws Exception {
+            testStarted.incrementAndGet();
+        }
+    }
+
+    @Test
+    public void realUsage() throws InterruptedException {
+        final RunNotifier notifier = new RunNotifier();
+
+        ConcurrentRunListener listener1 = new ConcurrentRunListener();
+        ConcurrentRunListener listener2 = new ConcurrentRunListener();
+        notifier.addListener(listener1);
+        notifier.addListener(listener2);
+
+        final int numParallelTests = 4;
+        ExecutorService pool = Executors.newFixedThreadPool(numParallelTests);
+        for (int i = 0; i < numParallelTests; ++i) {
+            pool.submit(new Runnable() {
+                public void run() {
+                    notifier.fireTestStarted(null);
+                }
+            });
+        }
+        pool.shutdown();
+        assertTrue(pool.awaitTermination(TIMEOUT, TimeUnit.SECONDS));
+
+        notifier.removeListener(listener1);
+        notifier.removeListener(listener2);
+
+        assertThat(listener1.testStarted.get(), is(numParallelTests));
+        assertThat(listener2.testStarted.get(), is(numParallelTests));
+    }
+
+    private static class ExaminedListener extends RunListener {
+        volatile boolean useMe = false;
+        volatile boolean hasTestFailure = false;
+
+        ExaminedListener(boolean useMe) {
+            this.useMe = useMe;
+        }
+
+        @Override
+        public void testStarted(Description description) throws Exception {
+            if (!useMe) {
+                throw new Exception();
+            }
+        }
+
+        @Override
+        public void testFailure(Failure failure) throws Exception {
+            hasTestFailure = true;
+        }
+    }
+
+    @Test
+    public void reportConcurrentFailuresAfterAddListener() throws Exception {
+        final RunNotifier notifier = new RunNotifier();
+
+        int totalListenersFailures = 0;
+
+        final ExaminedListener[] examinedListeners = new ExaminedListener[1000];
+        for (int i = 0; i < examinedListeners.length; ++i) {
+            boolean fail = StrictMath.random() >= 0.5d;
+            if (fail) {
+                ++totalListenersFailures;
+            }
+            examinedListeners[i] = new ExaminedListener(!fail);
+        }
+
+        final CyclicBarrier trigger = new CyclicBarrier(2);
+        final AtomicBoolean condition = new AtomicBoolean(true);
+
+        ExecutorService notificationsPool = Executors.newFixedThreadPool(4);
+        notificationsPool.submit(new Callable<Void>() {
+            public Void call() throws Exception {
+                trigger.await();
+                while (condition.get()) {
+                    notifier.fireTestStarted(null);
+                }
+                notifier.fireTestStarted(null);
+                return null;
+            }
+        });
+
+        trigger.await();
+
+        for (ExaminedListener examinedListener : examinedListeners) {
+            notifier.addListener(examinedListener);
+        }
+
+        notificationsPool.shutdown();
+        condition.set(false);
+        assertTrue(notificationsPool.awaitTermination(TIMEOUT, TimeUnit.SECONDS));
+
+        if (totalListenersFailures != 0) {
+            // If no listener failures, then all the listeners do not report any failure.
+            int countTestFailures = examinedListeners.length - countReportedTestFailures(examinedListeners);
+            assertThat(totalListenersFailures, is(countTestFailures));
+        }
+    }
+
+    @Test
+    public void reportConcurrentFailuresAfterAddFirstListener() throws Exception {
+        final RunNotifier notifier = new RunNotifier();
+
+        int totalListenersFailures = 0;
+
+        final ExaminedListener[] examinedListeners = new ExaminedListener[1000];
+        for (int i = 0; i < examinedListeners.length; ++i) {
+            boolean fail = StrictMath.random() >= 0.5d;
+            if (fail) {
+                ++totalListenersFailures;
+            }
+            examinedListeners[i] = new ExaminedListener(!fail);
+        }
+
+        final CyclicBarrier trigger = new CyclicBarrier(2);
+        final AtomicBoolean condition = new AtomicBoolean(true);
+
+        ExecutorService notificationsPool = Executors.newFixedThreadPool(4);
+        notificationsPool.submit(new Callable<Void>() {
+            public Void call() throws Exception {
+                trigger.await();
+                while (condition.get()) {
+                    notifier.fireTestStarted(null);
+                }
+                notifier.fireTestStarted(null);
+                return null;
+            }
+        });
+
+        trigger.await();
+
+        for (ExaminedListener examinedListener : examinedListeners) {
+            notifier.addFirstListener(examinedListener);
+        }
+
+        notificationsPool.shutdown();
+        condition.set(false);
+        assertTrue(notificationsPool.awaitTermination(TIMEOUT, TimeUnit.SECONDS));
+
+        if (totalListenersFailures != 0) {
+            // If no listener failures, then all the listeners do not report any failure.
+            int countTestFailures = examinedListeners.length - countReportedTestFailures(examinedListeners);
+            assertThat(totalListenersFailures, is(countTestFailures));
+        }
+    }
+
+    private static int countReportedTestFailures(ExaminedListener[] listeners) {
+        int count = 0;
+        for (ExaminedListener listener : listeners) {
+            if (listener.hasTestFailure) {
+                ++count;
+            }
+        }
+        return count;
+    }
+}

--- a/src/test/java/org/junit/runner/notification/RunNotifierTest.java
+++ b/src/test/java/org/junit/runner/notification/RunNotifierTest.java
@@ -1,9 +1,15 @@
 package org.junit.runner.notification;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.runner.notification.RunListener.ThreadSafe;
 
 import org.junit.Test;
+import org.junit.runner.Description;
 import org.junit.runner.Result;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class RunNotifierTest {
 
@@ -46,5 +52,168 @@ public class RunNotifierTest {
         public void testFailure(Failure failure) throws Exception {
             this.failure = failure;
         }
+    }
+
+    private static class NormalListener extends RunListener {
+        final AtomicInteger testStarted = new AtomicInteger(0);
+
+        public void testStarted(Description description) throws Exception {
+            testStarted.incrementAndGet();
+        }
+    }
+
+    @ThreadSafe
+    private static class ThreadSafeListener extends RunListener {
+        final AtomicInteger testStarted = new AtomicInteger(0);
+
+        public void testStarted(Description description) throws Exception {
+            testStarted.incrementAndGet();
+        }
+    }
+
+    @Test
+    public void keepContractOnEqualsNegative() {
+        RunNotifier notifier = new RunNotifier();
+        final NormalListener listener = new NormalListener();
+        NormalListener wrappedListener = new NormalListener() {
+            @Override
+            public boolean equals(Object o) {
+                return listener.equals(o);
+            }
+        };
+        notifier.addListener(wrappedListener);
+        assertThat(wrappedListener.testStarted.get(), is(0));
+        notifier.fireTestStarted(null);
+        assertThat(wrappedListener.testStarted.get(), is(1));
+        notifier.removeListener(listener);
+        notifier.fireTestStarted(null);
+        assertThat(wrappedListener.testStarted.get(), is(2));
+    }
+
+    @Test
+    public void keepContractOnEquals() {
+        RunNotifier notifier = new RunNotifier();
+        final NormalListener listener = new NormalListener();
+        NormalListener wrappedListener = new NormalListener() {
+            @Override
+            public boolean equals(Object o) {
+                return listener.equals(o);
+            }
+        };
+        notifier.addListener(listener);
+        assertThat(listener.testStarted.get(), is(0));
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+        notifier.removeListener(wrappedListener);
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+    }
+
+    @Test
+    public void addRemoveNormalListener() {
+        RunNotifier notifier = new RunNotifier();
+        NormalListener listener = new NormalListener();
+        assertThat(listener.testStarted.get(), is(0));
+        notifier.addListener(listener);
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+        notifier.removeListener(listener);
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+    }
+
+    @Test
+    public void addFirstRemoveNormalListener() {
+        RunNotifier notifier = new RunNotifier();
+        NormalListener listener = new NormalListener();
+        assertThat(listener.testStarted.get(), is(0));
+        notifier.addFirstListener(listener);
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+        notifier.removeListener(listener);
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+    }
+
+    @Test
+    public void addRemoveThreadSafeListener() {
+        RunNotifier notifier = new RunNotifier();
+        ThreadSafeListener listener = new ThreadSafeListener();
+        assertThat(listener.testStarted.get(), is(0));
+        notifier.addListener(listener);
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+        notifier.removeListener(listener);
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+    }
+
+    @Test
+    public void addFirstRemoveThreadSafeListener() {
+        RunNotifier notifier = new RunNotifier();
+        ThreadSafeListener listener = new ThreadSafeListener();
+        assertThat(listener.testStarted.get(), is(0));
+        notifier.addFirstListener(listener);
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+        notifier.removeListener(listener);
+        notifier.fireTestStarted(null);
+        assertThat(listener.testStarted.get(), is(1));
+    }
+
+    @Test
+    public void addRemoveBoth() {
+        RunNotifier notifier = new RunNotifier();
+
+        NormalListener normalListener = new NormalListener();
+        assertThat(normalListener.testStarted.get(), is(0));
+        notifier.addListener(normalListener);
+        notifier.fireTestStarted(null);
+        assertThat(normalListener.testStarted.get(), is(1));
+
+        ThreadSafeListener tSafeListener = new ThreadSafeListener();
+        assertThat(tSafeListener.testStarted.get(), is(0));
+        notifier.addListener(tSafeListener);
+        notifier.fireTestStarted(null);
+        assertThat(normalListener.testStarted.get(), is(2));
+        assertThat(tSafeListener.testStarted.get(), is(1));
+
+        notifier.removeListener(normalListener);
+        notifier.fireTestStarted(null);
+        assertThat(normalListener.testStarted.get(), is(2));
+        assertThat(tSafeListener.testStarted.get(), is(2));
+
+        notifier.removeListener(tSafeListener);
+        notifier.fireTestStarted(null);
+        assertThat(normalListener.testStarted.get(), is(2));
+        assertThat(tSafeListener.testStarted.get(), is(2));
+    }
+
+    @Test
+    public void addFirstRemoveBoth() {
+        RunNotifier notifier = new RunNotifier();
+
+        NormalListener normalListener = new NormalListener();
+        assertThat(normalListener.testStarted.get(), is(0));
+        notifier.addListener(normalListener);
+        notifier.fireTestStarted(null);
+        assertThat(normalListener.testStarted.get(), is(1));
+
+        ThreadSafeListener tSafeListener = new ThreadSafeListener();
+        assertThat(tSafeListener.testStarted.get(), is(0));
+        notifier.addFirstListener(tSafeListener);
+        notifier.fireTestStarted(null);
+        assertThat(normalListener.testStarted.get(), is(2));
+        assertThat(tSafeListener.testStarted.get(), is(1));
+
+        notifier.removeListener(normalListener);
+        notifier.fireTestStarted(null);
+        assertThat(normalListener.testStarted.get(), is(2));
+        assertThat(tSafeListener.testStarted.get(), is(2));
+
+        notifier.removeListener(tSafeListener);
+        notifier.fireTestStarted(null);
+        assertThat(normalListener.testStarted.get(), is(2));
+        assertThat(tSafeListener.testStarted.get(), is(2));
     }
 }

--- a/src/test/java/org/junit/runner/notification/SynchronizedRunListenerTest.java
+++ b/src/test/java/org/junit/runner/notification/SynchronizedRunListenerTest.java
@@ -1,0 +1,141 @@
+package org.junit.runner.notification;
+
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link SynchronizedRunListener}.
+ *
+ * @author kcooney (Kevin Cooney)
+ */
+public class SynchronizedRunListenerTest {
+
+    private static class MethodSignature {
+        private final Method method;
+        private final String name;
+        private final List<Class<?>> parameterTypes;
+
+        public MethodSignature(Method method) {
+            this.method = method;
+            name = method.getName();
+            parameterTypes = Arrays.asList(method.getParameterTypes());
+        }
+
+        @Override
+        public String toString() {
+            return method.toString();
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+
+            if (!(obj instanceof MethodSignature)) {
+                return false;
+            }
+
+            MethodSignature that = (MethodSignature) obj;
+            return name.equals(that.name) && parameterTypes.equals(that.parameterTypes);
+        }
+    }
+
+    private Set<MethodSignature> getAllDeclaredMethods(Class<?> type) {
+        Set<MethodSignature> methods = new HashSet<MethodSignature>();
+        for (Method method : type.getDeclaredMethods()) {
+            methods.add(new MethodSignature(method));
+        }
+        return methods;
+    }
+
+    @Test
+    public void overridesAllMethodsInRunListener() {
+        Set<MethodSignature> runListenerMethods = getAllDeclaredMethods(RunListener.class);
+        Set<MethodSignature> synchronizedRunListenerMethods = getAllDeclaredMethods(SynchronizedRunListener.class);
+        assertTrue(synchronizedRunListenerMethods.containsAll(runListenerMethods));
+    }
+
+    private static class NamedListener extends RunListener {
+        private final String name;
+
+        public NamedListener(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public int hashCode() {
+            return name.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+
+            if (!(obj instanceof NamedListener)) {
+                return false;
+            }
+
+            NamedListener that = (NamedListener) obj;
+            return name.equals(that.name);
+        }
+    }
+
+    @Test
+    public void namedListenerCorrectlyImplementsEqualsAndHashCode() {
+        NamedListener listener1 = new NamedListener("blue");
+        NamedListener listener2 = new NamedListener("blue");
+        NamedListener listener3 = new NamedListener("red");
+
+        assertTrue(listener1.equals(listener1));
+        assertTrue(listener2.equals(listener2));
+        assertTrue(listener3.equals(listener3));
+
+        assertFalse(listener1.equals(null));
+        assertFalse(listener1.equals(new Object()));
+
+        assertTrue(listener1.equals(listener2));
+        assertTrue(listener2.equals(listener1));
+        assertFalse(listener1.equals(listener3));
+        assertFalse(listener3.equals(listener1));
+
+        assertEquals(listener1.hashCode(), listener2.hashCode());
+        assertNotEquals(listener1.hashCode(), listener3.hashCode());
+    }
+
+    @Test
+    public void equalsDelegates() {
+        NamedListener listener1 = new NamedListener("blue");
+        NamedListener listener2 = new NamedListener("blue");
+        NamedListener listener3 = new NamedListener("red");
+
+        assertEquals(new SynchronizedRunListener(listener1), new SynchronizedRunListener(listener1));
+        assertEquals(new SynchronizedRunListener(listener1), new SynchronizedRunListener(listener2));
+        assertNotEquals(new SynchronizedRunListener(listener1), new SynchronizedRunListener(listener3));
+        assertEquals(new SynchronizedRunListener(listener1), listener1);
+        assertNotEquals(listener1, new SynchronizedRunListener(listener1));
+    }
+
+    @Test
+    public void hashCodeDelegates() {
+        NamedListener listener = new NamedListener("blue");
+        assertEquals(listener.hashCode(), new SynchronizedRunListener(listener).hashCode());
+    }
+}

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -5,6 +5,9 @@ import junit.framework.Test;
 import org.junit.internal.MethodSorterTest;
 import org.junit.internal.matchers.StacktracePrintingMatcherTest;
 import org.junit.runner.RunWith;
+import org.junit.runner.notification.ConcurrentRunNotifierTest;
+import org.junit.runner.notification.RunNotifierTest;
+import org.junit.runner.notification.SynchronizedRunListenerTest;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.junit.tests.assertion.AssertionTest;
@@ -174,7 +177,10 @@ import org.junit.tests.validation.ValidationTest;
         MethodSorterTest.class,
         TestedOnSupplierTest.class,
         StacktracePrintingMatcherTest.class,
-        StopwatchTest.class
+        StopwatchTest.class,
+        RunNotifierTest.class,
+        ConcurrentRunNotifierTest.class,
+        SynchronizedRunListenerTest.class
 })
 public class AllTests {
     public static Test suite() {


### PR DESCRIPTION
@dsaff
@kcooney
I hope you will not kill me now :)

All necessary changes regarding concurrent RunNotifier are here.
It's clear documentation for others as well.
It was hard for me not to be lost in #625 and #578, and for others could be even much harder.

I did NOT ignore the addons of both authors.

Tests:
- AllTests
- ConcurrentRunNotifierTest (from mine repo)
- SynchronizedRunListenerTest (from Kevin's repo)
- RunNotifierTest (added bottom tests from my repo)

Code:
- RunListener (only important Javadoc)
- RunNotifier (#wrapSynchronizedIfNotThreadSafe is internal patch and should not be public)
- SynchronizedRunListener (simple synchronization because of simplicity and modern VM optimize fast)
