### PR TITLE
fixes #861

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -647,24 +647,27 @@ public class Assert {
     }
 
     /**
-     * @deprecated Use
-     *             <code>assertEquals(double expected, double actual, double delta)</code>
-     *             instead
+     * Asserts that two doubles are equal up to a bit representation.
+     * 
+     * @param expected expected value
+     * @param actual the value to check against
      */
-    @Deprecated
     static public void assertEquals(double expected, double actual) {
         assertEquals(null, expected, actual);
     }
 
     /**
-     * @deprecated Use
-     *             <code>assertEquals(String message, double expected, double actual, double delta)</code>
-     *             instead
+     * Asserts that two floats are equal up to a bit representation.
+     * If it is an {@link AssertionError} is thrown with the given message.
+     * 
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code>
+     * okay)
+     * @param expected expected value
+     * @param actual the value to check against
      */
-    @Deprecated
     static public void assertEquals(String message, double expected,
             double actual) {
-        fail("Use assertEquals(expected, actual, delta) to compare floating-point numbers");
+        assertEquals(message, expected, actual, 0.0d);
     }
 
     /**
@@ -684,6 +687,16 @@ public class Assert {
     }
 
     /**
+     * Asserts that two floats are equal up to a bit representation.
+     * 
+     * @param expected expected value
+     * @param actual the value to check against
+     */
+    static public void assertEquals(float expected, float actual) {
+        assertEquals(null, expected, actual, 0.0f);
+    }
+    
+    /**
      * Asserts that two floats are equal to within a positive delta.
      * If they are not, an {@link AssertionError} is thrown. If the expected
      * value is infinity then the delta value is ignored. NaNs are considered
@@ -695,7 +708,6 @@ public class Assert {
      * <code>actual</code> for which both numbers are still
      * considered equal.
      */
-
     static public void assertEquals(float expected, float actual, float delta) {
         assertEquals(null, expected, actual, delta);
     }

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -331,14 +331,22 @@ public class AssertionTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void floatsNotEqual() {
+    public void floatsNotEqualWithDelta() {
         assertEquals(1.0, 2.0, 0.9);
     }
+    
+    public void floatsEqualWithDelta() {
+        assertEquals(1.0, 2.0, 1.0);
+    }
 
-    @SuppressWarnings("deprecation")
     @Test(expected = AssertionError.class)
-    public void floatsNotEqualWithoutDelta() {
+    public void floatsNotEqual() {
         assertEquals(1.0, 1.1);
+    }
+    
+    @Test
+    public void floatsEqual() {
+        assertEquals(1.1, 1.1);
     }
 
     @Test
@@ -356,8 +364,22 @@ public class AssertionTest {
 
 
     @Test(expected = AssertionError.class)
-    public void doublesNotEqual() {
+    public void doublesNotEqualWithDelta() {
         assertEquals(1.0d, 2.0d, 0.9d);
+    }
+    
+    public void doublesEqualWithDelta() {
+        assertEquals(1.0d, 2.0d, 1.0d);
+    }
+    
+    @Test(expected = AssertionError.class)
+    public void doublesNotEqual() {
+        assertEquals(1.0d, 2.0d);
+    }
+    
+    @Test
+    public void doublesEqual() {
+        assertEquals(1.1d, 1.1d);
     }
 
     @Test


### PR DESCRIPTION
resurrecting assertEquals(double,double) and 
assertEquals(float,float) methods

Signed-off-by: Alexander Jipa alexander.jipa@gmail.com
