### PR TITLE
Allow expecting an exception's cause has a specific type

### DIFF
--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -225,6 +225,21 @@ public class ExpectedException implements TestRule {
         expect(hasCause(expectedCause));
     }
 
+    /**
+     * Verify that your code throws an exception whose cause is an instance of
+     * specific {@code type}.
+     * <pre> &#064;Test
+     * public void throwsExceptionWhoseCauseIsASpecificType() {
+     *     NullPointerException expectedCause = new NullPointerException();
+     *     thrown.expectCause(NullPointerException.class);
+     *     throw new IllegalArgumentException(&quot;What happened?&quot;, cause);
+     * }</pre>
+     */
+    public void expectCause(Class<? extends Throwable> type) {
+        Matcher<Throwable> instanceOfType = instanceOf(type);
+        expectCause(instanceOfType);
+    }
+
     private class ExpectedExceptionStatement extends Statement {
         private final Statement fNext;
 

--- a/src/test/java/org/junit/tests/experimental/rules/ExpectedExceptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/ExpectedExceptionTest.java
@@ -69,6 +69,7 @@ public class ExpectedExceptionTest {
                         ExpectsMultipleMatchers.class,
                         hasSingleFailureWithMessage(startsWith("\nExpected: (an instance of java.lang.IllegalArgumentException and exception with message a string containing \"Ack!\")"))},
                 {ThrowExceptionWithMatchingCause.class, everyTestRunSuccessful()},
+                {ThrowsExceptionWithExpectedCauseType.class, everyTestRunSuccessful()},
                 {ThrowExpectedNullCause.class, everyTestRunSuccessful()},
                 {
                         ThrowUnexpectedCause.class,
@@ -327,6 +328,21 @@ public class ExpectedExceptionTest {
             thrown.expectCause(is(new NullPointerException("expected cause")));
 
             throw new IllegalArgumentException("Ack!", new NullPointerException("an unexpected cause"));
+        }
+    }
+
+    public static class ThrowsExceptionWithExpectedCauseType {
+
+        @Rule
+        public ExpectedException thrown = none();
+
+        @Test
+        public void throwExceptionWithMatchingCause() {
+            NullPointerException expectedCause = new NullPointerException("expected cause");
+
+            thrown.expectCause(NullPointerException.class);
+
+            throw new IllegalArgumentException("Ack!", expectedCause);
         }
     }
     


### PR DESCRIPTION
Hi,

Sorry for just jumping in with a pull request without discussing this first - I realise it might not get accepted, as a result! It was just so quick and easy I thought it'd be best to get a PR in and have it rejected if need be.

I recently had need to match on the type of an exception's cause, and was briefly confused by `ExpectedException#expect` taking either a `Matcher` or a `Class<? extends Throwable>`, but `expectCause` only taking a `Matcher`. Obviously, what I wanted could be achieved via `expectedCause(instanceOf(...))` (as pointed out in #337), but my dev experience would have been marginally more pleasant if I hadn't had to work this out - perhaps it's worth reconsidering this choice? This PR brings parity to the two methods.

Note that if this is merged, we should probably do something similar with #778.

Thanks,
Rowan
