### PR TITLE
Extract annotations validation to a single class.

### DIFF
--- a/src/main/java/org/junit/runners/model/Annotatable.java
+++ b/src/main/java/org/junit/runners/model/Annotatable.java
@@ -1,0 +1,15 @@
+package org.junit.runners.model;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A model element that may have annotations.
+ * 
+ * @since 4.12
+ */
+public interface Annotatable {
+    /**
+     * Returns the model elements' annotations.
+     */
+    Annotation[] getAnnotations();
+}

--- a/src/main/java/org/junit/runners/model/FrameworkField.java
+++ b/src/main/java/org/junit/runners/model/FrameworkField.java
@@ -27,7 +27,6 @@ public class FrameworkField extends FrameworkMember<FrameworkField> {
         return getField().getName();
     }
 
-    @Override
     public Annotation[] getAnnotations() {
         return fField.getAnnotations();
     }

--- a/src/main/java/org/junit/runners/model/FrameworkMember.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMember.java
@@ -1,6 +1,5 @@
 package org.junit.runners.model;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
@@ -9,12 +8,8 @@ import java.util.List;
  *
  * @since 4.7
  */
-public abstract class FrameworkMember<T extends FrameworkMember<T>> {
-    /**
-     * Returns the annotations on this member
-     */
-    abstract Annotation[] getAnnotations();
-
+public abstract class FrameworkMember<T extends FrameworkMember<T>> implements
+        Annotatable {
     abstract boolean isShadowedBy(T otherMember);
 
     boolean isShadowedBy(List<T> members) {

--- a/src/main/java/org/junit/runners/model/FrameworkMethod.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMethod.java
@@ -186,7 +186,6 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
     /**
      * Returns the annotations on this method
      */
-    @Override
     public Annotation[] getAnnotations() {
         return fMethod.getAnnotations();
     }

--- a/src/main/java/org/junit/validator/AnnotationValidatorFactory.java
+++ b/src/main/java/org/junit/validator/AnnotationValidatorFactory.java
@@ -8,8 +8,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 4.12
  */
 public class AnnotationValidatorFactory {
-
-    private static ConcurrentHashMap<ValidateWith, AnnotationValidator> fAnnotationTypeToValidatorMap =
+    private static final ConcurrentHashMap<ValidateWith, AnnotationValidator> VALIDATORS_FOR_ANNOTATION_TYPES =
             new ConcurrentHashMap<ValidateWith, AnnotationValidator>();
 
     /**
@@ -23,7 +22,7 @@ public class AnnotationValidatorFactory {
      * @since 4.12
      */
     public AnnotationValidator createAnnotationValidator(ValidateWith validateWithAnnotation) {
-        AnnotationValidator validator = fAnnotationTypeToValidatorMap.get(validateWithAnnotation);
+        AnnotationValidator validator = VALIDATORS_FOR_ANNOTATION_TYPES.get(validateWithAnnotation);
         if (validator != null) {
             return validator;
         }
@@ -34,8 +33,8 @@ public class AnnotationValidatorFactory {
         }
         try {
             AnnotationValidator annotationValidator = clazz.newInstance();
-            fAnnotationTypeToValidatorMap.putIfAbsent(validateWithAnnotation, annotationValidator);
-            return fAnnotationTypeToValidatorMap.get(validateWithAnnotation);
+            VALIDATORS_FOR_ANNOTATION_TYPES.putIfAbsent(validateWithAnnotation, annotationValidator);
+            return VALIDATORS_FOR_ANNOTATION_TYPES.get(validateWithAnnotation);
         } catch (Exception e) {
             throw new RuntimeException("Exception received when creating AnnotationValidator class " + clazz.getName(), e);
         }

--- a/src/main/java/org/junit/validator/AnnotationsValidator.java
+++ b/src/main/java/org/junit/validator/AnnotationsValidator.java
@@ -1,0 +1,120 @@
+package org.junit.validator;
+
+import static java.util.Collections.singletonList;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.runners.model.Annotatable;
+import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
+
+/**
+ * An {@code AnnotationsValidator} validates all annotations of a test class,
+ * including its annotated fields and methods.
+ * 
+ * @since 4.12
+ */
+public final class AnnotationsValidator {
+    private static final List<AnnotatableValidator<?>> VALIDATORS = Arrays.<AnnotatableValidator<?>>asList(
+            new ClassValidator(), new MethodValidator(), new FieldValidator());
+
+    /**
+     * Validate all annotations of the specified test class that are be
+     * annotated with {@link ValidateWith}.
+     * 
+     * @param testClass
+     *            the {@link TestClass} that is validated.
+     * @return the errors found by the validator.
+     */
+    public List<Exception> validateTestClass(TestClass testClass) {
+        List<Exception> validationErrors= new ArrayList<Exception>();
+        for (AnnotatableValidator<?> validator : VALIDATORS) {
+            List<Exception> additionalErrors= validator
+                    .validateTestClass(testClass);
+            validationErrors.addAll(additionalErrors);
+        }
+        return validationErrors;
+    }
+
+    private static abstract class AnnotatableValidator<T extends Annotatable> {
+        private static final AnnotationValidatorFactory ANNOTATION_VALIDATOR_FACTORY = new AnnotationValidatorFactory();
+
+        abstract Iterable<T> getAnnotatablesForTestClass(TestClass testClass);
+
+        abstract List<Exception> validateAnnotatable(
+                AnnotationValidator validator, T annotatable);
+
+        public List<Exception> validateTestClass(TestClass testClass) {
+            List<Exception> validationErrors= new ArrayList<Exception>();
+            for (T annotatable : getAnnotatablesForTestClass(testClass)) {
+                List<Exception> additionalErrors= validateAnnotatable(annotatable);
+                validationErrors.addAll(additionalErrors);
+            }
+            return validationErrors;
+        }
+
+        private List<Exception> validateAnnotatable(T annotatable) {
+            List<Exception> validationErrors= new ArrayList<Exception>();
+            for (Annotation annotation : annotatable.getAnnotations()) {
+                Class<? extends Annotation> annotationType = annotation
+                        .annotationType();
+                ValidateWith validateWith = annotationType
+                        .getAnnotation(ValidateWith.class);
+                if (validateWith != null) {
+                    AnnotationValidator annotationValidator = ANNOTATION_VALIDATOR_FACTORY
+                            .createAnnotationValidator(validateWith);
+                    List<Exception> errors= validateAnnotatable(
+                            annotationValidator, annotatable);
+                    validationErrors.addAll(errors);
+                }
+            }
+            return validationErrors;
+        }
+    }
+
+    private static class ClassValidator extends AnnotatableValidator<TestClass> {
+        @Override
+        Iterable<TestClass> getAnnotatablesForTestClass(TestClass testClass) {
+            return singletonList(testClass);
+        }
+
+        @Override
+        List<Exception> validateAnnotatable(
+                AnnotationValidator validator, TestClass testClass) {
+            return validator.validateAnnotatedClass(testClass);
+        }
+    }
+
+    private static class MethodValidator extends
+            AnnotatableValidator<FrameworkMethod> {
+        @Override
+        Iterable<FrameworkMethod> getAnnotatablesForTestClass(
+                TestClass testClass) {
+            return testClass.getAnnotatedMethods();
+        }
+
+        @Override
+        List<Exception> validateAnnotatable(
+                AnnotationValidator validator, FrameworkMethod method) {
+            return validator.validateAnnotatedMethod(method);
+        }
+    }
+
+    private static class FieldValidator extends
+            AnnotatableValidator<FrameworkField> {
+        @Override
+        Iterable<FrameworkField> getAnnotatablesForTestClass(TestClass testClass) {
+            return testClass.getAnnotatedFields();
+        }
+
+        @Override
+        List<Exception> validateAnnotatable(
+                AnnotationValidator validator, FrameworkField field) {
+            return validator.validateAnnotatedField(field);
+        }
+    };
+}

--- a/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
@@ -1,19 +1,20 @@
 package org.junit.tests.running.classes;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
-import org.junit.runners.model.FrameworkField;
-import org.junit.runners.model.FrameworkMethod;
-import org.junit.runners.model.TestClass;
-import org.junit.validator.AnnotationValidator;
-import org.junit.validator.ValidateWith;
 import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.Result;
 import org.junit.runner.manipulation.Filter;
-import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.ParentRunner;
@@ -21,17 +22,6 @@ import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerScheduler;
 import org.junit.tests.experimental.rules.RuleFieldValidatorTest.TestWithNonStaticClassRule;
 import org.junit.tests.experimental.rules.RuleFieldValidatorTest.TestWithProtectedClassRule;
-
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.util.ArrayList;
-import java.util.List;
-
-import static java.util.Arrays.asList;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class ParentRunnerTest {
     public static String log = "";
@@ -141,79 +131,9 @@ public class ParentRunnerTest {
         JUnitCore junitCore = new JUnitCore();
         Request request = Request.aClass(klass);
         Result result = junitCore.run(request);
-        List<String> messages = new ArrayList<String>();
-        for (Failure failure : result.getFailures()) {
-            messages.add(failure.getMessage());
-        }
-        assertThat(messages, hasItem(message));
+        assertThat(result.getFailureCount(), is(2)); //the second failure is no runnable methods
+        assertThat(result.getFailures().get(0).getMessage(),
+                is(equalTo(message)));
 
-    }
-
-    public static class ExampleAnnotationValidator extends AnnotationValidator {
-        private static final String ANNOTATED_METHOD_CALLED = "annotated method called";
-        private static final String ANNOTATED_FIELD_CALLED = "annotated field called";
-        private static final String ANNOTATED_CLASS_CALLED = "annotated class called";
-
-        @Override
-        public List<Exception> validateAnnotatedClass(TestClass testClass) {
-            return asList(new Exception(ANNOTATED_CLASS_CALLED));
-        }
-
-        @Override
-        public List<Exception> validateAnnotatedField(FrameworkField field) {
-            return asList(new Exception(ANNOTATED_FIELD_CALLED));
-        }
-
-        @Override
-        public List<Exception> validateAnnotatedMethod(FrameworkMethod method) {
-            return asList(new Exception(ANNOTATED_METHOD_CALLED));
-        }
-    }
-
-    @Retention(RetentionPolicy.RUNTIME)
-    @Inherited
-    @ValidateWith(ExampleAnnotationValidator.class)
-    public @interface ExampleAnnotationWithValidator {
-    }
-
-    public static class AnnotationValidatorMethodTest {
-        @ExampleAnnotationWithValidator
-        @Test
-        public void test() {
-        }
-    }
-
-    public static class AnnotationValidatorFieldTest {
-        @ExampleAnnotationWithValidator
-        private String field;
-
-        @Test
-        public void test() {
-        }
-    }
-
-    @ExampleAnnotationWithValidator
-    public static class AnnotationValidatorClassTest {
-        @Test
-        public void test() {
-        }
-    }
-
-    @Test
-    public void validatorIsCalledForAClass() {
-        assertClassHasFailureMessage(AnnotationValidatorClassTest.class,
-                ExampleAnnotationValidator.ANNOTATED_CLASS_CALLED);
-    }
-
-    @Test
-    public void validatorIsCalledForAMethod() throws InitializationError {
-        assertClassHasFailureMessage(AnnotationValidatorMethodTest.class,
-                ExampleAnnotationValidator.ANNOTATED_METHOD_CALLED);
-    }
-
-    @Test
-    public void validatorIsCalledForAField() {
-        assertClassHasFailureMessage(AnnotationValidatorFieldTest.class,
-                ExampleAnnotationValidator.ANNOTATED_FIELD_CALLED);
     }
 }

--- a/src/test/java/org/junit/tests/running/classes/TestClassTest.java
+++ b/src/test/java/org/junit/tests/running/classes/TestClassTest.java
@@ -1,21 +1,14 @@
 package org.junit.tests.running.classes;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.theories.DataPoint;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestRule;
 import org.junit.runners.model.FrameworkField;
@@ -92,116 +85,69 @@ public class TestClassTest {
     }
         
     public static class FieldAnnotated {
-    	@Rule
-    	public String fieldThatShouldBeMatched = "andromeda";
+        @Rule
+        public String fieldC= "andromeda";
+
+        @Rule
+        public boolean fieldA;
     	
-    	@Rule
-    	public boolean fieldThatShouldNotBeMachted;
+        @Rule
+        public boolean fieldB;
     }
     
     @Test
+    public void providesAnnotatedFieldsSortedByName() {
+        TestClass tc= new TestClass(FieldAnnotated.class);
+        List<FrameworkField> annotatedFields= tc.getAnnotatedFields();
+        assertThat("Wrong number of annotated fields.", annotatedFields.size(), is(3));
+        assertThat("First annotated field is wrong.", annotatedFields
+            .iterator().next().getName(), is("fieldA"));
+    }
+
+    @Test
     public void annotatedFieldValues() {
-    	TestClass tc = new TestClass(FieldAnnotated.class);
-    	List<String> values = tc.getAnnotatedFieldValues(new FieldAnnotated(), Rule.class, String.class);
-    	assertThat(values, hasItem("andromeda"));
-    	assertThat(values.size(), is(1));
+        TestClass tc = new TestClass(FieldAnnotated.class);
+        List<String> values = tc.getAnnotatedFieldValues(new FieldAnnotated(), Rule.class, String.class);
+        assertThat(values, hasItem("andromeda"));
+        assertThat(values.size(), is(1));
     }
     
     public static class MethodsAnnotated {
-    	@Ignore
-    	@Test
-    	public String methodToBeMatched() { 
-    		return "jupiter";
-    	}
+        @Ignore
+        @Test
+        public int methodC() {
+            return 0;
+        }
+
+        @Ignore
+        @Test
+        public String methodA() {
+            return "jupiter";
+        }
     	
-    	@Ignore
-    	@Test
-    	public int methodOfWrongType() {
-    		return 0;
+        @Ignore
+        @Test
+        public int methodB() {
+            return 0;
     	}
     }
     
+    @Test
+    public void providesAnnotatedMethodsSortedByName() {
+    	TestClass tc = new TestClass(MethodsAnnotated.class);
+    	List<FrameworkMethod> annotatedMethods = tc.getAnnotatedMethods();
+    	assertThat("Wrong number of annotated methods.",
+    	    annotatedMethods.size(), is(3));
+    	assertThat("First annotated method is wrong.", annotatedMethods
+    	    .iterator().next().getName(), is("methodA"));
+    }
+
     @Test
     public void annotatedMethodValues() {
     	TestClass tc = new TestClass(MethodsAnnotated.class);
-    	List<String> values = tc.getAnnotatedMethodValues(new MethodsAnnotated(), Ignore.class, String.class);
+    	List<String> values = tc.getAnnotatedMethodValues(
+    	    new MethodsAnnotated(), Ignore.class, String.class);
     	assertThat(values, hasItem("jupiter"));
     	assertThat(values.size(), is(1));
-    }
-
-    @Test
-    public void annotationToMethods() {
-        TestClass tc = new TestClass(MethodsAnnotated.class);
-        Map<Class<? extends Annotation>, List<FrameworkMethod>> annotationToMethods = tc.getAnnotationToMethods();
-        List<FrameworkMethod> methods = annotationToMethods.get(Ignore.class);
-        assertThat(methods.size(), is(2));
-    }
-
-    @Test
-    public void annotationToMethodsReturnsUnmodifiableMap() {
-        TestClass tc = new TestClass(MethodsAnnotated.class);
-        Map<Class<? extends Annotation>, List<FrameworkMethod>> annotationToMethods = tc.getAnnotationToMethods();
-        exception.expect(UnsupportedOperationException.class);
-        annotationToMethods.put(Ignore.class, null);
-    }
-
-    @Test
-    public void annotationToMethodsReturnsValuesInTheMapThatAreUnmodifiable() {
-        TestClass tc = new TestClass(MethodsAnnotated.class);
-        Map<Class<? extends Annotation>, List<FrameworkMethod>> annotationToMethods = tc.getAnnotationToMethods();
-        List<FrameworkMethod> methods = annotationToMethods.get(Ignore.class);
-        exception.expect(UnsupportedOperationException.class);
-        methods.add(null);
-    }
-    
-    @Test
-    public void annotationToFields() {
-        TestClass tc = new TestClass(FieldAnnotated.class);
-        Map<Class<? extends Annotation>, List<FrameworkField>> annotationToFields = tc.getAnnotationToFields();
-        List<FrameworkField> fields = annotationToFields.get(Rule.class);
-        assertThat(fields.size(), is(2));
-    }
-
-    @Test
-    public void annotationToFieldsReturnsUnmodifiableMap() {
-        TestClass tc = new TestClass(FieldAnnotated.class);
-        Map<Class<? extends Annotation>, List<FrameworkField>> annotationToFields = tc.getAnnotationToFields();
-        exception.expect(UnsupportedOperationException.class);
-        annotationToFields.put(Rule.class, null);
-    }
-
-    @Test
-    public void annotationToFieldsReturnsValuesInTheMapThatAreUnmodifiable() {
-        TestClass tc = new TestClass(FieldAnnotated.class);
-        Map<Class<? extends Annotation>, List<FrameworkField>> annotationToFields = tc.getAnnotationToFields();
-        List<FrameworkField> fields = annotationToFields.get(Rule.class);
-        exception.expect(UnsupportedOperationException.class);
-        fields.add(null);
-    }
-
-    public static class MultipleFieldsAnnotated {
-        @DataPoint
-        public String a = "testing a";
-
-        @Rule
-        public boolean b;
-
-        @DataPoint
-        public String c = "testing c";
-
-        @Rule
-        public boolean d;
-    }
-
-    @Test
-    public void annotationToFieldsReturnsKeysInADeterministicOrder() {
-        TestClass tc = new TestClass(MultipleFieldsAnnotated.class);
-        Map<Class<? extends Annotation>, List<FrameworkField>> annotationToFields = tc.getAnnotationToFields();
-        List<Class<? extends Annotation>> keys = new ArrayList<Class<? extends Annotation>>();
-        for (Class<? extends Annotation> annotation : annotationToFields.keySet()) {
-            keys.add(annotation);
-        }
-        assertThat(keys.get(0), CoreMatchers.<Class<? extends Annotation>>is(DataPoint.class));
-        assertThat(keys.get(1), CoreMatchers.<Class<? extends Annotation>>is(Rule.class));
     }
 }

--- a/src/test/java/org/junit/validator/AnnotationsValidatorTest.java
+++ b/src/test/java/org/junit/validator/AnnotationsValidatorTest.java
@@ -1,0 +1,98 @@
+package org.junit.validator;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
+
+public class AnnotationsValidatorTest {
+    public static class ExampleAnnotationValidator extends AnnotationValidator {
+        private static final String ANNOTATED_METHOD_CALLED= "annotated method called";
+
+        private static final String ANNOTATED_FIELD_CALLED= "annotated field called";
+
+        private static final String ANNOTATED_CLASS_CALLED= "annotated class called";
+
+        @Override
+        public List<Exception> validateAnnotatedClass(TestClass testClass) {
+            return asList(new Exception(ANNOTATED_CLASS_CALLED));
+        }
+
+        @Override
+        public List<Exception> validateAnnotatedField(FrameworkField field) {
+            return asList(new Exception(ANNOTATED_FIELD_CALLED));
+        }
+
+        @Override
+        public List<Exception> validateAnnotatedMethod(FrameworkMethod method) {
+            return asList(new Exception(ANNOTATED_METHOD_CALLED));
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Inherited
+    @ValidateWith(ExampleAnnotationValidator.class)
+    public @interface ExampleAnnotationWithValidator {
+    }
+
+    public static class AnnotationValidatorMethodTest {
+        @ExampleAnnotationWithValidator
+        @Test
+        public void test() {
+        }
+    }
+
+    public static class AnnotationValidatorFieldTest {
+        @ExampleAnnotationWithValidator
+        private String field;
+
+        @Test
+        public void test() {
+        }
+    }
+
+    @ExampleAnnotationWithValidator
+    public static class AnnotationValidatorClassTest {
+        @Test
+        public void test() {
+        }
+    }
+
+    @Test
+    public void validatorIsCalledForAClass() {
+        assertClassHasFailureMessage(AnnotationValidatorClassTest.class,
+                ExampleAnnotationValidator.ANNOTATED_CLASS_CALLED);
+    }
+
+    @Test
+    public void validatorIsCalledForAMethod() {
+        assertClassHasFailureMessage(AnnotationValidatorMethodTest.class,
+                ExampleAnnotationValidator.ANNOTATED_METHOD_CALLED);
+    }
+
+    @Test
+    public void validatorIsCalledForAField() {
+        assertClassHasFailureMessage(AnnotationValidatorFieldTest.class,
+                ExampleAnnotationValidator.ANNOTATED_FIELD_CALLED);
+    }
+
+    private void assertClassHasFailureMessage(Class<?> klass,
+            String expectedFailure) {
+        AnnotationsValidator validator= new AnnotationsValidator();
+        Collection<Exception> errors= validator
+                .validateTestClass(new TestClass(klass));
+        assertThat(errors.size(), is(1));
+        assertThat(errors.iterator().next().getMessage(),
+                is(expectedFailure));
+    }
+}


### PR DESCRIPTION
Encapsulate the algorithm about verifying annotations. SRP and it now reusable by people who build their own runners without extending ParrentRunner. 
