### PR TITLE
JavaDoc for TestedOn and ParametersSuppliedBy

### DIFF
--- a/src/main/java/org/junit/experimental/theories/ParametersSuppliedBy.java
+++ b/src/main/java/org/junit/experimental/theories/ParametersSuppliedBy.java
@@ -7,9 +7,40 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
+/**
+ * Annotating a {@link org.junit.experimental.theories.Theory Theory} method
+ * parameter with &#064;ParametersSuppliedBy causes it to be supplied with
+ * values from the named
+ * {@link org.junit.experimental.theories.ParameterSupplier ParameterSupplier}
+ * when run as a theory by the {@link org.junit.experimental.theories.Theories
+ * Theories} runner.
+ * 
+ * In addition, annotations themselves can be annotated with
+ * &#064;ParametersSuppliedBy, and then used similarly. ParameterSuppliedBy
+ * annotations on parameters are detected by searching up this heirarchy such
+ * that these act as syntactic sugar, making:
+ * 
+ * <pre>
+ * &#064;ParametersSuppliedBy(Supplier.class)
+ * public &#064;interface SpecialParameter { }
+ * 
+ * &#064;Theory
+ * public void theoryMethod(&#064SpecialParameter String param) {
+ *   ...
+ * }
+ * </pre>
+ * 
+ * equivalent to:
+ * 
+ * <pre>
+ * &#064;Theory
+ * public void theoryMethod(&#064;ParametersSuppliedBy(Supplier.class) String param) {
+ *   ...
+ * }
+ * </pre>
+ */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ANNOTATION_TYPE, PARAMETER})
+@Target({ ANNOTATION_TYPE, PARAMETER })
 public @interface ParametersSuppliedBy {
 
     Class<? extends ParameterSupplier> value();

--- a/src/main/java/org/junit/experimental/theories/suppliers/TestedOn.java
+++ b/src/main/java/org/junit/experimental/theories/suppliers/TestedOn.java
@@ -8,6 +8,21 @@ import java.lang.annotation.Target;
 
 import org.junit.experimental.theories.ParametersSuppliedBy;
 
+/**
+ * Annotating a {@link org.junit.experimental.theories.Theory Theory} method int
+ * parameter with &#064;TestedOn causes it to be supplied with values from the
+ * ints array given when run as a theory by the
+ * {@link org.junit.experimental.theories.Theories Theories} runner. For
+ * example, the below method would be called three times by the Theories runner,
+ * once with each of the int parameters specified.
+ * 
+ * <pre>
+ * &#064;Theory
+ * public void shouldPassForSomeInts(&#064;TestedOn(ints={1, 2, 3}) int param) {
+ *     ...
+ * }
+ * </pre>
+ */
 @ParametersSuppliedBy(TestedOnSupplier.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(PARAMETER)


### PR DESCRIPTION
Some simple javadoc for TestedOn and ParametersSuppliedBy, with mini examples, since I noticed they're still undocumented. There's a few other bits without much on them either that I'll get on soon too, this is just a start.

On a slightly-related note: is there a good reason why TestedOn only works for int parameters? Is there any appetite for opening this up just allowing any Objects to be specified? (especially since we now do autoboxing right, so Integer params would still work properly, and it'd be all nicely backward compatible)
