### PR TITLE
Close possibility to make reassignment for some constant-fields

### DIFF
--- a/src/main/java/org/junit/internal/MethodSorter.java
+++ b/src/main/java/org/junit/internal/MethodSorter.java
@@ -10,7 +10,7 @@ public class MethodSorter {
     /**
      * DEFAULT sort order
      */
-    public static Comparator<Method> DEFAULT = new Comparator<Method>() {
+    public static final Comparator<Method> DEFAULT = new Comparator<Method>() {
         public int compare(Method m1, Method m2) {
             int i1 = m1.getName().hashCode();
             int i2 = m2.getName().hashCode();
@@ -24,7 +24,7 @@ public class MethodSorter {
     /**
      * Method name ascending lexicographic sort order, with {@link Method#toString()} as a tiebreaker
      */
-    public static Comparator<Method> NAME_ASCENDING = new Comparator<Method>() {
+    public static final Comparator<Method> NAME_ASCENDING = new Comparator<Method>() {
         public int compare(Method m1, Method m2) {
             final int comparison = m1.getName().compareTo(m2.getName());
             if (comparison != 0) {

--- a/src/main/java/org/junit/runner/manipulation/Filter.java
+++ b/src/main/java/org/junit/runner/manipulation/Filter.java
@@ -18,7 +18,7 @@ public abstract class Filter {
     /**
      * A null <code>Filter</code> that passes all tests through.
      */
-    public static Filter ALL = new Filter() {
+    public static final Filter ALL = new Filter() {
         @Override
         public boolean shouldRun(Description description) {
             return true;


### PR DESCRIPTION
I found some "public static" fields that should be final (in my opinion), because someone could change them and break the internal behavior.

List of fields:
- MethodSorter.DEFAULT
- MethodSorter.NAME_ASCENDING
- Filter.ALL
