### PR TITLE
Sniffer plugin to check Java 5 signatures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,7 @@
                 <executions>
                     <execution>
                         <id>signature-check</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>


### PR DESCRIPTION
As discussed in #881, the Maven sniffer plugin guarantees that the JUnit code has Java 5 signatures.
Improved build process.

@stefanbirkner
@kcooney 
@marcphilipp
Feel free to have a look.
