### PR TITLE
Too short timeout in TimeoutRuleTest.

### DIFF
--- a/src/test/java/org/junit/tests/experimental/rules/TimeoutRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TimeoutRuleTest.java
@@ -89,13 +89,13 @@ public class TimeoutRuleTest {
     public static class HasGlobalLongTimeout extends AbstractTimeoutTest {
 
         @Rule
-        public final TestRule globalTimeout = Timeout.millis(50L);
+        public final TestRule globalTimeout = Timeout.millis(200);
     }
 
     public static class HasGlobalTimeUnitTimeout extends AbstractTimeoutTest {
 
         @Rule
-        public final TestRule globalTimeout = new Timeout(50, TimeUnit.MILLISECONDS);
+        public final TestRule globalTimeout = new Timeout(200, TimeUnit.MILLISECONDS);
     }
 
     @Before


### PR DESCRIPTION
TimeoutRuleTest fails with 50 millis timeout.
Timeout has already elapsed before calling #run6() when test is running in an overloaded build system.

Fix: 200 millis
