### PR TITLE
Sniffer plugin to check Java 5 signatures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,6 +211,27 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>animal-sniffer-maven-plugin</artifactId>
+                <version>1.11</version>
+                <executions>
+                    <execution>
+                        <id>signature-check</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <signature>
+                                <groupId>org.codehaus.mojo.signature</groupId>
+                                <artifactId>java15</artifactId>
+                                <version>1.0</version>
+                            </signature>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <!--
                 A plugin which uses the JUnit framework in order to start
                 our junit suite "AllTests" after the sources are compiled.


### PR DESCRIPTION
As discussed in #881, the Maven sniffer plugin guarantees that the JUnit code has Java 5 signatures.
 Improved build process.

@stefanbirkner
 @kcooney 
@marcphilipp
 Feel free to have a look.
