### PR TITLE
Add contributing guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+We love pull requests. Here is a quick guide:
+1. You need to have `ant` and a JDK (at least version 1.5) installed.
+2. Fork the repo.
+3. Ensure that you have a clean state by running `ant test`.
+4. Add your change together with a test. (Tests are not needed for refactorings and documentation changes.)
+5. Format your code: Import the JUnit project in Eclipse and use its formatter or apply the rules in the `CODING_STYLE` file manually.
+6. Run `ant test` again and ensure all tests are passing.
+7. Push to your fork and submit a pull request.
+
+Now you are waiting on us. We review your pull request and at least leave some comments.


### PR DESCRIPTION
Hopefully this is helpful to new contributors. Github displays these guidelines when a new issue or pull request is created (https://github.com/blog/1184-contributing-guidelines).
