### PR TITLE
add groupId org.apache.maven.plugins for official Apache Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
                 the JDK is 1.5+, no non-standard repositories are specified in
                 the project, requires only release versions of dependencies of other artifacts.
                 -->
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>1.3.1</version>
                 <executions>
@@ -195,6 +196,7 @@
                 <!--
                 java compiler plugin forked in extra process
                 -->
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
@@ -238,6 +240,7 @@
                 A plugin which uses the JUnit framework in order to start
                 our junit suite "AllTests" after the sources are compiled.
                 -->
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
@@ -251,6 +254,7 @@
                 This plugin can package the main artifact's sources (src/main/java)
                 in to jar archive. See target/junit-*-sources.jar.
                 -->
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>2.2.1</version>
             </plugin>
@@ -260,6 +264,7 @@
                 process and then package the Javadoc
                 in jar archive target/junit-*-javadoc.jar.
                 -->
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
                 <configuration>
@@ -293,6 +298,7 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5</version>
                 <configuration>
@@ -303,6 +309,7 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.3</version>
                 <dependencies>
@@ -319,6 +326,7 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
@@ -336,6 +344,7 @@
     <reporting>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>2.7</version>
                 <configuration>
@@ -366,6 +375,7 @@
                 </reportSets>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-changes-plugin</artifactId>
                 <version>2.10</version>
                 <reportSets>
@@ -378,6 +388,7 @@
                 </reportSets>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
                 <configuration>
@@ -418,10 +429,12 @@
                 </reportSets>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jxr-plugin</artifactId>
                 <version>2.4</version>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>2.17</version>
             </plugin>
@@ -444,6 +457,7 @@
                         In order to create the key pair, use the command "gpg &ndash;&ndash;gen-key".
                         (&ndash;&ndash; stands for double dash)
                         -->
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>1.5</version>
                         <executions>
@@ -469,6 +483,7 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
                         <executions>
                             <execution>
@@ -481,6 +496,7 @@
                         </executions>
                     </plugin>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>
                             <execution>


### PR DESCRIPTION
We know that :   Calling it maven-< yourplugin >-plugin (note "Maven" is at the beginning of the plugin name) is strongly discouraged since it's a reserved naming pattern for official Apache Maven plugins maintained by the Apache Maven team with groupId org.apache.maven.plugins. Using this naming pattern is an infringement of the Apache Maven Trademark.   from http://maven.apache.org/guides/plugin/guide-java-plugin-development.html#Plugin_Naming_Convention_and_Apache_Maven_Trademark , but some plugins  may not keep this standard. 

For Example: maven-replacer-plugin(version 1.4.1) in pom belongs  < groupId >com.google.code.maven-replacer-plugin< /groupId >, though its artifactId was renamed to "replacer" from "maven-replacer-plugin" due to a naming policy change from the Maven team since version 1.5.0. Pls see http://code.google.com/p/maven-replacer-plugin/ 

If we add < groupId >org.apache.maven.plugins< /groupId > for official Apache Maven plugins, there will be no ambiguity.
