### PR TITLE
@ displayed incorrectly in javadocs

### DIFF
--- a/src/main/java/org/junit/Assume.java
+++ b/src/main/java/org/junit/Assume.java
@@ -16,7 +16,7 @@ import org.hamcrest.Matcher;
  * For example:
  * <pre>
  * // only provides information if database is reachable.
- * \@Test public void calculateTotalSalary() {
+ * &#064;Test public void calculateTotalSalary() {
  *    DBConnection dbc = Database.connect();
  *    assumeNotNull(dbc);
  *    // ...


### PR DESCRIPTION
This is how it's displayed when rendered: http://junit.org/javadoc/latest/org/junit/Assume.html

Used the same escaping strategy as in RunWith's javadocs source (https://github.com/junit-team/junit/blob/master/src/main/java/org/junit/runner/RunWith.java)
