### PR TITLE
Testing contents of exception-messages

### DIFF
--- a/src/main/java/org/junit/Test.java
+++ b/src/main/java/org/junit/Test.java
@@ -78,6 +78,12 @@ public @interface Test {
     Class<? extends Throwable> expected() default None.class;
 
     /**
+     * Optionally specify <code>expectedMessage</code>, a String, to cause a test method to succeed if
+     * and only if an exception containing the specified string is thrown by the method.
+     */
+    String expectedMessage() default "";
+
+    /**
      * Optionally specify <code>timeout</code> in milliseconds to cause a test method to fail if it
      * takes longer than that number of milliseconds.
      * <p>

--- a/src/main/java/org/junit/internal/runners/statements/ExpectException.java
+++ b/src/main/java/org/junit/internal/runners/statements/ExpectException.java
@@ -4,12 +4,17 @@ import org.junit.internal.AssumptionViolatedException;
 import org.junit.runners.model.Statement;
 
 public class ExpectException extends Statement {
+
     private Statement fNext;
     private final Class<? extends Throwable> fExpected;
+    private final String fExpectedMessage;
 
-    public ExpectException(Statement next, Class<? extends Throwable> expected) {
+    public ExpectException(Statement next,
+                           Class<? extends Throwable> expected,
+                           String expectedMessage) {
         fNext = next;
         fExpected = expected;
+        fExpectedMessage = expectedMessage;
     }
 
     @Override
@@ -21,10 +26,17 @@ public class ExpectException extends Statement {
         } catch (AssumptionViolatedException e) {
             throw e;
         } catch (Throwable e) {
-            if (!fExpected.isAssignableFrom(e.getClass())) {
+            if (fExpected != null && !fExpected.isAssignableFrom(e.getClass())) {
                 String message = "Unexpected exception, expected<"
                         + fExpected.getName() + "> but was<"
                         + e.getClass().getName() + ">";
+                throw new Exception(message, e);
+            }
+
+            if (fExpectedMessage != null && !e.getMessage().contains(fExpectedMessage)) {
+                String message = String.format("Unexpected message, " +
+                         "expected it to contain <%s> but was <%s>",
+                         fExpectedMessage, e.getMessage());
                 throw new Exception(message, e);
             }
         }

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -76,7 +76,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
             runLeaf(methodBlock(method), description, notifier);
         }
     }
-    
+
     /**
      * Evaluates whether {@link FrameworkMethod}s are ignored based on the
      * {@link Ignore} annotation.
@@ -298,7 +298,8 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
             Object test, Statement next) {
         Test annotation = method.getAnnotation(Test.class);
         return expectsException(annotation) ? new ExpectException(next,
-                getExpectedException(annotation)) : next;
+                getExpectedException(annotation),
+                getExpectedMessage(annotation)) : next;
     }
 
     /**
@@ -412,8 +413,17 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         }
     }
 
+    private String getExpectedMessage(final Test annotation) {
+        if (annotation == null || "".equals(annotation.expectedMessage())) {
+            return null;
+        } else {
+            return annotation.expectedMessage();
+        }
+    }
+
     private boolean expectsException(Test annotation) {
-        return getExpectedException(annotation) != null;
+        return getExpectedException(annotation) != null ||
+               getExpectedMessage(annotation) != null;
     }
 
     private long getTimeout(Test annotation) {

--- a/src/test/java/org/junit/tests/running/methods/ExpectedMessageTest.java
+++ b/src/test/java/org/junit/tests/running/methods/ExpectedMessageTest.java
@@ -1,0 +1,78 @@
+package org.junit.tests.running.methods;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+
+/**
+ * Tests for the optional {@link org.junit.Test#expectedMessage()} parameter of the {@link Test} annotation.
+ */
+public class ExpectedMessageTest {
+
+    public static class UnexpectedMessage {
+        @Test(expectedMessage = "has to be greater than zero")
+        public void unexpectedMessage() {
+            throw new IllegalArgumentException("Parameter x cannot be null");
+        }
+    }
+
+    @Test
+    public void unexpectedMessage() {
+        final JUnitCore core = new JUnitCore();
+        final Result result = core.run(UnexpectedMessage.class);
+        assertEquals(1, result.getFailureCount());
+        assertEquals("Unexpected message, expected it to contain " +
+                         "<has to be greater than zero> but was " +
+                         "<Parameter x cannot be null>",
+                     result.getFailures().get(0).getMessage());
+    }
+
+    public static class ExpectedExceptionTakesPrecedence {
+        @Test(expected = IllegalArgumentException.class,
+              expectedMessage = "Parameter x cannot be null")
+        public void expectedExceptionTakesPrecedence() {
+            throw new Error("Variable x cannot be null");
+        }
+    }
+
+    @Test
+    public void expectedExceptionTakesPrecedence() {
+        final JUnitCore core = new JUnitCore();
+        final Result result = core.run(ExpectedExceptionTakesPrecedence.class);
+        assertEquals(1, result.getFailureCount());
+        final Failure failure = result.getFailures().get(0);
+        assertFalse(failure.getMessage().contains("Unexpected message"));
+    }
+
+    public static class NoneThrown {
+        @Test(expected = IllegalArgumentException.class,
+              expectedMessage = "x cannot be empty")
+        public void noneThrown() {
+            throw new IllegalArgumentException("Parameter x cannot be empty");
+        }
+    }
+
+    @Test
+    public void noneThrown() {
+        final JUnitCore core = new JUnitCore();
+        final Result result = core.run(NoneThrown.class);
+        assertTrue(result.wasSuccessful());
+    }
+
+    public static class IndependentOfExpectedException {
+        @Test(expectedMessage = "cannot be null")
+        public void independentOfExpectedException() {
+            throw new IllegalArgumentException("Variable cannot be null!");
+        }
+    }
+
+    @Test
+    public void independentOfExpectedException() {
+        final JUnitCore core = new JUnitCore();
+        final Result result = core.run(IndependentOfExpectedException.class);
+        assertTrue(result.wasSuccessful());
+    }
+}


### PR DESCRIPTION
I've more than once wanted to test at least some part of the exception messages our applications throw. We accept input from various sources and have standards for validation and the level of detail of the exception messages that should be thrown for bad input. So we quite often end up with code like this:

```
public void method(final Long id, final String parameter) {
  Validate.notNull(id, "id cannot be null");
  Validate.notEmpty(parameter, "parameter cannot be an empty string (id=" + id + ")");
  // ...
}
```

We've used @Rule and ExpectedException to test these validations separately so far, and it works ok. But it does sort of feel like a few of lines more than necessary, and we have lot of these types of situations... So this is an attempt to make it slightly easier to test these types of situations, by allowing for constructs like this:

```
@Test(expectedMessage = "id cannot be null")
public void shouldThrowExceptionForMissingId() {
  service.method(null, "Something");
}

@Test(expectedMessage = "parameter cannot be empty")
public void shouldThrowExceptionForMissingParameter() {
  service.method(1L, null);
}
```

Note:
I've tried following code standards and placed logic where it seemed appropriate, but I'm open to any and all criticism. I also hope this is the correct way of trying to make a contribution, I had to do some reading on how Github works ;).
