### PR TITLE
Add error message to TemporaryFolder.newFolder("String/String")

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -92,13 +92,28 @@ public class TemporaryFolder extends ExternalResource {
         File file = getRoot();
         for (int i = 0; i < folderNames.length; i++) {
             String folderName = folderNames[i];
+            validateIOSeparator(folderName);
             file = new File(file, folderName);
             if (!file.mkdir() && isLastElementInArray(i, folderNames)) {
-                throw new IOException(
-                        "a folder with the name \'" + folderName + "\' already exists");
+                throw new IOException("a folder with the name \'" + folderName + "\' already exists");
             }
         }
         return file;
+    }
+
+    /**
+     * Validates if a OS separator was used in the attempt to create a folder structure.
+     *
+     * @param folderName
+     *         String passed as the temp folder name
+     */
+    private void validateIOSeparator(String folderName) throws IOException {
+        if (folderName.contains(File.separator)) {
+            String errorMsg = "It's not possible to use the OS separator to create folder " +
+                    "hierarchies like 'MyParentFolder'%s'MyFolder'. Please use newFolder('MyParentFolder', "+
+                            "'MyFolder') instead";
+            throw new IOException(String.format(errorMsg,File.separator));
+        }
     }
 
     private boolean isLastElementInArray(int index, String[] array) {

--- a/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderUsageTest.java
@@ -167,6 +167,19 @@ public class TemporaryFolderUsageTest {
         assertThat(tempDir, is(folder.getRoot().getParentFile()));
     }
 
+    @Test
+    public void fileSeparatorShouldThrowExceptionWhenUsedAsPartOfFolderNameParameter() throws IOException {
+        tempFolder.create();
+
+        thrown.expect(IOException.class);
+        String errorMsg = "It's not possible to use the OS separator to create folder " +
+                                  "hierarchies like 'MyParentFolder'%s'MyFolder'. Please use newFolder('MyParentFolder', "+
+                                  "'MyFolder') instead";
+        thrown.expectMessage(String.format(errorMsg,File.separator));
+        tempFolder.newFolder("MyParentFolder" + File.separator + "MyFolder");
+
+    }
+
     private File createTemporaryFolder() throws IOException {
         File tempDir = File.createTempFile("junit", "tempFolder");
         assertTrue("Unable to delete temporary file", tempDir.delete());


### PR DESCRIPTION
Adding error message explaining that you can't create a tempFolder using "Parent/Folder" as one string.
