### PR TITLE
Support for non-public @Parameter

### DIFF
--- a/src/main/java/org/junit/runners/Parameterized.java
+++ b/src/main/java/org/junit/runners/Parameterized.java
@@ -216,6 +216,7 @@ public class Parameterized extends Suite {
             Object testClassInstance = getTestClass().getJavaClass().newInstance();
             for (FrameworkField each : annotatedFieldsByParameter) {
                 Field field = each.getField();
+                field.setAccessible(true);
                 Parameter annotation = field.getAnnotation(Parameter.class);
                 int index = annotation.value();
                 try {

--- a/src/test/java/org/junit/tests/running/classes/ParameterizedTestTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParameterizedTestTest.java
@@ -119,7 +119,7 @@ public class ParameterizedTestTest {
         public int fInput;
 
         @Parameter(1)
-        public int fExpected;
+        protected int fExpected;
 
         @Test
         public void test() {


### PR DESCRIPTION
Hello JUnit! 

This patch makes it possible to have @Parameter fields in @RunWith(Parameterized.class) tests non-public.

I'm not sure if my change to ParameterizedTestTest is really an appropriate and sufficient test for this minor extension. (But the patch does work and achieve what it should, of course.)

BTW: As I've also found that @Parameter was not yet documented on https://github.com/junit-team/junit/wiki/Parameterized-tests, I've taken the liberty of going ahead and directly adding a section about it (incl. ref. to this) - hope that's OK.

Regards,
Michael
