### PR TITLE
fix typo in javadoc for MethodRule

### DIFF
--- a/src/main/java/org/junit/rules/MethodRule.java
+++ b/src/main/java/org/junit/rules/MethodRule.java
@@ -36,7 +36,7 @@ public interface MethodRule {
      *
      * @param base The {@link Statement} to be modified
      * @param method The method to be run
-     * @param target The object on with the method will be run.
+     * @param target The object on which the method will be run.
      * @return a new statement, which may be the same as {@code base},
      *         a wrapper around {@code base}, or a completely new Statement.
      */


### PR DESCRIPTION
I think there is a typo in the JavaDoc for the MethodRule: Instead of
@param target The object on _with_ the method will be run.
the JavaDoc should say
@param target The object on _which_ the method will be run.
