### PR TITLE
#463: Add ability for timeout to print full thread stack dump

### DIFF
--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -1,10 +1,10 @@
 package org.junit.rules;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.internal.runners.statements.FailOnTimeout;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * The Timeout Rule applies the same timeout to all test methods in a class:
@@ -37,6 +37,7 @@ public class Timeout implements TestRule {
     private final long fTimeout;
     private final TimeUnit fTimeUnit;
     private boolean fLookForStuckThread;
+    private boolean fFullThreadStackDump;
 
     /**
      * Create a {@code Timeout} instance with the timeout specified
@@ -68,6 +69,7 @@ public class Timeout implements TestRule {
         fTimeout = timeout;
         fTimeUnit = unit;
         fLookForStuckThread = false;
+        fFullThreadStackDump = false;
     }
 
     /**
@@ -100,7 +102,12 @@ public class Timeout implements TestRule {
         return this;
     }
 
+    public Timeout printFullThreadStackDump(boolean enable) {
+        fFullThreadStackDump = enable;
+        return this;
+    }
+
     public Statement apply(Statement base, Description description) {
-        return new FailOnTimeout(base, fTimeout, fTimeUnit, fLookForStuckThread);
+        return new FailOnTimeout(base, fTimeout, fTimeUnit, fLookForStuckThread, fFullThreadStackDump);
     }
 }


### PR DESCRIPTION
Although originally this started based on #727: Fail on timeout displays stack of stuck thread …

This is a first naive attempt that (a) optionally adds information from ThreadMXBean#findMonitorDeadlockedThreads and (b) always adds full thread dump to exception message

---

@dsaff and #727: Since the Timeout#createTimeoutException is now (?) in FailOnTimeout#createTimeoutException (statement) it would require to (1) subclass FailOnTimeout to override FailOnTimeout#createTimeoutException and (2) subclass Timeout to override Timeout#apply to create and return an instance of the new FailOnTimeout sublcass from before. I had hoped for more convenience...

Besides that I also stumbled over the fact that quite some interesting thread dump information (locks, monitors, synchronizers) can only be retrieved from ThreadMXBean from Java >= 1.6.

Thus, what do you think of the following naive and admittedly very ugly thoughts, when I want to have this extended thread dump?
* Is any poor mans plugin/extension attempt via an non-elegant reflection based class creation (e.g. there is a system property with the full qualified name of the dumping class) thinkable?
** => actually this is roughly implemented in #770
* Another ugly idea would be making JUnit a multi-project with an optional 1.6 compatible part, where this extended thread dump class can be placed. Of course this then could be packaged in whatever ugly style in a single JAR and again via system property + reflection plugged in... But this gets extremely dirty...