### PR TITLE
Change "Junit" to "JUnit" in website header

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
     <header>
       <div class="container">
-        <h1>Junit</h1>
+        <h1>JUnit</h1>
         <h2>A programmer-oriented testing framework for Java.</h2>
 
         <section id="downloads">


### PR DESCRIPTION
It's written JUnit everywhere else, looks like "Junit" was a typo.
