### PR TITLE
Timeout non-deterministic

### DIFF
--- a/src/main/java/org/junit/Test.java
+++ b/src/main/java/org/junit/Test.java
@@ -40,6 +40,16 @@ import java.lang.annotation.Target;
  *       while(true);
  *    }
  * </pre>
+ * <b>Warning</b>: while <code>timeout</code> is useful to catch and terminate
+ * infinite loops, it should <em>not</em> be considered deterministic. The
+ * following test may or may not fail depending on how the operating system
+ * schedules threads:
+ * <pre>
+ *    &#064;Test(<b>timeout=100</b>) public void sleep100() {
+ *       Thread.sleep(100);
+ *    }
+ * </pre>
+ *
  *
  * @since 4.0
  */


### PR DESCRIPTION
The timeout argument for the @Test annotation is non-deterministic. 

It times out after waiting a certain amount of clock time, rather than CPU time - this means the success / failure of the test will depend on the current state of the machine ( what other processes are running, etc ). 

This has a relatively simple fix: use ThreadMXBean to figure out the CPU time taken. Only org.junit.internal.runners.statements.FailOnTimeout.java would need to be modified.
