### PR TITLE
Add reference to ExpectedException. Fixes #806.

### DIFF
--- a/src/main/java/org/junit/Test.java
+++ b/src/main/java/org/junit/Test.java
@@ -31,7 +31,11 @@ import java.lang.annotation.Target;
  *    &#064;Test(<b>expected=IndexOutOfBoundsException.class</b>) public void outOfBounds() {
  *       new ArrayList&lt;Object&gt;().get(1);
  *    }
- * </pre></p>
+ * </pre>
+ * If the exception's message or one of its properties should be verified, the
+ * {@link org.junit.rules.ExpectedException ExpectedException} rule can be used. Further
+ * information about exception testing can be found at the
+ * <a href="https://github.com/junit-team/junit/wiki/Exception-testing">JUnit Wiki</a>.
  * <p>
  * The second optional parameter, <code>timeout</code>, causes a test to fail if it takes
  * longer than a specified amount of clock time (measured in milliseconds). The following test fails:
@@ -73,7 +77,9 @@ public @interface Test {
 
     /**
      * Optionally specify <code>expected</code>, a Throwable, to cause a test method to succeed if
-     * and only if an exception of the specified class is thrown by the method.
+     * and only if an exception of the specified class is thrown by the method. If the Throwable's
+     * message or one of its properties should be verified, the
+     * {@link org.junit.rules.ExpectedException ExpectedException} rule can be used instead.
      */
     Class<? extends Throwable> expected() default None.class;
 


### PR DESCRIPTION
The ExpectedException can be used for better exception testing. The
reference should guide the reader to its documentation.
