### PR TITLE
Make ParameterizedAssertionError override hashCode()

### DIFF
--- a/src/main/java/org/junit/experimental/theories/internal/ParameterizedAssertionError.java
+++ b/src/main/java/org/junit/experimental/theories/internal/ParameterizedAssertionError.java
@@ -18,6 +18,11 @@ public class ParameterizedAssertionError extends AssertionError {
         return obj instanceof ParameterizedAssertionError && toString().equals(obj.toString());
     }
 
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
     public static String join(String delimiter, Object... params) {
         return join(delimiter, Arrays.asList(params));
     }

--- a/src/test/java/org/junit/tests/experimental/theories/internal/ParameterizedAssertionErrorTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/internal/ParameterizedAssertionErrorTest.java
@@ -54,15 +54,28 @@ public class ParameterizedAssertionErrorTest {
     @Theory
     public void equalsReturnsTrue(Throwable targetException, String methodName,
             Object[] params) {
-        assertThat(new ParameterizedAssertionError(targetException, methodName,
-                params), is(new ParameterizedAssertionError(targetException,
-                methodName, params)));
+        assertThat(
+                new ParameterizedAssertionError(targetException, methodName, params),
+                is(new ParameterizedAssertionError(targetException, methodName, params)));
+    }
+
+    @Theory
+    public void sameHashCodeWhenEquals(Throwable targetException, String methodName,
+            Object[] params) {
+        ParameterizedAssertionError one = new ParameterizedAssertionError(
+                targetException, methodName, params);
+        ParameterizedAssertionError two = new ParameterizedAssertionError(
+                targetException, methodName, params);
+        assumeThat(one, is(two));
+
+        assertThat(one.hashCode(), is(two.hashCode()));
     }
 
     @Theory(nullsAccepted = false)
     public void buildParameterizedAssertionError(String methodName, String param) {
-        assertThat(new ParameterizedAssertionError(new RuntimeException(),
-                methodName, param).toString(), containsString(methodName));
+        assertThat(new ParameterizedAssertionError(
+                new RuntimeException(), methodName, param).toString(),
+                containsString(methodName));
     }
 
     @Theory


### PR DESCRIPTION
ParameterizedAssertionError overrides equals() so it should override hashCode()
