### PR TITLE
support for assertEquals([String message, ] CharSequence, CharSequence)

### DIFF
--- a/src/main/java/junit/framework/Assert.java
+++ b/src/main/java/junit/framework/Assert.java
@@ -112,9 +112,8 @@ public class Assert {
      * 
      * @author Michael Vorburger
      */
-    @SuppressWarnings("deprecation")
     public static void assertEquals(String message, CharSequence expected, CharSequence actual) {
-        Assert.assertEquals(message, expected.toString(), actual.toString());
+        assertEquals(message, expected.toString(), actual.toString());
     }
 
     /**
@@ -122,9 +121,8 @@ public class Assert {
      * 
      * @author Michael Vorburger
      */
-    @SuppressWarnings("deprecation")
     public static void assertEquals(CharSequence expected, CharSequence actual) {
-        Assert.assertEquals(expected.toString(), actual.toString());
+        assertEquals(expected.toString(), actual.toString());
     }
 
     /**

--- a/src/main/java/junit/framework/Assert.java
+++ b/src/main/java/junit/framework/Assert.java
@@ -106,6 +106,26 @@ public class Assert {
     static public void assertEquals(String expected, String actual) {
         assertEquals(null, expected, actual);
     }
+    
+    /**
+     * Asserts that two CharSequence are equal.
+     * 
+     * @author Michael Vorburger
+     */
+    @SuppressWarnings("deprecation")
+    public static void assertEquals(String message, CharSequence expected, CharSequence actual) {
+        Assert.assertEquals(message, expected.toString(), actual.toString());
+    }
+
+    /**
+     * Asserts that two CharSequence are equal.
+     * 
+     * @author Michael Vorburger
+     */
+    @SuppressWarnings("deprecation")
+    public static void assertEquals(CharSequence expected, CharSequence actual) {
+        Assert.assertEquals(expected.toString(), actual.toString());
+    }
 
     /**
      * Asserts that two doubles are equal concerning a delta.  If they are not

--- a/src/main/java/junit/framework/Assert.java
+++ b/src/main/java/junit/framework/Assert.java
@@ -106,24 +106,6 @@ public class Assert {
     static public void assertEquals(String expected, String actual) {
         assertEquals(null, expected, actual);
     }
-    
-    /**
-     * Asserts that two CharSequence are equal.
-     * 
-     * @author Michael Vorburger
-     */
-    public static void assertEquals(String message, CharSequence expected, CharSequence actual) {
-        assertEquals(message, expected.toString(), actual.toString());
-    }
-
-    /**
-     * Asserts that two CharSequence are equal.
-     * 
-     * @author Michael Vorburger
-     */
-    public static void assertEquals(CharSequence expected, CharSequence actual) {
-        assertEquals(expected.toString(), actual.toString());
-    }
 
     /**
      * Asserts that two doubles are equal concerning a delta.  If they are not

--- a/src/main/java/junit/framework/TestCase.java
+++ b/src/main/java/junit/framework/TestCase.java
@@ -262,16 +262,6 @@ public abstract class TestCase extends Assert implements Test {
     }
 
     /**
-     * Asserts that two CharSequence are equal.
-     * 
-     * @author Michael Vorburger
-     */
-    @SuppressWarnings("deprecation")
-    public static void assertEquals(String message, CharSequence expected, CharSequence actual) {
-        Assert.assertEquals(message, expected, actual);
-    }
-
-    /**
      * Asserts that two Strings are equal.
      */
     @SuppressWarnings("deprecation")
@@ -281,12 +271,18 @@ public abstract class TestCase extends Assert implements Test {
 
     /**
      * Asserts that two CharSequence are equal.
-     * 
-     * @author Michael Vorburger
      */
     @SuppressWarnings("deprecation")
-    public static void assertEquals(CharSequence expected, CharSequence actual) {
-        Assert.assertEquals(expected, actual);
+    protected static void assertEquals(String message, CharSequence expected, CharSequence actual) {
+        Assert.assertEquals(message, expected.toString(), actual.toString());
+    }
+
+    /**
+     * Asserts that two CharSequence are equal.
+     */
+    @SuppressWarnings("deprecation")
+    protected void assertEquals(CharSequence expected, CharSequence actual) {
+        Assert.assertEquals(expected.toString(), actual.toString());
     }
 
     /**

--- a/src/main/java/junit/framework/TestCase.java
+++ b/src/main/java/junit/framework/TestCase.java
@@ -262,10 +262,30 @@ public abstract class TestCase extends Assert implements Test {
     }
 
     /**
+     * Asserts that two CharSequence are equal.
+     * 
+     * @author Michael Vorburger
+     */
+    @SuppressWarnings("deprecation")
+    public static void assertEquals(String message, CharSequence expected, CharSequence actual) {
+        Assert.assertEquals(message, expected, actual);
+    }
+
+    /**
      * Asserts that two Strings are equal.
      */
     @SuppressWarnings("deprecation")
     public static void assertEquals(String expected, String actual) {
+        Assert.assertEquals(expected, actual);
+    }
+
+    /**
+     * Asserts that two CharSequence are equal.
+     * 
+     * @author Michael Vorburger
+     */
+    @SuppressWarnings("deprecation")
+    public static void assertEquals(CharSequence expected, CharSequence actual) {
         Assert.assertEquals(expected, actual);
     }
 

--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -110,10 +110,11 @@ public class Assert {
             Object actual) {
         if (equalsRegardingNull(expected, actual)) {
             return;
-        } else if (expected instanceof String && actual instanceof String) {
+        } else if (expected instanceof CharSequence && actual instanceof CharSequence) {
             String cleanMessage = message == null ? "" : message;
-            throw new ComparisonFailure(cleanMessage, (String) expected,
-                    (String) actual);
+            throw new ComparisonFailure(cleanMessage,
+                    ((CharSequence) expected).toString(),
+                    ((CharSequence) actual).toString());
         } else {
             failNotEquals(message, expected, actual);
         }

--- a/src/test/java/junit/tests/framework/ComparisonFailureTest.java
+++ b/src/test/java/junit/tests/framework/ComparisonFailureTest.java
@@ -44,4 +44,37 @@ public class ComparisonFailureTest extends TestCase {
         }
         fail();
     }
+    
+    /**
+     * Tests that assertEquals(CharSequence, CharSequence) throws a
+     * ComparisonFailure instead of just an AssertionFailedError.
+     * 
+     * This is important so that IDE views such as Eclipse' Result Comparison
+     * pop-up work; note that the diff is only available if a test fails with a
+     * ComparisonFailureError.
+     * 
+     * @author Michael Vorburger
+     */
+    public void testCharSequence() {
+        try {
+            CharSequence cs1 = new StringBuilder("a"); // NOT just "a";
+            CharSequence cs2 = new StringBuilder("b"); // NOT just "b";
+            assertEquals(cs1, cs2);
+        } catch (ComparisonFailure e) {
+            return;
+        }
+        fail();
+    }
+
+    public void testCharSequenceWithUserMessage() {
+        try {
+            CharSequence cs1 = new StringBuilder("a"); // NOT just "a";
+            CharSequence cs2 = new StringBuilder("b"); // NOT just "b";
+            assertEquals("NOK", cs1, cs2);
+        } catch (ComparisonFailure e) {
+            return;
+        }
+        fail();
+    }
+
 }

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -222,9 +222,45 @@ public class AssertionTest {
     public void stringsDifferWithUserMessage() {
         try {
             assertEquals("not equal", "one", "two");
-        } catch (Throwable exception) {
+        } catch (ComparisonFailure exception) {
             assertEquals("not equal expected:<[one]> but was:<[two]>", exception.getMessage());
+            return;
         }
+        fail();
+    }
+
+    /**
+     * Tests that assertEquals(CharSequence, CharSequence) throws a
+     * ComparisonFailure instead of just an AssertionFailedError.
+     * 
+     * This is important so that IDE views such as Eclipse' Result Comparison
+     * pop-up work; note that the diff is only available if a test fails with a
+     * ComparisonFailureError.
+     * 
+     * @author Michael Vorburger
+     */
+    @Test
+    public void charSequence() {
+        try {
+            CharSequence cs1 = new StringBuilder("a"); // NOT just "a";
+            CharSequence cs2 = new StringBuilder("b"); // NOT just "b";
+            assertEquals(cs1, cs2);
+        } catch (ComparisonFailure e) {
+            return;
+        }
+        fail();
+    }
+
+    @Test
+    public void charSequenceWithUserMessage() {
+        try {
+            CharSequence cs1 = new StringBuilder("a"); // NOT just "a";
+            CharSequence cs2 = new StringBuilder("b"); // NOT just "b";
+            assertEquals("NOK", cs1, cs2);
+        } catch (ComparisonFailure e) {
+            return;
+        }
+        fail();
     }
 
     @Test


### PR DESCRIPTION
This contribution fixes a problem I've run into when using assertEquals on two CharSequence.

It basically already works, of course - BUT one is left wondering why e.g. the Eclipse (and presumably other IDE as well) JUnit view's Result Comparison pop-up does not work on double-clicking a failure.. this is because, currently, assertEquals on two CharSequence throws only a generic AssertionFailedError and not the ComparisonFailure expected by such UIs.

PS: As the pom.xml specifies jdk.version 1.5 and <compilerVersion>1.5</compilerVersion>,  I was assuming, hopefully correctly, that introducing a @since 1.4 CharSequence was not a problem for backward compat.