### PR TITLE
Allow expectation as parameter of custom message.

### DIFF
--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -1,5 +1,6 @@
 package org.junit.rules;
 
+import static java.lang.String.format;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
@@ -93,8 +94,11 @@ import org.junit.runners.model.Statement;
  * <h3>Missing Exceptions</h3>
  * <p>
  * By default missing exceptions are reported with an error message
- * like "Expected test to throw foo.". You can configure a different
- * message by means of {@link #reportMissingExceptionWithMessage(String)}.
+ * like "Expected test to throw an instance of foo". You can configure a different
+ * message by means of {@link #reportMissingExceptionWithMessage(String)}. You
+ * can use a {@code %s} placeholder for the description of the expected
+ * exception. E.g. "Test doesn't throw %s." will fail with the error message
+ * "Test doesn't throw an instance of foo.".
  *
  * @since 4.7
  */
@@ -109,7 +113,7 @@ public class ExpectedException implements TestRule {
 
     private final ExpectedExceptionMatcherBuilder fMatcherBuilder = new ExpectedExceptionMatcherBuilder();
 
-    private String missingExceptionMessage;
+    private String missingExceptionMessage= "Expected test to throw %s";
 
     private ExpectedException() {
     }
@@ -136,7 +140,11 @@ public class ExpectedException implements TestRule {
 
     /**
      * Specifies the failure message for tests that are expected to throw 
-     * an exception but do not throw any.
+     * an exception but do not throw any. You can use a {@code %s} placeholder for
+     * the description of the expected exception. E.g. "Test doesn't throw %s."
+     * will fail with the error message
+     * "Test doesn't throw an instance of foo.".
+     *
      * @param message exception detail message
      * @return the rule itself
      */
@@ -255,15 +263,7 @@ public class ExpectedException implements TestRule {
     }
     
     private String missingExceptionMessage() {
-        if (isMissingExceptionMessageEmpty()) {
-            String expectation = StringDescription.toString(fMatcherBuilder.build());
-            return "Expected test to throw " + expectation;
-        } else {
-            return missingExceptionMessage;
-        }        
-    }
-    
-    private boolean isMissingExceptionMessageEmpty() {
-        return missingExceptionMessage == null || missingExceptionMessage.length() == 0;
+        String expectation= StringDescription.toString(fMatcherBuilder.build());
+        return format(missingExceptionMessage, expectation);
     }
 }

--- a/src/test/java/org/junit/tests/experimental/rules/EventCollector.java
+++ b/src/test/java/org/junit/tests/experimental/rules/EventCollector.java
@@ -31,6 +31,13 @@ class EventCollector extends RunListener {
                 description.appendValue(numberOfFailures);
                 description.appendText(" failures");
             }
+
+            @Override
+            protected void describeMismatchSafely(EventCollector item,
+                    org.hamcrest.Description description) {
+                description.appendValue(item.fFailures.size());
+                description.appendText(" failures");
+            }
         };
     }
 
@@ -83,6 +90,24 @@ class EventCollector extends RunListener {
             public void describeTo(org.hamcrest.Description description) {
                 description.appendText("has single failure with message ");
                 messageMatcher.describeTo(description);
+            }
+
+            @Override
+            protected void describeMismatchSafely(EventCollector item,
+                    org.hamcrest.Description description) {
+                description.appendText("was ");
+                hasSingleFailure().describeMismatch(item, description);
+                description.appendText(": ");
+                boolean first= true;
+                for (Failure f : item.fFailures) {
+                    if (!first) {
+                        description.appendText(" ,");
+                    }
+                    description.appendText("'");
+                    description.appendText(f.getMessage());
+                    description.appendText("'");
+                    first= false;
+                }
             }
         };
     }

--- a/src/test/java/org/junit/tests/experimental/rules/ExpectedExceptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/ExpectedExceptionTest.java
@@ -32,7 +32,7 @@ import org.junit.runners.Parameterized.Parameters;
 public class ExpectedExceptionTest {
     private static final String ARBITRARY_MESSAGE = "arbitrary message";
 
-    @Parameters
+    @Parameters(name= "{0}")
     public static Collection<Object[]> testsWithEventMatcher() {
         return asList(new Object[][]{
                 {EmptyTestExpectingNoException.class, everyTestRunSuccessful()},
@@ -78,7 +78,16 @@ public class ExpectedExceptionTest {
                                 containsString("cause was <java.lang.NullPointerException: an unexpected cause>"),
                                 containsString("Stacktrace was: java.lang.IllegalArgumentException: Ack!"),
                                 containsString("Caused by: java.lang.NullPointerException: an unexpected cause")))},
-                { CustomMessageWithoutExpectedException.class, hasSingleFailureWithMessage(ARBITRARY_MESSAGE) }
+                {
+                        UseNoCustomMessage.class,
+                        hasSingleFailureWithMessage("Expected test to throw an instance of java.lang.IllegalArgumentException") },
+                {
+                        UseCustomMessageWithoutPlaceHolder.class,
+                        hasSingleFailureWithMessage(ARBITRARY_MESSAGE) },
+                {
+                        UseCustomMessageWithPlaceHolder.class,
+                        hasSingleFailureWithMessage(ARBITRARY_MESSAGE
+                                + " - an instance of java.lang.IllegalArgumentException") }
         });
     }
 
@@ -321,10 +330,34 @@ public class ExpectedExceptionTest {
         }
     }
     
-    public static class CustomMessageWithoutExpectedException {
+    public static class UseNoCustomMessage {
+
+        @Rule
+        public ExpectedException thrown= ExpectedException.none();
+
+        @Test
+        public void noThrow() {
+            thrown.expect(IllegalArgumentException.class);
+        }
+    }
+
+    public static class UseCustomMessageWithPlaceHolder {
 
         @Rule
         public ExpectedException thrown = ExpectedException.none();
+
+        @Test
+        public void noThrow() {
+            thrown.expect(IllegalArgumentException.class);
+            thrown.reportMissingExceptionWithMessage(ARBITRARY_MESSAGE
+                    + " - %s");
+        }
+    }
+
+    public static class UseCustomMessageWithoutPlaceHolder {
+
+        @Rule
+        public ExpectedException thrown= ExpectedException.none();
 
         @Test
         public void noThrow() {


### PR DESCRIPTION
Simplifies the code, because custom and default message use the same code.
