### PR TITLE
Restore field names with f prefix. Fixes #960.

### DIFF
--- a/src/main/java/org/junit/internal/requests/ClassRequest.java
+++ b/src/main/java/org/junit/internal/requests/ClassRequest.java
@@ -6,12 +6,18 @@ import org.junit.runner.Runner;
 
 public class ClassRequest extends Request {
     private final Object runnerLock = new Object();
-    private final Class<?> testClass;
+
+    /*
+     * We have to use the f prefix, because IntelliJ's JUnit4IdeaTestRunner uses
+     * reflection to access this field. See
+     * https://github.com/junit-team/junit/issues/960
+     */
+    private final Class<?> fTestClass;
     private final boolean canUseSuiteMethod;
     private volatile Runner runner;
 
     public ClassRequest(Class<?> testClass, boolean canUseSuiteMethod) {
-        this.testClass = testClass;
+        this.fTestClass = testClass;
         this.canUseSuiteMethod = canUseSuiteMethod;
     }
 
@@ -24,7 +30,7 @@ public class ClassRequest extends Request {
         if (runner == null) {
             synchronized (runnerLock) {
                 if (runner == null) {
-                    runner = new AllDefaultPossibilitiesBuilder(canUseSuiteMethod).safeRunnerForClass(testClass);
+                    runner = new AllDefaultPossibilitiesBuilder(canUseSuiteMethod).safeRunnerForClass(fTestClass);
                 }
             }
         }

--- a/src/main/java/org/junit/internal/requests/FilterRequest.java
+++ b/src/main/java/org/junit/internal/requests/FilterRequest.java
@@ -11,7 +11,12 @@ import org.junit.runner.manipulation.NoTestsRemainException;
  */
 public final class FilterRequest extends Request {
     private final Request request;
-    private final Filter filter;
+    /*
+     * We have to use the f prefix, because IntelliJ's JUnit4IdeaTestRunner uses
+     * reflection to access this field. See
+     * https://github.com/junit-team/junit/issues/960
+     */
+    private final Filter fFilter;
 
     /**
      * Creates a filtered Request
@@ -22,18 +27,18 @@ public final class FilterRequest extends Request {
      */
     public FilterRequest(Request request, Filter filter) {
         this.request = request;
-        this.filter = filter;
+        this.fFilter = filter;
     }
 
     @Override
     public Runner getRunner() {
         try {
             Runner runner = request.getRunner();
-            filter.apply(runner);
+            fFilter.apply(runner);
             return runner;
         } catch (NoTestsRemainException e) {
             return new ErrorReportingRunner(Filter.class, new Exception(String
-                    .format("No tests found matching %s from %s", filter
+                    .format("No tests found matching %s from %s", fFilter
                             .describe(), request.toString())));
         }
     }


### PR DESCRIPTION
The prefix has been removed by df00d5eced3a7737b88de0f6f9e3673f0cf88f88,
because we changed the coding style. Unfortunately IntelliJ IDEA reads
ClassRequest.fTestClass and FilterRequest.fFilter via reflection. (See
http://grepcode.com/file/repository.grepcode.com/java/ext/com.jetbrains/intellij-idea/13.0.0/com/intellij/junit4/JUnit4IdeaTestRunner.java/ ) This makes it impossible to
start tests by using IntelliJ IDEA.

There is already an issue at JetBrains:
[IDEA-127349 ](http://youtrack.jetbrains.com/issue/IDEA-127349) We can
revert the fix when this ticket is solved and most users are using an
IntelliJ version with the fix.
