### PR TITLE
Update plugins to current versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
                 the project, requires only release versions of dependencies of other artifacts.
                 -->
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.1.1</version>
+                <version>1.3.1</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -167,7 +167,7 @@
                 -->
                 <groupId>com.google.code.maven-replacer-plugin</groupId>
                 <artifactId>maven-replacer-plugin</artifactId>
-                <version>1.3.8</version>
+                <version>1.4.1</version>
                 <executions>
                     <execution>
                         <phase>process-sources</phase>
@@ -190,7 +190,7 @@
                 java compiler plugin forked in extra process
                 -->
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.1</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <source>${jdkVersion}</source>
@@ -223,7 +223,7 @@
                 in to jar archive. See target/junit-*-sources.jar.
                 -->
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2</version>
+                <version>2.2.1</version>
             </plugin>
             <plugin>
                 <!--
@@ -341,7 +341,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-changes-plugin</artifactId>
-                <version>2.9</version>
+                <version>2.10</version>
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -395,7 +395,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.3</version>
+                <version>2.4</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
com.google.code.maven-replacer-plugin:maven-replacer-plugin  1.3.8 -> 1.4.1
maven-changes-plugin .................................... 2.9 -> 2.10
maven-compiler-plugin .................................. 2.5.1 -> 3.1
maven-enforcer-plugin ................................ 1.1.1 -> 1.3.1
maven-jxr-plugin ......................................... 2.3 -> 2.4
maven-source-plugin .................................... 2.2 -> 2.2.1
