### PR TITLE
Add the default 'Implementation-*' headers to the manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,6 +289,19 @@
                    </dependency>
                </dependencies>
            </plugin>
+           <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-jar-plugin</artifactId>
+               <version>2.4</version>
+               <configuration>
+                   <archive>
+                       <addMavenDescriptor>false</addMavenDescriptor>
+                       <manifest>
+                           <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                       </manifest>
+                   </archive>
+               </configuration>
+           </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Added headers are:
Implementation-Title:     ${project.name}
Implementation-Version:   ${project.version}
Implementation-Vendor-Id: ${project.groupId}
Implementation-Vendor:    ${project.organization.name}

Related to #878

Signed-off-by: Ferry Huberts ferry.huberts@pelagic.nl
