### PR TITLE
TestRule to disable specific other TestRules when debugging without modification to the test class

### DIFF
--- a/src/main/java/org/junit/rules/DisableOnDebug.java
+++ b/src/main/java/org/junit/rules/DisableOnDebug.java
@@ -1,0 +1,127 @@
+package org.junit.rules;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * The {@code DisableOnDebug} Rule allows you to label certain rules to be
+ * disabled when debugging.
+ * <p>
+ * The most illustrative use case is for tests that make use of the
+ * {@link Timeout} rule, when ran in debug mode the test may terminate on
+ * timeout abruptly during debugging. Developers may disable the timeout, or
+ * increase the timeout by making a code change on tests that need debugging and
+ * remember revert the change afterwards or rules such as {@link Timeout} that
+ * may be disabled during debugging may be wrapped in a {@code DisableOnDebug}.
+ * <p>
+ * The important benefit of this feature is that you can disable such rules
+ * without any making any modifications to your test class to remove them during
+ * debugging.
+ * <p>
+ * This does nothing to tackle timeouts or time sensitive code under test when
+ * debugging and may make this less useful in such circumstances.
+ * <p>
+ * Example usage:
+ * 
+ * <pre>
+ * public static class DisableTimeoutOnDebugSampleTest {
+ * 
+ *     &#064;Rule
+ *     public TestRule timeout = new DisableOnDebug(new Timeout(20));
+ * 
+ *     &#064;Test
+ *     public void myTest() {
+ *         int i = 0;
+ *         assertEquals(0, i); // suppose you had a break point here to inspect i
+ *     }
+ * }
+ * </pre>
+ * 
+ * @since 4.12
+ */
+public class DisableOnDebug implements TestRule {
+    private final TestRule rule;
+    private final boolean debugging;
+
+    /**
+     * Create a {@code DisableOnDebug} instance with the timeout specified in
+     * milliseconds.
+     * 
+     * @param rule to disable during debugging
+     */
+    public DisableOnDebug(TestRule rule) {
+        this(rule, ManagementFactory.getRuntimeMXBean()
+                .getInputArguments());
+    }
+
+    /**
+     * Visible for testing purposes only.
+     * 
+     * @param rule the rule to disable during debugging
+     * @param inputArguments
+     *            arguments provided to the Java runtime
+     */
+    DisableOnDebug(TestRule rule, List<String> inputArguments) {
+        this.rule = rule;
+        debugging = isDebugging(inputArguments);
+    }
+
+    /**
+     * @see TestRule#apply(Statement, Description)
+     */
+    public Statement apply(Statement base, Description description) {
+        if (debugging) {
+            return base;
+        } else {
+            return rule.apply(base, description);
+        }
+    }
+
+    /**
+     * Parses arguments passed to the runtime environment for debug flags
+     * <p>
+     * Options specified in:
+     * <ul>
+     * <li>
+     * <a href="http://docs.oracle.com/javase/6/docs/technotes/guides/jpda/conninv.html#Invocation"
+     * >javase-6</a></li>
+     * <li><a href="http://docs.oracle.com/javase/7/docs/technotes/guides/jpda/conninv.html#Invocation"
+     * >javase-7</a></li>
+     * <li><a href="http://docs.oracle.com/javase/8/docs/technotes/guides/jpda/conninv.html#Invocation"
+     * >javase-8</a></li>
+     * 
+     * 
+     * @param arguments
+     *            the arguments passed to the runtime environment, usually this
+     *            will be {@link RuntimeMXBean#getInputArguments()}
+     * @return true if the current JVM was started in debug mode, false
+     *         otherwise.
+     */
+    private static boolean isDebugging(List<String> arguments) {
+        for (final String argument : arguments) {
+            if ("-Xdebug".equals(argument)) {
+                return true;
+            } else if (argument.startsWith("-agentlib:jdwp")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if the JVM is in debug mode. This method may be used
+     * by test classes to take additional action to disable code paths that
+     * interfere with debugging if required.
+     * 
+     * @return {@code true} if the current JVM is in debug mode, {@code false}
+     *         otherwise
+     */
+    public boolean isDebugging() {
+        return debugging;
+    }
+
+}

--- a/src/test/java/org/junit/rules/DisableOnDebugTest.java
+++ b/src/test/java/org/junit/rules/DisableOnDebugTest.java
@@ -1,0 +1,164 @@
+package org.junit.rules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runners.model.Statement;
+
+public class DisableOnDebugTest {
+    private static final List<String> WITHOUT_DEBUG_ARGUMENTS = Collections
+            .emptyList();
+
+    private static final List<String> PRE_JAVA5_DEBUG_ARGUMENTS = Arrays
+            .asList("-Xdebug",
+                    "-Xrunjdwp:transport=dt_socket,server=y,address=8000");
+
+    private static final List<String> PRE_JAVA5_DEBUG_ARGUMENTS_IN_REVERSE_ORDER = Arrays
+            .asList("-Xrunjdwp:transport=dt_socket,server=y,address=8000",
+                    "-Xdebug");
+
+    private static final List<String> POST_JAVA5_DEBUG_ARGUMENTS = Arrays
+            .asList("-agentlib:jdwp=transport=dt_socket,server=y,address=8000");
+
+    /**
+     * Nasty rule that always fails
+     */
+    private static class FailOnExecution implements TestRule {
+
+        public Statement apply(Statement base,
+                Description description) {
+            return new Statement() {
+
+                @Override
+                public void evaluate() throws Throwable {
+                    throw new AssertionError();
+                }
+            };
+        }
+
+    }
+
+    public static abstract class AbstractDisableOnDebugTest {
+
+        @Rule
+        public TestRule failOnExecution;
+
+        public AbstractDisableOnDebugTest(List<String> arguments) {
+            this.failOnExecution = new DisableOnDebug(new FailOnExecution(),
+                    arguments);
+        }
+
+        @Test
+        public void test() {
+        }
+    }
+
+    public static class PreJava5DebugArgumentsTest extends
+            AbstractDisableOnDebugTest {
+
+        public PreJava5DebugArgumentsTest() {
+            super(PRE_JAVA5_DEBUG_ARGUMENTS);
+        }
+
+    }
+
+    public static class PreJava5DebugArgumentsReversedTest extends
+            AbstractDisableOnDebugTest {
+
+        public PreJava5DebugArgumentsReversedTest() {
+            super(PRE_JAVA5_DEBUG_ARGUMENTS_IN_REVERSE_ORDER);
+        }
+
+    }
+
+    public static class PostJava5DebugArgumentsTest extends
+            AbstractDisableOnDebugTest {
+
+        public PostJava5DebugArgumentsTest() {
+            super(POST_JAVA5_DEBUG_ARGUMENTS);
+        }
+
+    }
+
+    public static class WithoutDebugArgumentsTest extends
+            AbstractDisableOnDebugTest {
+
+        public WithoutDebugArgumentsTest() {
+            super(WITHOUT_DEBUG_ARGUMENTS);
+        }
+
+    }
+
+    @Test
+    public void givenPreJava5DebugArgumentsIsDebuggingShouldReturnTrue() {
+        DisableOnDebug subject = new DisableOnDebug(
+                new FailOnExecution(), PRE_JAVA5_DEBUG_ARGUMENTS);
+        assertTrue("Should be debugging", subject.isDebugging());
+    }
+
+    @Test
+    public void givenPreJava5DebugArgumentsInReverseIsDebuggingShouldReturnTrue() {
+        DisableOnDebug subject = new DisableOnDebug(
+                new FailOnExecution(),
+                PRE_JAVA5_DEBUG_ARGUMENTS_IN_REVERSE_ORDER);
+        assertTrue("Should be debugging", subject.isDebugging());
+    }
+
+    @Test
+    public void givenPostJava5DebugArgumentsIsDebuggingShouldReturnTrue() {
+        DisableOnDebug subject = new DisableOnDebug(
+                new FailOnExecution(), POST_JAVA5_DEBUG_ARGUMENTS);
+        assertTrue("Should be debugging", subject.isDebugging());
+    }
+
+    @Test
+    public void givenArgumentsWithoutDebugFlagsIsDebuggingShouldReturnFalse() {
+        DisableOnDebug subject = new DisableOnDebug(
+                new FailOnExecution(), WITHOUT_DEBUG_ARGUMENTS);
+        Assert.assertFalse("Should not be debugging", subject.isDebugging());
+    }
+
+    @Test
+    public void whenRunWithPreJava5DebugArgumentsTestShouldFail() {
+        JUnitCore core = new JUnitCore();
+        Result result = core.run(PreJava5DebugArgumentsTest.class);
+        assertEquals("Should run the test", 1, result.getRunCount());
+        assertEquals("Test should not have failed", 0, result.getFailureCount());
+    }
+
+    @Test
+    public void whenRunWithPreJava5DebugArgumentsInReverseOrderTestShouldFail() {
+        JUnitCore core = new JUnitCore();
+        Result result = core
+                .run(PreJava5DebugArgumentsReversedTest.class);
+        assertEquals("Should run the test", 1, result.getRunCount());
+        assertEquals("Test should not have failed", 0, result.getFailureCount());
+    }
+
+    @Test
+    public void whenRunWithPostJava5DebugArgumentsTestShouldFail() {
+        JUnitCore core = new JUnitCore();
+        Result result = core.run(PostJava5DebugArgumentsTest.class);
+        assertEquals("Should run the test", 1, result.getRunCount());
+        assertEquals("Test should not have failed", 0, result.getFailureCount());
+    }
+
+    @Test
+    public void whenRunWithoutDebugFlagsTestShouldPass() {
+        JUnitCore core = new JUnitCore();
+        Result result = core.run(WithoutDebugArgumentsTest.class);
+        assertEquals("Should run the test", 1, result.getRunCount());
+        assertEquals("Test should have failed", 1, result.getFailureCount());
+    }
+
+}

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -6,6 +6,7 @@ import org.junit.AssumptionViolatedExceptionTest;
 import org.junit.experimental.categories.CategoryFilterFactoryTest;
 import org.junit.internal.MethodSorterTest;
 import org.junit.internal.matchers.StacktracePrintingMatcherTest;
+import org.junit.rules.DisableOnDebugTest;
 import org.junit.rules.StopwatchTest;
 import org.junit.runner.FilterFactoriesTest;
 import org.junit.runner.FilterOptionIntegrationTest;
@@ -203,7 +204,8 @@ import org.junit.validator.PublicClassValidatorTest;
         JUnitCoreTest.class,
         TestWithParametersTest.class,
         ParameterizedNamesTest.class,
-        PublicClassValidatorTest.class
+        PublicClassValidatorTest.class,
+        DisableOnDebugTest.class
 })
 public class AllTests {
     public static Test suite() {


### PR DESCRIPTION
This pull request is an alternative to https://github.com/junit-team/junit/pull/904. I prefer this change over https://github.com/junit-team/junit/pull/904 because it is cleaner code, it may be use for debugging problems beyond than of Timeout's, it's easier to test and maintain and it preserves backwards compatible in doing so.

This feature is immediately useful with @Timeouts by disabling them during debugging allowing developers time to debug at their leisure without the test terminating abruptly.

Timeouts or time sensitive logic in the code under test is not handled by this feature and may make this unuseful in some circumstances. Similarly any other uses are limited to behaviour within it's control.

The most attractive benefit of this feature is that you can suspend rules without any making any modifications to your test class to remove them during debugging. Anecdotally removing timeouts for debug purposes often results in developers forgetting to restore them (including myself!).

This feature somewhat relates to issue https://github.com/junit-team/junit/issues/738

The DisableOnDebug rule exposes an isDebugging() method accessible to tests. I saw no harm in doing this and thought there might be some interesting uses with the Assume feature or disabling other code paths that cannot easily be debugged. e.g. above I alluded to time sensitive logic in user code that we can't control, isDebugging() may be combined with user code to manage that.

I've tried to keep as close to the JUnit projects conventions but please let me know if there is anything you'd prefer to be changed.
