### PR TITLE
Unnecessary array in varargs in AnnotatedBuildrer

### DIFF
--- a/src/main/java/org/junit/internal/builders/AnnotatedBuilder.java
+++ b/src/main/java/org/junit/internal/builders/AnnotatedBuilder.java
@@ -26,13 +26,11 @@ public class AnnotatedBuilder extends RunnerBuilder {
     public Runner buildRunner(Class<? extends Runner> runnerClass,
             Class<?> testClass) throws Exception {
         try {
-            return runnerClass.getConstructor(Class.class).newInstance(
-                    new Object[]{testClass});
+            return runnerClass.getConstructor(Class.class).newInstance(testClass);
         } catch (NoSuchMethodException e) {
             try {
                 return runnerClass.getConstructor(Class.class,
-                        RunnerBuilder.class).newInstance(
-                        new Object[]{testClass, fSuiteBuilder});
+                        RunnerBuilder.class).newInstance(testClass, fSuiteBuilder);
             } catch (NoSuchMethodException e2) {
                 String simpleName = runnerClass.getSimpleName();
                 throw new InitializationError(String.format(


### PR DESCRIPTION
A simple improvement. The IDE highlights two lines in `AnnotatedBuildrer` that an array in varargs is not necessary.
Reason is that `Constructor#newInstance(Object ... initargs)` really does not need any array in source code.
