### PR TITLE
JUnit4TestAdapter with a class with no test methods should result in a Test with no children

### DIFF
--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -153,7 +153,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
     protected void validateOnlyOneConstructor(List<Throwable> errors) {
         if (!hasOneConstructor()) {
             String gripe = "Test class should have exactly one public constructor";
-            errors.add(new Exception(gripe));
+            errors.add(new InitializationError(gripe));
         }
     }
 
@@ -166,7 +166,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
                 && hasOneConstructor()
                 && (getTestClass().getOnlyConstructor().getParameterTypes().length != 0)) {
             String gripe = "Test class should have exactly one public zero-argument constructor";
-            errors.add(new Exception(gripe));
+            errors.add(new InitializationError(gripe));
         }
     }
 
@@ -186,7 +186,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         validateTestMethods(errors);
 
         if (computeTestMethods().size() == 0) {
-            errors.add(new Exception("No runnable methods"));
+            errors.add(new InitializationError("No runnable methods"));
         }
     }
 

--- a/src/main/java/org/junit/runners/model/InitializationError.java
+++ b/src/main/java/org/junit/runners/model/InitializationError.java
@@ -17,7 +17,28 @@ public class InitializationError extends Exception {
      * errors {@code errors} as causes
      */
     public InitializationError(List<Throwable> errors) {
+        super(getMessage(errors));
         fErrors = errors;
+    }
+    
+    private static String getMessage(List<Throwable> errors) {
+        switch(errors.size()) {
+            case 0: return null;
+            case 1: return errors.get(0).getMessage();
+            default:
+                StringBuilder cause = new StringBuilder();
+                int i = 0;
+                for(Throwable error : errors) {
+                    String message = error.getMessage();
+                    if(message != null) {
+                        if(i > 0) {
+                            cause.append('\n');
+                        }
+                        cause.append(i++).append('.').append(' ').append(message);
+                    }
+                }
+                return cause.toString();
+        }
     }
 
     public InitializationError(Throwable error) {

--- a/src/test/java/org/junit/tests/experimental/categories/CategoryTest.java
+++ b/src/test/java/org/junit/tests/experimental/categories/CategoryTest.java
@@ -440,7 +440,7 @@ public class CategoryTest {
     public void ignoredTest() {// behaves same as Suite
         Result result= JUnitCore.runClasses(IgnoredTestCategoriesSuite.class);
         assertFalse(result.wasSuccessful());
-        assertThat(result.getRunCount(), is(1));
+        assertThat(result.getRunCount(), is(0));
         assertThat(result.getFailureCount(), is(1));
         assertThat(result.getIgnoreCount(), is(1));
     }


### PR DESCRIPTION
wrapping several initialisation errors into one
not triggering notifier in case test is not run

Signed-off-by: Alexander Jipa <alexander.jipa@gmail.com>