### PR TITLE
Update TemporaryFolder.newFolder() to give a better error message if a path contains a slash

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -92,6 +92,7 @@ public class TemporaryFolder extends ExternalResource {
         File file = getRoot();
         for (int i = 0; i < folderNames.length; i++) {
             String folderName = folderNames[i];
+            validateFolderName(folderName);
             file = new File(file, folderName);
             if (!file.mkdir() && isLastElementInArray(i, folderNames)) {
                 throw new IOException(
@@ -99,6 +100,21 @@ public class TemporaryFolder extends ExternalResource {
             }
         }
         return file;
+    }
+    
+    /**
+     * Validates if multiple path components were used while creating a folder.
+     * 
+     * @param folderName
+     *            Name of the folder being created
+     */
+    private void validateFolderName(String folderName) throws IOException {
+        File tempFile = new File(folderName);
+        if (tempFile.getParent() != null) {
+            String errorMsg = "Folder name cannot consist of multiple path components separated by a file separator."
+                    + " Please use newFolder('MyParentFolder','MyFolder') to create hierarchies of folders";
+            throw new IOException(errorMsg);
+        }
     }
 
     private boolean isLastElementInArray(int index, String[] array) {

--- a/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderUsageTest.java
@@ -84,7 +84,16 @@ public class TemporaryFolderUsageTest {
         thrown.expectMessage("a folder with the name 'level1' already exists");
         tempFolder.newFolder("level1");
     }
-
+    
+    @Test
+    public void newFolderWithGivenFolderThrowsIOExceptionIfFolderNameConsistsOfMultiplePathComponents()
+            throws IOException {
+        tempFolder.create();
+        thrown.expect(IOException.class);
+        thrown.expectMessage("name cannot consist of multiple path components");
+        tempFolder.newFolder("temp1/temp2");
+    }
+    
     @Test
     public void newFolderWithGivenPathThrowsIllegalArgumentExceptionIfPathExists() throws IOException {
         tempFolder.create();
@@ -95,6 +104,15 @@ public class TemporaryFolderUsageTest {
         tempFolder.newFolder("level1", "level2", "level3");
     }
 
+    @Test
+    public void newFolderWithGivenPathThrowsIOExceptionIfFolderNamesConsistOfMultiplePathComponents()
+            throws IOException {
+        tempFolder.create();
+        thrown.expect(IOException.class);
+        thrown.expectMessage("name cannot consist of multiple path components");
+        tempFolder.newFolder("temp1", "temp2", "temp3/temp4");
+    }
+    
     @Test
     public void createInitializesRootFolder() throws IOException {
         tempFolder.create();


### PR DESCRIPTION
Please review the fix and let me know if it does good.
