### PR TITLE
Add Serializable interface for comparators

### DIFF
--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -3,6 +3,7 @@ package org.junit.runners.model;
 import static java.lang.reflect.Modifier.isStatic;
 import static org.junit.internal.MethodSorter.NAME_ASCENDING;
 
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
@@ -255,7 +256,7 @@ public class TestClass implements Annotatable {
     /**
      * Compares two fields by its name.
      */
-    private static class FieldComparator implements Comparator<Field> {
+    private static class FieldComparator implements Comparator<Field>, Serializable {
         public int compare(Field left, Field right) {
             return left.getName().compareTo(right.getName());
         }
@@ -264,8 +265,7 @@ public class TestClass implements Annotatable {
     /**
      * Compares two methods by its name.
      */
-    private static class MethodComparator implements
-            Comparator<FrameworkMethod> {
+    private static class MethodComparator implements Comparator<FrameworkMethod>, Serializable {
         public int compare(FrameworkMethod left, FrameworkMethod right) {
             return NAME_ASCENDING.compare(left.getMethod(), right.getMethod());
         }


### PR DESCRIPTION
It is not something important, just Java SDK recommendation: http://docs.oracle.com/javase/6/docs/api/java/util/Comparator.html

> Note: It is generally a good idea for comparators to also implement java.io.Serializable, as they may be used as ordering methods in serializable data structures (like TreeSet, TreeMap). In order for the data structure to serialize successfully, the comparator (if provided) must implement Serializable.
