### PR TITLE
Add support for Travis CI (http://travis-ci.org).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - oraclejdk7
+  - openjdk7
+  - openjdk6


### PR DESCRIPTION
I like the Travis CI because it automatically runs `ant test` for each of my branches. Every developer can create a Travis account and enable this feature for its fork.

One nice feature is its support for Github's [Commit Status API](https://github.com/blog/1227-commit-status-api). Github's web interface shows us the CI result for each pull request.

Would be nice if we add support for Travis CI. It does not have to replace Cloudbee's Jenkins.

Any thoughts?
