### PR TITLE
 Assert not empty for collections?

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -1,5 +1,7 @@
 package org.junit;
 
+import java.util.Collection;
+
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
 import org.junit.internal.ArrayComparisonFailure;
@@ -297,7 +299,7 @@ public class Assert {
     public static void assertArrayEquals(Object[] expecteds, Object[] actuals) {
         assertArrayEquals(null, expecteds, actuals);
     }
-    
+
     /**
      * Asserts that two boolean arrays are equal. If they are not, an
      * {@link AssertionError} is thrown with the given message. If
@@ -312,8 +314,8 @@ public class Assert {
     public static void assertArrayEquals(String message, boolean[] expecteds,
             boolean[] actuals) throws ArrayComparisonFailure {
         internalArrayEquals(message, expecteds, actuals);
-    }    
-    
+    }
+
     /**
      * Asserts that two boolean arrays are equal. If they are not, an
      * {@link AssertionError} is thrown. If <code>expected</code> and
@@ -954,5 +956,67 @@ public class Assert {
     public static <T> void assertThat(String reason, T actual,
             Matcher<? super T> matcher) {
         MatcherAssert.assertThat(reason, actual, matcher);
+    }
+
+    /**
+     * Asserts that collection <code>c</value> is not empty. If <code>c</code> is <code>null</code> or empty,
+     * an {@link AssertionError} is thrown.
+     *
+     * @param c the collection to check for not being empty
+     */
+    public static void assertNotEmpty(Collection<?> c) {
+        assertNotEmpty(null, c);
+    }
+
+    /**
+     * Asserts that collection <code>c</value> is not empty. If <code>c</code> is <code>null</code> or empty,
+     * an {@link AssertionError} is thrown.
+     *
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code>
+     * okay)
+     * @param c the collection to check for not being empty
+     */
+    public static void assertNotEmpty(String message, Collection<?> c) {
+        if (null ==c) {
+            failWithMessageOrDefault(message, "Collection is null but should not be empty.");
+        }
+        if (c.isEmpty()) {
+            failWithMessageOrDefault(message, "Collection should not be empty.");
+        }
+    }
+
+    /**
+     * Asserts that collection <code>c</value> is empty. If <code>c</code> is <code>null</code> or not empty,
+     * an {@link AssertionError} is thrown.
+     *
+     * @param c the collection to check for being empty
+     */
+    public static void assertEmpty(Collection<?> c) {
+        assertEmpty(null, c);
+    }
+
+    /**
+     * Asserts that collection <code>c</value> is empty. If <code>c</code> is <code>null</code> or not empty,
+     * an {@link AssertionError} is thrown.
+     *
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code>
+     * okay)
+     * @param c the collection to check for being empty
+     */
+    public static void assertEmpty(String message, Collection<?> c) {
+        if (null == c) {
+            failWithMessageOrDefault(message, "Collection is null but should just be empty.");
+        }
+        if (!c.isEmpty()) {
+            failWithMessageOrDefault(message, "Collection should be empty.");
+        }
+    }
+
+    static private void failWithMessageOrDefault(String message, String defaultMessage) {
+        if (null == message) {
+            fail(defaultMessage);
+        } else {
+            fail(message);
+        }
     }
 }

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -12,8 +12,12 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotEmpty;
+import static org.junit.Assert.assertEmpty;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.ComparisonFailure;
@@ -170,7 +174,7 @@ public class AssertionTest {
     public void oneDimensionalFloatArraysAreNotEqual() {
         assertArrayEquals(new float[]{1.0f}, new float[]{2.5f}, 1.0f);
     }
-    
+
     @Test(expected = AssertionError.class)
     public void oneDimensionalBooleanArraysAreNotEqual() {
         assertArrayEquals(new boolean[]{true}, new boolean[]{false});
@@ -647,5 +651,35 @@ public class AssertionTest {
     @Test(expected = AssertionError.class)
     public void assertNotEqualsIgnoresFloatDeltaOnNaN() {
         assertNotEquals(Float.NaN, Float.NaN, 1f);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void assertCollectionNotEmptyErrorOnEmpty() {
+        assertNotEmpty(new ArrayList<Object>());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void assertCollectionNotEmptyErrorOnNullCollection() {
+        assertNotEmpty(null);
+    }
+
+    @Test
+    public void assertCollectionNotEmptyValid() {
+        assertNotEmpty(Arrays.asList("an entry"));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void assertCollectionEmptyErrorOnNotEmpty() {
+        assertEmpty(Arrays.asList("an entry"));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void assertCollectionEmptyErrorOnNullCollection() {
+        assertEmpty(null);
+    }
+
+    @Test
+    public void assertCollectionEmptyOnEmpty() {
+        assertEmpty(new ArrayList<Object>());
     }
 }


### PR DESCRIPTION
fixes junit-team/junit#681
Although same could be achieved with hamcrest matchers. It's probably
personal preference how you'd do it. I know many that write
assertFalse(collection.isEmpty()) ...
