### PR TITLE
Fix possible NPE in method equals (ParameterizedAssertionError)

### DIFF
--- a/src/main/java/org/junit/experimental/theories/internal/ParameterizedAssertionError.java
+++ b/src/main/java/org/junit/experimental/theories/internal/ParameterizedAssertionError.java
@@ -15,7 +15,7 @@ public class ParameterizedAssertionError extends AssertionError {
 
     @Override
     public boolean equals(Object obj) {
-        return toString().equals(obj.toString());
+        return obj instanceof ParameterizedAssertionError && toString().equals(obj.toString());
     }
 
     public static String join(String delimiter, Object... params) {

--- a/src/test/java/org/junit/tests/experimental/theories/internal/ParameterizedAssertionErrorTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/internal/ParameterizedAssertionErrorTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeThat;
 
 import org.junit.Test;
@@ -62,6 +63,11 @@ public class ParameterizedAssertionErrorTest {
     public void buildParameterizedAssertionError(String methodName, String param) {
         assertThat(new ParameterizedAssertionError(new RuntimeException(),
                 methodName, param).toString(), containsString(methodName));
+    }
+
+    @Theory
+    public void isNotEqualToNull(ParameterizedAssertionError a) {
+        assertFalse(a.equals(null));
     }
 
     @Test


### PR DESCRIPTION
``` java
@Override
public boolean equals(Object obj) {
    return toString().equals(obj.toString());
}
```

Problems:
- As you can see the old version of "equals" method could throw NullPointerException (obj.toSting()). 
- And also it has not got check for correct class (instanceOf).

It will be better to make additional check: obj instanceof ParameterizedAssertionError
