### PR TITLE
For #855, remove FrameworkMethod.getParameterSignatures()

### DIFF
--- a/src/main/java/org/junit/experimental/theories/Theories.java
+++ b/src/main/java/org/junit/experimental/theories/Theories.java
@@ -78,7 +78,7 @@ public class Theories extends BlockJUnit4ClassRunner {
                 each.validatePublicVoidNoArg(false, errors);
             }
             
-            for (ParameterSignature signature : each.getParameterSignatures()) {
+            for (ParameterSignature signature : ParameterSignature.signatures(each.getMethod())) {
                 ParametersSuppliedBy annotation = signature.findDeepAnnotation(ParametersSuppliedBy.class);
                 if (annotation != null) {
                     validateParameterSupplier(annotation.value(), errors);

--- a/src/main/java/org/junit/runners/model/FrameworkMethod.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMethod.java
@@ -7,7 +7,6 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.List;
 
-import org.junit.experimental.theories.ParameterSignature;
 import org.junit.internal.runners.model.ReflectiveCallable;
 
 /**
@@ -196,10 +195,6 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
      */
     public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
         return fMethod.getAnnotation(annotationType);
-    }
-
-    public List<ParameterSignature> getParameterSignatures() {
-        return ParameterSignature.signatures(fMethod);
     }
 
     @Override


### PR DESCRIPTION
Having this method in place made a class from the "core" of JUnit
(org.junit.runners.model) depend on something from "experimental" --
a dependency going in the wrong direction.
