### PR TITLE
Avoid repeated checks.

### DIFF
--- a/src/main/java/org/junit/experimental/categories/Categories.java
+++ b/src/main/java/org/junit/experimental/categories/Categories.java
@@ -339,11 +339,12 @@ public class Categories extends Suite {
     }
 
     private static void assertNoCategorizedDescendentsOfUncategorizeableParents(Description description) throws InitializationError {
-        if (!canHaveCategorizedChildren(description)) {
+        if (canHaveCategorizedChildren(description)) {
+            for (Description each : description.getChildren()) {
+                assertNoCategorizedDescendentsOfUncategorizeableParents(each);
+            }
+        } else {
             assertNoDescendantsHaveCategoryAnnotations(description);
-        }
-        for (Description each : description.getChildren()) {
-            assertNoCategorizedDescendentsOfUncategorizeableParents(each);
         }
     }
 


### PR DESCRIPTION
The only check is `assertNoDescendantsHaveCategoryAnnotations`. It checks all descendants. Hence further calls of `assertNoCategorizedDescendentsOfUncategorizeableParents` for each child are redundant, because it has already been checked.
