### PR TITLE
External version of AssumptionViolatedException

### DIFF
--- a/src/main/java/org/junit/Assume.java
+++ b/src/main/java/org/junit/Assume.java
@@ -7,7 +7,6 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 
 import org.hamcrest.Matcher;
-import org.junit.internal.AssumptionViolatedException;
 
 /**
  * A set of methods useful for stating assumptions about the conditions in which a test is meaningful.

--- a/src/main/java/org/junit/AssumptionViolatedException.java
+++ b/src/main/java/org/junit/AssumptionViolatedException.java
@@ -1,0 +1,48 @@
+package org.junit;
+
+import org.hamcrest.Matcher;
+
+/**
+ * An exception class used to implement <i>assumptions</i> (state in which a given test
+ * is meaningful and should or should not be executed). A test for which an assumption
+ * fails should not generate a test case failure.
+ *
+ * @see org.junit.Assume
+ */
+public class AssumptionViolatedException extends org.junit.internal.AssumptionViolatedException {
+    private static final long serialVersionUID = 1L;
+
+    public AssumptionViolatedException(String assumption, boolean valueMatcher, Object value, Matcher<?> matcher) {
+        super(assumption, valueMatcher, value, matcher);
+    }
+
+    /**
+     * An assumption exception with the given <i>value</i> (String or
+     * Throwable) and an additional failing {@link Matcher}.
+     */
+    public AssumptionViolatedException(Object value, Matcher<?> matcher) {
+        super(value, matcher);
+    }
+
+    /**
+     * An assumption exception with the given <i>value</i> (String or
+     * Throwable) and an additional failing {@link Matcher}.
+     */
+    public AssumptionViolatedException(String assumption, Object value, Matcher<?> matcher) {
+        super(assumption, value, matcher);
+    }
+
+    /**
+     * An assumption exception with the given message only.
+     */
+    public AssumptionViolatedException(String assumption) {
+        super(assumption);
+    }
+
+    /**
+     * An assumption exception with the given message and a cause.
+     */
+    public AssumptionViolatedException(String assumption, Throwable t) {
+        super(assumption, t);
+    }
+}

--- a/src/main/java/org/junit/internal/AssumptionViolatedException.java
+++ b/src/main/java/org/junit/internal/AssumptionViolatedException.java
@@ -10,8 +10,11 @@ import org.hamcrest.StringDescription;
  * is meaningful and should or should not be executed). A test for which an assumption
  * fails should not generate a test case failure.
  *
- * @see Assume
+ * @see org.junit.Assume
+ *
+ * @deprecated Please use {@link org.junit.AssumptionViolatedException} instead.
  */
+@Deprecated
 public class AssumptionViolatedException extends RuntimeException implements SelfDescribing {
     private static final long serialVersionUID = 2L;
 

--- a/src/main/java/org/junit/internal/runners/ClassRoadie.java
+++ b/src/main/java/org/junit/internal/runners/ClassRoadie.java
@@ -4,6 +4,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 
+import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunNotifier;
@@ -59,7 +60,7 @@ public class ClassRoadie {
             } catch (InvocationTargetException e) {
                 throw e.getTargetException();
             }
-        } catch (org.junit.internal.AssumptionViolatedException e) {
+        } catch (AssumptionViolatedException e) {
             throw new FailedBefore();
         } catch (Throwable e) {
             addFailure(e);

--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -7,9 +7,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.internal.matchers.ThrowableCauseMatcher.hasCause;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
+
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.junit.runners.model.Statement;
 
 /**

--- a/src/main/java/org/junit/runner/notification/RunListener.java
+++ b/src/main/java/org/junit/runner/notification/RunListener.java
@@ -6,7 +6,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 
@@ -109,7 +108,7 @@ public class RunListener {
      * false
      *
      * @param failure describes the test that failed and the
-     * {@link AssumptionViolatedException} that was thrown
+     * {@link org.junit.AssumptionViolatedException} that was thrown
      */
     public void testAssumptionFailure(Failure failure) {
     }

--- a/src/main/java/org/junit/runner/notification/RunNotifier.java
+++ b/src/main/java/org/junit/runner/notification/RunNotifier.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.Result;
 
@@ -152,7 +151,7 @@ public class RunNotifier {
      * something false.
      *
      * @param failure the description of the test that failed and the
-     * {@link AssumptionViolatedException} thrown
+     * {@link org.junit.AssumptionViolatedException} thrown
      */
     public void fireTestAssumptionFailed(final Failure failure) {
         new SafeNotifier() {

--- a/src/test/java/org/junit/AssumptionViolatedExceptionTest.java
+++ b/src/test/java/org/junit/AssumptionViolatedExceptionTest.java
@@ -1,4 +1,4 @@
-package org.junit.tests.experimental;
+package org.junit;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -8,11 +8,9 @@ import static org.junit.Assume.assumeThat;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
-import org.junit.Test;
 import org.junit.experimental.theories.DataPoint;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
-import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.RunWith;
 
 @RunWith(Theories.class)

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -2,6 +2,7 @@ package org.junit.tests;
 
 import junit.framework.JUnit4TestAdapter;
 import junit.framework.Test;
+import org.junit.AssumptionViolatedExceptionTest;
 import org.junit.experimental.categories.CategoryFilterFactoryTest;
 import org.junit.internal.MethodSorterTest;
 import org.junit.internal.matchers.StacktracePrintingMatcherTest;
@@ -25,7 +26,6 @@ import org.junit.tests.description.AnnotatedDescriptionTest;
 import org.junit.tests.description.SuiteDescriptionTest;
 import org.junit.tests.description.TestDescriptionTest;
 import org.junit.tests.experimental.AssumptionTest;
-import org.junit.tests.experimental.AssumptionViolatedExceptionTest;
 import org.junit.tests.experimental.ExperimentalTests;
 import org.junit.tests.experimental.MatcherTest;
 import org.junit.tests.experimental.categories.CategoriesAndParameterizedTest;

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -18,10 +18,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Assume;
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;


### PR DESCRIPTION
This is a pull-request for issue #390.

Just subclassing and deprecating the internal version and updating references. I'm wondering if there's a better package for the external version?
