### PR TITLE
Optimize memory consumption in junit.framework.Assert

### DIFF
--- a/src/main/java/junit/framework/Assert.java
+++ b/src/main/java/junit/framework/Assert.java
@@ -117,7 +117,7 @@ public class Assert {
             return;
         }
         if (!(Math.abs(expected - actual) <= delta)) {
-            failNotEquals(message, Double.valueOf(expected), Double.valueOf(actual));
+            failNotEquals(message, new Double(expected), new Double(actual));
         }
     }
 
@@ -139,7 +139,7 @@ public class Assert {
             return;
         }
         if (!(Math.abs(expected - actual) <= delta)) {
-            failNotEquals(message, Float.valueOf(expected), Float.valueOf(actual));
+            failNotEquals(message, new Float(expected), new Float(actual));
         }
     }
 


### PR DESCRIPTION
New class org.junit.Assert already contains optimized assert methods (with Long.valueOf etc), for example:

``` java
    static public void assertEquals(String message, long expected, long actual) {
        if (expected != actual) {
            failNotEquals(message, Long.valueOf(expected), Long.valueOf(actual));
        }
    }
```

Old (deprecated) version of this class (junit.framework.Assert) contains not-optimized methods, for example:

``` java
    static public void assertEquals(String message, long expected, long actual) {
        assertEquals(message, new Long(expected), new Long(actual));
    }
```

Whole class is deprecated, but I sure that this methods are still used in many projects, so I suggest to optimize them, until they are presented in JUnit.
