### PR TITLE
Assert.assertCollectionEquals()

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -535,12 +535,46 @@ public class Assert {
         new ExactComparisonCriteria().arrayEquals(message, expecteds, actuals);
     }
     
+    /**
+     * Asserts that two collections are equal by checking if their size is the same and their iterators return
+     * the same (equal) objects in the same order.
+     * 
+     * If the collections don't contain the same elements or their size differs, then an {@link AssertionError} is
+     * thrown.
+     * 
+     * If the <code>size()</code> method of the <code>expected</code> and <code>actual</code> collection returned
+     * the same value, but the collection iterators don't return the same number of elements, then an
+     * {@link AssertionError} is thrown too.
+     * 
+     * @param expected expected collection
+     * @param actual actual collection
+     */
     public static <T> void assertCollectionEquals(Collection<T> expected, Collection<T> actual) {
         assertCollectionEquals(null, expected, actual);
     }
     
+    /**
+     * Asserts that two collections are equal by checking if their size is the same and their iterators return
+     * the same (equal) objects in the same order.
+     * 
+     * If the collections don't contain the same elements or their size differs, then an {@link AssertionError} is
+     * thrown.
+     * 
+     * If the <code>size()</code> method of the <code>expected</code> and <code>actual</code> collection returned
+     * the same value, but the collection iterators don't return the same number of elements, then an
+     * {@link AssertionError} is thrown too.
+     * 
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code> is permitted)
+     * @param expected expected collection
+     * @param actual actual collection
+     */
     public static <T> void assertCollectionEquals(String message, Collection<T> expected,
             Collection<T> actual) {
+        if (expected == null) {
+            assertNull(message, actual);
+        } else {
+            assertNotNull(message, actual);
+        }
         String failurePrefix = message == null ? "" : message + " ";
         if (expected.size() != actual.size())
             throw new AssertionError(failurePrefix + "expected size:" + expected.size()  + " but was:" + actual.size());

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -396,6 +396,16 @@ public class AssertionTest {
         List<String> actual = new LinkedList<String>(expected);
         assertCollectionEquals(expected, actual);
     }
+    
+    @Test(expected = AssertionError.class)
+    public void collectionNotEqualsExpectedNull() {
+        assertCollectionEquals(null, Arrays.asList(""));
+    }
+    
+    @Test(expected = AssertionError.class)
+    public void collectionNotEqualsActualNull() {
+        assertCollectionEquals(Arrays.asList(""), null);
+    }
 
     @Test 
     public void collectionNotEquals() {


### PR DESCRIPTION
This new assertion method asserts that the actual collection
- returns the same size() as the expected collection
- its iterator returns the same elements in the same order as the expected collection's iterator

I find myself often creating an expected List in my test using Arrays.asList() but the actual collection is an ArrayList instance. In such cases this new assertion method is useful.

The formal parameter types are Collection-s and not List-s therefore assertCollectionEquals() can be used to assert on SortedMap.keySet() values too.
