### PR TITLE
Extended Description with additional factory methods

### DIFF
--- a/src/main/java/org/junit/runner/Description.java
+++ b/src/main/java/org/junit/runner/Description.java
@@ -61,11 +61,11 @@ public class Description implements Serializable {
      * Generally, you will add children to this <code>Description</code>.
      *
      * @param testClass A {@link Class} containing tests
-     * @param className an alternative class name for the <code>Description</code>
+     * @param displayName a display name for the <code>Description</code>
      * @return a <code>Description</code> of <code>testClass</code> named <code>name</code>
      */
-    public static Description createSuiteDescription(Class<?> testClass, String className) {
-        return new Description(testClass, className, testClass.getCanonicalName(), testClass.getAnnotations());
+    public static Description createSuiteDescription(Class<?> testClass, String displayName) {
+        return new Description(testClass, displayName, testClass.getCanonicalName(), testClass.getAnnotations());
     }
 
     /**


### PR DESCRIPTION
... to allow clients to specify alternative names for the Suites and Tests, without loosing the tied linking between the test result and the class / methods that specifies the test.

I added two (IMHO missing) factory methods, regrouped Suite and Test factories together and corrected the JavaDoc for all factory methods.

Note: I'd like to use these new factory methods having inner classes still link to their code while their names can differ from EnclosingClass$InnerClassName$AnotherInnerClass, e.g. AnotherInnerClass in this case. When the inner classes are well placed as children of their enclosing class, it makes sence to skip the enclosing class names in the description.
