### PR TITLE
Fix ErrorReportingRunner to not accept a null class (fixes #177)

### DIFF
--- a/src/main/java/org/junit/internal/runners/ErrorReportingRunner.java
+++ b/src/main/java/org/junit/internal/runners/ErrorReportingRunner.java
@@ -16,6 +16,9 @@ public class ErrorReportingRunner extends Runner {
     private final Class<?> fTestClass;
 
     public ErrorReportingRunner(Class<?> testClass, Throwable cause) {
+        if (testClass == null) {
+            throw new NullPointerException("Test class cannot be null");
+        }
         fTestClass = testClass;
         fCauses = getCauses(cause);
     }

--- a/src/test/java/org/junit/tests/internal/runners/ErrorReportingRunnerTest.java
+++ b/src/test/java/org/junit/tests/internal/runners/ErrorReportingRunnerTest.java
@@ -1,0 +1,11 @@
+package org.junit.tests.internal.runners;
+
+import org.junit.Test;
+import org.junit.internal.runners.ErrorReportingRunner;
+
+public class ErrorReportingRunnerTest {
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateWithNullClass() {
+        new ErrorReportingRunner(null, new RuntimeException());
+    }
+}


### PR DESCRIPTION
null check for test class in ErrorReportingRunner
