### PR TITLE
Verify that all (base-) classes declaring @ClassRules are public

### DIFF
--- a/src/main/java/org/junit/internal/runners/rules/RuleFieldValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/RuleFieldValidator.java
@@ -1,6 +1,7 @@
 package org.junit.internal.runners.rules;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
 import java.util.List;
 
 import org.junit.ClassRule;
@@ -70,13 +71,19 @@ public enum RuleFieldValidator {
     }
 
     private void validateMember(FrameworkMember<?> member, List<Throwable> errors) {
+        validatePublicClass(member, errors);
         validateStatic(member, errors);
         validatePublic(member, errors);
         validateTestRuleOrMethodRule(member, errors);
     }
+    
+    private void validatePublicClass(FrameworkMember<?> member, List<Throwable> errors) {
+        if (fStaticMembers && !isDeclaringClassPublic(member)) {
+            addError(errors, member, " must be declared in a public class.");
+        }
+    }
 
-    private void validateStatic(FrameworkMember<?> member,
-            List<Throwable> errors) {
+    private void validateStatic(FrameworkMember<?> member, List<Throwable> errors) {
         if (fStaticMembers && !member.isStatic()) {
             addError(errors, member, "must be static.");
         }
@@ -100,11 +107,14 @@ public enum RuleFieldValidator {
         }
     }
 
+    private boolean isDeclaringClassPublic(FrameworkMember<?> member) {
+        return Modifier.isPublic(member.getDeclaringClass().getModifiers());
+    }
+
     private boolean isTestRule(FrameworkMember<?> member) {
         return TestRule.class.isAssignableFrom(member.getType());
     }
 
-    @SuppressWarnings("deprecation")
     private boolean isMethodRule(FrameworkMember<?> member) {
         return MethodRule.class.isAssignableFrom(member.getType());
     }

--- a/src/main/java/org/junit/runners/model/FrameworkField.java
+++ b/src/main/java/org/junit/runners/model/FrameworkField.java
@@ -61,6 +61,11 @@ public class FrameworkField extends FrameworkMember<FrameworkField> {
     public Class<?> getType() {
         return fField.getType();
     }
+    
+    @Override
+    public Class<?> getDeclaringClass() {
+        return fField.getDeclaringClass();
+    }
 
     /**
      * Attempts to retrieve the value of this field on {@code target}

--- a/src/main/java/org/junit/runners/model/FrameworkMember.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMember.java
@@ -10,7 +10,7 @@ import java.util.List;
  */
 public abstract class FrameworkMember<T extends FrameworkMember<T>> {
     /**
-     * Returns the annotations on this method
+     * Returns the annotations on this member
      */
     abstract Annotation[] getAnnotations();
 
@@ -32,4 +32,6 @@ public abstract class FrameworkMember<T extends FrameworkMember<T>> {
     public abstract String getName();
 
     public abstract Class<?> getType();
+
+    public abstract Class<?> getDeclaringClass();
 }

--- a/src/main/java/org/junit/runners/model/FrameworkMethod.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMethod.java
@@ -84,14 +84,14 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
      * <li>is not static (given {@code isStatic is true}).
      */
     public void validatePublicVoid(boolean isStatic, List<Throwable> errors) {
-        if (Modifier.isStatic(fMethod.getModifiers()) != isStatic) {
+        if (isStatic() != isStatic) {
             String state = isStatic ? "should" : "should not";
             errors.add(new Exception("Method " + fMethod.getName() + "() " + state + " be static"));
         }
-        if (!Modifier.isPublic(fMethod.getDeclaringClass().getModifiers())) {
-            errors.add(new Exception("Class " + fMethod.getDeclaringClass().getName() + " should be public"));
+        if (!Modifier.isPublic(getDeclaringClass().getModifiers())) {
+            errors.add(new Exception("Class " + getDeclaringClass().getName() + " should be public"));
         }
-        if (!Modifier.isPublic(fMethod.getModifiers())) {
+        if (!isPublic()) {
             errors.add(new Exception("Method " + fMethod.getName() + "() should be public"));
         }
         if (fMethod.getReturnType() != Void.TYPE) {
@@ -128,6 +128,14 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
     @Override
     public Class<?> getType() {
         return getReturnType();
+    }
+
+    /**
+     * Returns the class where the method is actually declared
+     */
+    @Override
+    public Class<?> getDeclaringClass() {
+        return fMethod.getDeclaringClass();
     }
 
     public void validateNoTypeParametersOnArgs(List<Throwable> errors) {
@@ -197,7 +205,7 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
     public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
         return fMethod.getAnnotation(annotationType);
     }
-    
+
     public List<ParameterSignature> getParameterSignatures() {
         return ParameterSignature.signatures(fMethod);
     }

--- a/src/test/java/org/junit/tests/experimental/rules/RuleFieldValidatorTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/RuleFieldValidatorTest.java
@@ -48,6 +48,18 @@ public class RuleFieldValidatorTest {
     }
 
     @Test
+    public void rejectClassRuleInNonPublicClass() {
+        TestClass target = new TestClass(NonPublicTestWithClassRule.class);
+        CLASS_RULE_VALIDATOR.validate(target, errors);
+        assertOneErrorWithMessage("The @ClassRule 'temporaryFolder'  must be declared in a public class.");
+    }
+
+    static class NonPublicTestWithClassRule {
+        @ClassRule
+        public static TestRule temporaryFolder = new TemporaryFolder();
+    }
+
+    @Test
     public void acceptNonStaticTestRule() {
         TestClass target = new TestClass(TestWithNonStaticTestRule.class);
         RULE_VALIDATOR.validate(target, errors);
@@ -70,7 +82,7 @@ public class RuleFieldValidatorTest {
         @Rule
         public static TestRule temporaryFolder = new TemporaryFolder();
     }
-
+    
     @Test
     public void acceptMethodRule() throws Exception {
         TestClass target = new TestClass(TestWithMethodRule.class);


### PR DESCRIPTION
An `IllegalAccessException` is thrown in case a test class derives from a non-public base class which declares a `@ClassRule`.

For example, this code ...

```
 abstract class BaseTest {
   @ClassRule
   public static ExpectedException expEx = ExpectedException.none();
 }

 public class RealTest extends BaseTest {
   @Test
   public void myTest() {
     ...
   }
 }
```

… will cause this exception

```
 java.lang.RuntimeException: How did getFields return a field we couldn't access?
    at org.junit.runners.model.TestClass.getAnnotatedFieldValues(TestClass.java:161)
    ...
  Caused by: java.lang.IllegalAccessException: Class org.junit.runners.model.FrameworkField can not access a member of class BaseTest with modifiers "public static final"
    at sun.reflect.Reflection.ensureMemberAccess(Reflection.java:95)
    ...
```

To solve this issue, I added an additional verification to `RuleFieldValidator` that checks that all `@ClassRule`s are declared in public classes. A similar validation is already done for `@BeforeClass` and `@AfterClass` methods.
