### PR TITLE
Adding MethodRuleChain for chaining MethodRule classes.

### DIFF
--- a/src/main/java/org/junit/rules/MethodRuleChain.java
+++ b/src/main/java/org/junit/rules/MethodRuleChain.java
@@ -1,0 +1,98 @@
+package org.junit.rules;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+/**
+ * The MethodRuleChain rule allows ordering of MethodRules. You create a
+ * {@code MethodRuleChain} with {@link #outerRule(MethodRule)} and subsequent calls of
+ * {@link #around(MethodRule)}:
+ *
+ * <pre>
+ * public static class UseRuleChain {
+ * 	&#064;Rule
+ * 	public MethodRuleChain chain= MethodRuleChain
+ * 	                       .outerRule(new LoggingMethodRule("outer rule")
+ * 	                       .around(new LoggingMethodRule("middle rule")
+ * 	                       .around(new LoggingMethodRule("inner rule");
+ *
+ * 	&#064;Test
+ * 	public void example() {
+ * 		assertTrue(true);
+ *     }
+ * }
+ * </pre>
+ *
+ * writes the log
+ *
+ * <pre>
+ * starting outer rule
+ * starting middle rule
+ * starting inner rule
+ * finished inner rule
+ * finished middle rule
+ * finished outer rule
+ * </pre>
+ *
+ */
+public class MethodRuleChain implements MethodRule {
+
+	private static final MethodRuleChain EMPTY_CHAIN = new MethodRuleChain(
+            Collections.<MethodRule>emptyList());
+
+    private List<MethodRule> rulesStartingWithInnerMost;
+
+    /**
+     * Returns a {@code MethodRuleChain} without a {@link MethodRule}. This method may
+     * be the starting point of a {@code MethodRuleChain}.
+     *
+     * @return a {@code MethodRuleChain} without a {@link MethodRule}.
+     */
+    public static MethodRuleChain emptyMethodRuleChain() {
+        return EMPTY_CHAIN;
+    }
+	
+    /**
+     * Returns a {@code MethodRuleChain} with a single {@link MethodRule}. This method
+     * is the usual starting point of a {@code MethodRuleChain}.
+     *
+     * @param outerRule the outer rule of the {@code MethodRuleChain}.
+     * @return a {@code MethodRuleChain} with a single {@link MethodRule}.
+     */
+    public static MethodRuleChain outerRule(MethodRule outerRule) {
+        return emptyMethodRuleChain().around(outerRule);
+    }
+
+    private MethodRuleChain(List<MethodRule> rules) {
+        this.rulesStartingWithInnerMost = rules;
+    }
+    
+    /**
+     * Create a new {@code RuleChain}, which encloses the {@code nextRule} with
+     * the rules of the current {@code RuleChain}.
+     *
+     * @param enclosedRule the rule to enclose.
+     * @return a new {@code RuleChain}.
+     */
+    public MethodRuleChain around(MethodRule enclosedRule) {
+        List<MethodRule> rulesOfNewChain = new ArrayList<MethodRule>();
+        rulesOfNewChain.add(enclosedRule);
+        rulesOfNewChain.addAll(rulesStartingWithInnerMost);
+        return new MethodRuleChain(rulesOfNewChain);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+	public Statement apply(Statement base, FrameworkMethod method, Object target) {
+		for (MethodRule each : rulesStartingWithInnerMost) {
+            base = each.apply(base, method, target);
+        }
+        return base;
+	}
+
+}

--- a/src/test/java/org/junit/tests/experimental/rules/MethodRuleChainTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/MethodRuleChainTest.java
@@ -1,0 +1,69 @@
+package org.junit.tests.experimental.rules;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.experimental.results.PrintableResult.testResult;
+import static org.junit.rules.MethodRuleChain.outerRule;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+import org.junit.rules.MethodRuleChain;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+public class MethodRuleChainTest {
+
+	 private static final List<String> LOG = new ArrayList<String>();
+
+	    private static class LoggingMethodRule implements MethodRule {
+	        private final String label;
+
+	        public LoggingMethodRule(String label) {
+	            this.label = label;
+	        }
+
+			public Statement apply(final Statement base, final FrameworkMethod method,
+					final Object target) {
+				return new Statement() {
+					
+					@Override
+					public void evaluate() throws Throwable {
+						LOG.add("starting "+ label);
+						base.evaluate();
+						LOG.add("finished "+ label);
+					}
+				};
+			}
+
+	       
+	    }
+
+	    public static class UseRuleChain {
+	        @Rule
+	        public final MethodRuleChain chain = outerRule(new LoggingMethodRule("outer rule"))
+	                .around(new LoggingMethodRule("middle rule")).around(
+	                        new LoggingMethodRule("inner rule"));
+
+	        @Test
+	        public void example() {
+	            assertTrue(true);
+	        }
+	    }
+
+	    @Test
+	    public void executeRulesInCorrectOrder() throws Exception {
+	        testResult(UseRuleChain.class);
+	        List<String> expectedLog = asList("starting outer rule",
+	                "starting middle rule", "starting inner rule",
+	                "finished inner rule", "finished middle rule",
+	                "finished outer rule");
+	        assertEquals(expectedLog, LOG);
+	    }
+	
+	
+}


### PR DESCRIPTION
Adding MethodRuleChain for chaining MethodRule classes. MethodRule was deprecated in version _junit 4.10_, but was undeprecated for version 4.11, so it seams reasonable that if you can order _TestRule_ executions by using _RuleChain_, we can do the same for _MethodRules_. For this purpose MethodRuleChain has been implemented which works equal as _RuleChain_, but receiving a MethodRule instance.
