### PR TITLE
Modification to the ParameterizedTest to support private field for the @Parameter annotation.

### DIFF
--- a/src/main/java/org/junit/runners/Parameterized.java
+++ b/src/main/java/org/junit/runners/Parameterized.java
@@ -218,13 +218,21 @@ public class Parameterized extends Suite {
                 Field field = each.getField();
                 Parameter annotation = field.getAnnotation(Parameter.class);
                 int index = annotation.value();
+                boolean accessible = field.isAccessible();
                 try {
+                    if (!accessible) {
+                        field.setAccessible(true);
+                    }
                     field.set(testClassInstance, fParameters[index]);
                 } catch (IllegalArgumentException iare) {
                     throw new Exception(getTestClass().getName() + ": Trying to set " + field.getName() +
                             " with the value " + fParameters[index] +
                             " that is not the right type (" + fParameters[index].getClass().getSimpleName() + " instead of " +
                             field.getType().getSimpleName() + ").", iare);
+                } finally {
+                    if (!accessible) {
+                        field.setAccessible(false);
+                    }
                 }
             }
             return testClassInstance;

--- a/src/test/java/org/junit/tests/running/classes/ParameterizedTestTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParameterizedTestTest.java
@@ -116,10 +116,10 @@ public class ParameterizedTestTest {
         }
 
         @Parameter(0)
-        public int fInput;
+        private int fInput;
 
         @Parameter(1)
-        public int fExpected;
+        private int fExpected;
 
         @Test
         public void test() {


### PR DESCRIPTION
This is a change to both support public and private field for Parameterized test. For some developer, it is "more logical" to use private field for all fields.
