### PR TITLE
#892 Description.getMethodName() should not return null

### DIFF
--- a/src/main/java/org/junit/runner/Description.java
+++ b/src/main/java/org/junit/runner/Description.java
@@ -300,7 +300,7 @@ public class Description implements Serializable {
      *         the name of the method (or null if not)
      */
     public String getMethodName() {
-        return methodAndClassNamePatternGroupOrDefault(1, toString());
+        return methodAndClassNamePatternGroupOrDefault(1, null);
     }
 
     private String methodAndClassNamePatternGroupOrDefault(int group,


### PR DESCRIPTION
Hi,

As described in #892
Description.getMethodName() returns null when parametrized test contains "\n" symbols.

Proposed simple fix to avoid such behavior.

Thanks.
