### PR TITLE
Increase running time of statement. Fixes #963.

### DIFF
--- a/src/test/java/org/junit/tests/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/tests/internal/runners/statements/FailOnTimeoutTest.java
@@ -23,10 +23,9 @@ import org.junit.runners.model.TestTimedOutException;
 /**
  * @author Asaf Ary, Stefan Birkner
  */
-// TODO Fix this. See https://github.com/junit-team/junit/issues/963
-@Ignore
 public class FailOnTimeoutTest {
     private static final int TIMEOUT = 100;
+    private static final int DURATION_THAT_EXCEEDS_TIMEOUT = Integer.MAX_VALUE;
 
     @Rule
     public final ExpectedException thrown = ExpectedException.none();
@@ -39,13 +38,13 @@ public class FailOnTimeoutTest {
     @Test
     public void throwsTestTimedOutException() throws Throwable {
         thrown.expect(TestTimedOutException.class);
-        evaluateWithWaitDuration(TIMEOUT + 50);
+        evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
     }
 
     @Test
     public void throwExceptionWithNiceMessageOnTimeout() throws Throwable {
         thrown.expectMessage("test timed out after 100 milliseconds");
-        evaluateWithWaitDuration(TIMEOUT + 50);
+        evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
     }
 
     @Test
@@ -60,7 +59,7 @@ public class FailOnTimeoutTest {
             throws Throwable {
         thrown.expect(TestTimedOutException.class);
         evaluateWithWaitDuration(0);
-        evaluateWithWaitDuration(TIMEOUT + 50);
+        evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
     }
 
     @Test
@@ -71,14 +70,14 @@ public class FailOnTimeoutTest {
             evaluateWithException(new RuntimeException());
         } catch (Throwable expected) {
         }
-        evaluateWithWaitDuration(TIMEOUT + 50);
+        evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
     }
 
     @Test
     public void throwsExceptionWithTimeoutValueAndTimeUnitSet()
             throws Throwable {
         try {
-            evaluateWithWaitDuration(TIMEOUT + 50);
+            evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
             fail("No exception was thrown when test timed out");
         } catch (TestTimedOutException e) {
             assertEquals(TIMEOUT, e.getTimeout());


### PR DESCRIPTION
The time between starting the statement and calling the future is
arbitrary. Now the execution time of the statement is very very long.
This ensures that the statement is not already finished when the
future is called.
