### PR TITLE
remove deprecation from array assertEquals

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -868,9 +868,7 @@ public class Assert {
      * expected values.
      * @param actuals Object array or array of arrays (multi-dimensional array) with
      * actual values
-     * @deprecated use assertArrayEquals
      */
-    @Deprecated
     public static void assertEquals(String message, Object[] expecteds,
             Object[] actuals) {
         assertArrayEquals(message, expecteds, actuals);
@@ -886,9 +884,7 @@ public class Assert {
      * expected values
      * @param actuals Object array or array of arrays (multi-dimensional array) with
      * actual values
-     * @deprecated use assertArrayEquals
      */
-    @Deprecated
     public static void assertEquals(Object[] expecteds, Object[] actuals) {
         assertArrayEquals(expecteds, actuals);
     }


### PR DESCRIPTION
deprecation is removed for array's assertEquals

Signed-off-by: Alexander Jipa alexander.jipa@gmail.com
