### PR TITLE
Add overload of TestWatcher.skipped() that uses the external AssumptionViolationException

### DIFF
--- a/src/main/java/org/junit/rules/Stopwatch.java
+++ b/src/main/java/org/junit/rules/Stopwatch.java
@@ -1,6 +1,6 @@
 package org.junit.rules;
 
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
 
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/org/junit/rules/TestWatcher.java
+++ b/src/main/java/org/junit/rules/TestWatcher.java
@@ -3,7 +3,7 @@ package org.junit.rules;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
@@ -54,7 +54,7 @@ public abstract class TestWatcher implements TestRule {
                 try {
                     base.evaluate();
                     succeededQuietly(description, errors);
-                } catch (AssumptionViolatedException e) {
+                } catch (@SuppressWarnings("deprecation") org.junit.internal.AssumptionViolatedException  e) {
                     errors.add(e);
                     skippedQuietly(e, description, errors);
                 } catch (Throwable e) {
@@ -87,10 +87,16 @@ public abstract class TestWatcher implements TestRule {
         }
     }
 
-    private void skippedQuietly(AssumptionViolatedException e, Description description,
+    @SuppressWarnings("deprecation")
+    private void skippedQuietly(
+            org.junit.internal.AssumptionViolatedException e, Description description,
             List<Throwable> errors) {
         try {
-            skipped(e, description);
+            if (e instanceof AssumptionViolatedException) {
+                skipped((AssumptionViolatedException) e, description);
+            } else {
+                skipped(e, description);
+            }
         } catch (Throwable e1) {
             errors.add(e1);
         }
@@ -129,7 +135,21 @@ public abstract class TestWatcher implements TestRule {
     /**
      * Invoked when a test is skipped due to a failed assumption.
      */
+    @SuppressWarnings("deprecation")
     protected void skipped(AssumptionViolatedException e, Description description) {
+        // For backwards compatibility with JUnit 4.11 and earlier, call the legacy version
+        org.junit.internal.AssumptionViolatedException asInternalException = e;
+        skipped(asInternalException, description);
+    }
+
+    /**
+     * Invoked when a test is skipped due to a failed assumption.
+     *
+     * @deprecated use {@link #skipped(AssumptionViolatedException, Description)}
+     */
+    @Deprecated
+    protected void skipped(
+            org.junit.internal.AssumptionViolatedException e, Description description) {
     }
 
     /**

--- a/src/test/java/org/junit/tests/experimental/rules/LoggingTestWatcher.java
+++ b/src/test/java/org/junit/tests/experimental/rules/LoggingTestWatcher.java
@@ -1,5 +1,6 @@
 package org.junit.tests.experimental.rules;
 
+import org.junit.AssumptionViolatedException;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
@@ -18,6 +19,11 @@ class LoggingTestWatcher extends TestWatcher {
     @Override
     protected void failed(Throwable e, Description description) {
         log.append("failed ");
+    }
+
+    @Override
+    protected void skipped(AssumptionViolatedException e, Description description) {
+        log.append("skipped ");
     }
 
     @Override

--- a/src/test/java/org/junit/tests/experimental/rules/StopwatchTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/StopwatchTest.java
@@ -1,14 +1,13 @@
 package org.junit.tests.experimental.rules;
 
+import org.junit.AssumptionViolatedException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.Stopwatch;
 import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
-
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/junit/tests/experimental/rules/TestWatcherTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TestWatcherTest.java
@@ -34,7 +34,41 @@ public class TestWatcherTest {
         ViolatedAssumptionTest.watchedLog = new StringBuilder();
         runClasses(ViolatedAssumptionTest.class);
         assertThat(ViolatedAssumptionTest.watchedLog.toString(),
-                is("starting finished "));
+                is("starting skipped finished "));
+    }
+
+    public static class InternalViolatedAssumptionTest {
+        private static StringBuilder watchedLog = new StringBuilder();
+
+        @Rule
+        public TestRule watcher = new TestWatcher() {
+            @Override
+            protected void starting(Description description) {
+                watchedLog.append("starting ");
+            }
+
+            @Override
+            protected void finished(Description description) {
+                watchedLog.append("finished ");
+            }
+
+            protected void skipped(AssumptionViolatedException e, Description description) {
+                watchedLog.append("skipped ");
+            }
+        };
+
+        @Test
+        public void succeeds() {
+            throw new AssumptionViolatedException("don't run");
+        }
+    }
+
+    @Test
+    public void internalViolatedAssumption() {
+        InternalViolatedAssumptionTest.watchedLog = new StringBuilder();
+        runClasses(InternalViolatedAssumptionTest.class);
+        assertThat(InternalViolatedAssumptionTest.watchedLog.toString(),
+                is("starting skipped finished "));
     }
 
     public static class TestWatcherSkippedThrowsExceptionTest {


### PR DESCRIPTION
Add overload of TestWatcher.skipped() that uses the external AssumptionViolationException

This allows code using TestWatcher to handle assumption violation exceptions
without using deprecated classes.
