### PR TITLE
Add a new abstract test rule to delay the building of the rule

### DIFF
--- a/src/main/java/org/junit/rules/DeferredRule.java
+++ b/src/main/java/org/junit/rules/DeferredRule.java
@@ -1,0 +1,57 @@
+package org.junit.rules;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * This rule can be use to build another rule, but only just before using it.
+ * This can be used to support rule that need data provided by another rule (and
+ * these data are only available after the initialization of the other rule).
+ * 
+ * @author borettim
+ * 
+ * @param <T>
+ */
+public abstract class DeferredRule<T extends TestRule> implements TestRule {
+    /**
+     * Implements this method to build the rule.
+     * 
+     * @return the rule
+     */
+    protected abstract T build();
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.junit.rules.TestRule#apply(org.junit.runners.model.Statement,
+     * org.junit.runner.Description)
+     */
+    public Statement apply(Statement base, Description description) {
+        return statement(base, description);
+    }
+
+    private T rule;
+
+    /**
+     * Retrieve the rule that has been used.
+     * 
+     * @return the rule
+     */
+    public T getRule() {
+        return rule;
+    }
+
+    private Statement statement(final Statement base,
+            final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                rule= build();
+                rule.apply(base, description).evaluate();
+            }
+        };
+    }
+
+}
+
+

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -42,6 +42,7 @@ import org.junit.tests.experimental.parallel.ParallelClassTest;
 import org.junit.tests.experimental.parallel.ParallelMethodTest;
 import org.junit.tests.experimental.rules.BlockJUnit4ClassRunnerOverrideTest;
 import org.junit.tests.experimental.rules.ClassRulesTest;
+import org.junit.tests.experimental.rules.DeferredRuleTest;
 import org.junit.tests.experimental.rules.ExpectedExceptionTest;
 import org.junit.tests.experimental.rules.ExternalResourceRuleTest;
 import org.junit.tests.experimental.rules.MethodRulesTest;
@@ -171,6 +172,7 @@ import org.junit.validator.PublicClassValidatorTest;
         JUnit38SortingTest.class,
         MethodRulesTest.class,
         TestRuleTest.class,
+        DeferredRuleTest.class,
         TimeoutRuleTest.class,
         ParallelClassTest.class,
         ParallelMethodTest.class,

--- a/src/test/java/org/junit/tests/experimental/rules/DeferredRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/DeferredRuleTest.java
@@ -1,0 +1,63 @@
+package org.junit.tests.experimental.rules;
+
+import junit.tests.framework.AssertTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DeferredRule;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+public class DeferredRuleTest {
+    
+    private int counter=0;
+
+    private final TestRule around= new ExternalResource() {
+        @Override
+        protected void before() throws Throwable {
+            assertThat(counter,is(0));
+            counter++;
+        }
+
+        @Override
+        protected void after() {
+            assertThat(counter,is(5));
+            counter++;
+        }
+
+    };
+
+    private final TestRule inner= new DeferredRule<TestRule>() {
+
+        @Override
+        protected TestRule build() {
+            assertThat(counter,is(1));
+            counter++;
+            return new ExternalResource() {
+
+                @Override
+                protected void before() throws Throwable {
+                    assertThat(counter,is(2));
+                    counter++;
+                }
+
+                @Override
+                protected void after() {
+                    assertThat(counter,is(4));
+                    counter++;
+                }
+            };
+        }
+    };
+
+    @Rule
+    public TestRule alls= RuleChain.outerRule(around).around(inner);
+
+    @Test
+    public void testSequence() {
+        assertThat(counter,is(3));
+        counter++;
+    }
+}


### PR DESCRIPTION
The purpose of this new Test Rule is to provide a way to delay the construction of the real used rule.

In some case, one rule require the output of another rule to be builded. As the required value is not available at this time, this rule provide a way to construct another rule, just before using it.

For instance, assume you have one rule (implementing ExternalResource), which provide access to a server, but only start this server (and so defining the URL) in the before method. If you have another rule that need this URL as a parameter, it will not work because the URL is not available at construct time.

Using DeferredRule, in this situation, it will be possible to construct the real rule (that need the URL), after the before method of the previous rule has been run.

The test case provide an example of how the rule are chained.
