### PR TITLE
changes to address kcooney's concerns about thread safety on issue #742

### DIFF
--- a/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
+++ b/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
@@ -17,7 +17,7 @@ public class FailOnTimeout extends Statement {
     private final TimeUnit fTimeUnit;
     private final long fTimeout;
     private final boolean fLookForStuckThread;
-    private ThreadGroup fThreadGroup = null;
+    private volatile ThreadGroup fThreadGroup = null;
 
     public FailOnTimeout(Statement originalStatement, long millis) {
         this(originalStatement, millis, TimeUnit.MILLISECONDS);

--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 public class Timeout implements TestRule {
     private final long fTimeout;
     private final TimeUnit fTimeUnit;
-    private boolean fLookForStuckThread;
+    private final boolean fLookForStuckThread;
 
     /**
      * Create a {@code Timeout} instance with the timeout specified
@@ -71,6 +71,20 @@ public class Timeout implements TestRule {
     }
 
     /**
+     * Create a {@code Timeout} instance with the same fields as {@code t}
+     * except for {@code fLookForStuckThread}.
+     *
+     * @param t the {@code Timeout} instance to copy
+     * @param lookForStuckThread whether to look for a stuck thread
+     * @since 4.12
+     */
+    protected Timeout(Timeout t, boolean lookForStuckThread) {
+        fTimeout = t.fTimeout;
+        fTimeUnit = t.fTimeUnit;
+        fLookForStuckThread = lookForStuckThread;
+    }
+
+    /**
      * @param millis the timeout in milliseconds
      * @since 4.12
      */
@@ -95,9 +109,8 @@ public class Timeout implements TestRule {
      * @return This object
      * @since 4.12
      */
-    public Timeout lookForStuckThread(boolean enable) {
-        fLookForStuckThread = enable;
-        return this;
+    public Timeout lookingForStuckThread(boolean enable) {
+        return new Timeout(this, enable);
     }
 
     public Statement apply(Statement base, Description description) {

--- a/src/test/java/org/junit/tests/running/methods/TimeoutTest.java
+++ b/src/test/java/org/junit/tests/running/methods/TimeoutTest.java
@@ -199,7 +199,7 @@ public class TimeoutTest {
     
     public static class InfiniteLoopWithStuckThreadTest {
         @Rule
-        public TestRule globalTimeout = new Timeout(100, TimeUnit.MILLISECONDS).lookForStuckThread(true);
+        public TestRule globalTimeout = new Timeout(100, TimeUnit.MILLISECONDS).lookingForStuckThread(true);
 
         @Test
         public void failure() throws Exception {
@@ -209,7 +209,7 @@ public class TimeoutTest {
     
     public static class InfiniteLoopStuckInMainThreadTest {
         @Rule
-        public TestRule globalTimeout = new Timeout(100, TimeUnit.MILLISECONDS).lookForStuckThread(true);
+        public TestRule globalTimeout = new Timeout(100, TimeUnit.MILLISECONDS).lookingForStuckThread(true);
 
         @Test
         public void failure() throws Exception {


### PR DESCRIPTION
Addressed kcooney's suggestions from 2013-11-03.  Made some changes to address concerns about thread safety, and renamed Timeout.lookForStuckThread() to lookingForStuckThread()
