### PR TITLE
Full thread stack dump on timeout with custom handler

### DIFF
--- a/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
+++ b/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
@@ -83,14 +83,13 @@ public class FailOnTimeout extends Statement {
         exceptions.add(currThreadException);
 
         if (stuckThread != null) {
-            Exception stuckThreadException = 
+            Exception stuckThreadException =
                 new Exception ("Appears to be stuck in thread " +
                                stuckThread.getName());
             stuckThreadException.setStackTrace(getStackTrace(stuckThread));
             exceptions.add(stuckThreadException);
         }
 
-        // TODO: would it make sense to make this optional, i.e. if stuckThread != null, then skip the full thread dump?
         if (fTimeoutHandler != null) {
             // For the sake of convenience just allow adding another exception by the custom timeout handler
             Exception timeoutHandlerException = fTimeoutHandler.handleTimeout(thread);
@@ -109,7 +108,7 @@ public class FailOnTimeout extends Statement {
     /**
      * Retrieves the stack trace for a given thread.
      * @param thread The thread whose stack is to be retrieved.
-     * @return The stack trace; returns a zero-length array if the thread has 
+     * @return The stack trace; returns a zero-length array if the thread has
      * terminated or the stack cannot be retrieved for some other reason.
      */
     private StackTraceElement[] getStackTrace(Thread thread) {
@@ -127,18 +126,18 @@ public class FailOnTimeout extends Statement {
      * @param mainThread The main thread created by {@code evaluate()}
      * @return The thread which appears to be causing the problem, if different from
      * {@code mainThread}, or {@code null} if the main thread appears to be the
-     * problem or if the thread cannot be determined.  The return value is never equal 
+     * problem or if the thread cannot be determined.  The return value is never equal
      * to {@code mainThread}.
      */
     private Thread getStuckThread (Thread mainThread) {
-        if (fThreadGroup == null) 
+        if (fThreadGroup == null)
             return null;
         Thread[] threadsInGroup = getThreadArray(fThreadGroup);
-        if (threadsInGroup == null) 
+        if (threadsInGroup == null)
             return null;
-        
+
         // Now that we have all the threads in the test's thread group: Assume that
-        // any thread we're "stuck" in is RUNNABLE.  Look for all RUNNABLE threads. 
+        // any thread we're "stuck" in is RUNNABLE.  Look for all RUNNABLE threads.
         // If just one, we return that (unless it equals threadMain).  If there's more
         // than one, pick the one that's using the most CPU time, if this feature is
         // supported.
@@ -151,13 +150,13 @@ public class FailOnTimeout extends Statement {
                     stuckThread = thread;
                     maxCpuTime = threadCpuTime;
                 }
-            }               
+            }
         }
         return (stuckThread == mainThread) ? null : stuckThread;
     }
 
     /**
-     * Returns all active threads belonging to a thread group.  
+     * Returns all active threads belonging to a thread group.
      * @param group The thread group.
      * @return The active threads in the thread group.  The result should be a
      * complete list of the active threads at some point in time.  Returns {@code null}
@@ -178,16 +177,16 @@ public class FailOnTimeout extends Statement {
             // is >= the array's length; therefore we can't trust that it returned all
             // the threads.  Try again.
             enumSize += 100;
-            if (++loopCount >= 5) 
+            if (++loopCount >= 5)
                 return null;
-            // threads are proliferating too fast for us.  Bail before we get into 
+            // threads are proliferating too fast for us.  Bail before we get into
             // trouble.
         }
         return copyThreads(threads, enumCount);
     }
 
     /**
-     * Returns an array of the first {@code count} Threads in {@code threads}. 
+     * Returns an array of the first {@code count} Threads in {@code threads}.
      * (Use instead of Arrays.copyOf to maintain compatibility with Java 1.5.)
      * @param threads The source array.
      * @param count The maximum length of the result array.

--- a/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
+++ b/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
@@ -77,7 +77,6 @@ public class FailOnTimeout extends Statement {
                 "test timed out after %d %s", fTimeout, fTimeUnit.name().toLowerCase()));
         if (stackTrace != null) {
             currThreadException.setStackTrace(stackTrace);
-            thread.interrupt();
         }
 
         List<Throwable> exceptions = new ArrayList<Throwable>();
@@ -103,6 +102,8 @@ public class FailOnTimeout extends Statement {
                 exceptions.add(timeoutHandlerException);
             }
         }
+
+        thread.interrupt();
 
         if (exceptions.size() > 1) {
             return new MultipleFailureException(exceptions);

--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -37,6 +37,7 @@ public class Timeout implements TestRule {
     private final long fTimeout;
     private final TimeUnit fTimeUnit;
     private boolean fLookForStuckThread;
+    private TimeoutHandler fTimeoutHandler;
 
     /**
      * Create a {@code Timeout} instance with the timeout specified
@@ -68,6 +69,7 @@ public class Timeout implements TestRule {
         fTimeout = timeout;
         fTimeUnit = unit;
         fLookForStuckThread = false;
+        fTimeoutHandler = null;
     }
 
     /**
@@ -100,7 +102,12 @@ public class Timeout implements TestRule {
         return this;
     }
 
+    public Timeout customTimeoutHandler(TimeoutHandler handler) {
+        fTimeoutHandler = handler;
+        return this;
+    }
+
     public Statement apply(Statement base, Description description) {
-        return new FailOnTimeout(base, fTimeout, fTimeUnit, fLookForStuckThread);
+        return new FailOnTimeout(base, fTimeout, fTimeUnit, fLookForStuckThread, fTimeoutHandler);
     }
 }

--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -34,6 +34,9 @@ import java.util.concurrent.TimeUnit;
  * @since 4.7
  */
 public class Timeout implements TestRule {
+
+    public static final String TIMEOUT_HANDLER_CLASS_NAME_PROPERTY_NAME = "org.junit.rules.timeout.handler";
+
     private final long fTimeout;
     private final TimeUnit fTimeUnit;
     private boolean fLookForStuckThread;

--- a/src/main/java/org/junit/rules/TimeoutHandler.java
+++ b/src/main/java/org/junit/rules/TimeoutHandler.java
@@ -1,0 +1,14 @@
+package org.junit.rules;
+
+public interface TimeoutHandler {
+
+    /**
+     * If the test runs into test timeout, this callback will be called allowing to gather
+     * additional test failure context (e.g. of other involved systems).
+     *
+     * @param thread the actual test executing main thread
+     * @return the optional exception will be added to the test failure
+     */
+    Exception handleTimeout(Thread thread);
+
+}


### PR DESCRIPTION
This is an attempt to start addressing: #463 Add ability for timeout to print full thread stack dump
- Another attempt that allows to "install" an additional custom timeout handler that can optionally also add a further exception to the test timeout exception

=> Extending the initial rudimentary attempt of #768 to allow "installing" an additional custom timeout handler (that can optionally also add a further exception to the test timeout exception) by a globally set custom timeout handler based on a system property, that is instantiated via reflection.

This custom timeout handler is also desirable to overcome the Java 1.5 compatibility requirement of JUnit, so any default timeout handler bundled with JUnit needs to adhere to this compatibility too: but quite some interesting thread dump information (locks, monitors, synchronizers) can only be retrieved from ThreadMXBean from Java >= 1.6, I think.

(Note one self test still fails in Ant context, but not in Eclipse though -- why is that the case? can it be the parallel usage of a test case timeout via annotation attribute and the global test class timeout via rule kind of interfere? but why is it then working in Eclipse?)

Deadlocked threads of self tests are not surviving anymore (fixed in a subsequent commit; in contrast to some infinite loop running threads from other self tests...
=> In order to fix that and allow full thread stack dump in custom handler, the interrupting of the test thread was moved slightly down.

What do you think of that approach?