### PR TITLE
Avoid a potentially expensive reflection-based loop in assertArrayEquals...

### DIFF
--- a/src/main/java/org/junit/internal/ComparisonCriteria.java
+++ b/src/main/java/org/junit/internal/ComparisonCriteria.java
@@ -1,6 +1,7 @@
 package org.junit.internal;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 
 import org.junit.Assert;
 
@@ -24,7 +25,11 @@ public abstract class ComparisonCriteria {
      */
     public void arrayEquals(String message, Object expecteds, Object actuals)
             throws ArrayComparisonFailure {
-        if (expecteds == actuals) {
+        if (expecteds == actuals
+            || Arrays.deepEquals(new Object[] {expecteds}, new Object[] {actuals})) {
+            // The reflection-based loop below is potentially very slow, especially for primitive
+            // arrays. The deepEquals check allows us to circumvent it in the usual case where
+            // the arrays are exactly equal.
             return;
         }
         String header = message == null ? "" : message + ": ";


### PR DESCRIPTION
..., in the usual case where the arrays are in fact exactly equal.

This is purely a performance optimization so there are no new tests. For primitive arrays, the Arrays.deepEquals method quickly dispatches to the appropriate overload of Arrays.equals, which simply loops over the elements in the expected way. Additionally, Arrays.equals(char[], char[]) is intrinsified by the HotSpot VM so the boost there should be even more substantial.
