### PR TITLE
Less restrictive type bounds for ThrowableCauseMatcher

### DIFF
--- a/src/main/java/org/junit/internal/matchers/ThrowableCauseMatcher.java
+++ b/src/main/java/org/junit/internal/matchers/ThrowableCauseMatcher.java
@@ -5,33 +5,46 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+/**
+ * A matcher that applies a delegate matcher to the cause of the current Throwable, returning the result of that
+ * match.
+ *
+ * @param <T> the type of the throwable being matched
+ */
 public class ThrowableCauseMatcher<T extends Throwable> extends
         TypeSafeMatcher<T> {
 
-    private final Matcher<T> matcher;
+    private final Matcher<? extends Throwable> causeMatcher;
 
-    public ThrowableCauseMatcher(Matcher<T> matcher) {
-        this.matcher = matcher;
+    public ThrowableCauseMatcher(Matcher<? extends Throwable> causeMatcher) {
+        this.causeMatcher = causeMatcher;
     }
 
     public void describeTo(Description description) {
         description.appendText("exception with cause ");
-        description.appendDescriptionOf(matcher);
+        description.appendDescriptionOf(causeMatcher);
     }
 
     @Override
     protected boolean matchesSafely(T item) {
-        return matcher.matches(item.getCause());
+        return causeMatcher.matches(item.getCause());
     }
 
     @Override
     protected void describeMismatchSafely(T item, Description description) {
         description.appendText("cause ");
-        matcher.describeMismatch(item.getCause(), description);
+        causeMatcher.describeMismatch(item.getCause(), description);
     }
 
+    /**
+     * Returns a matcher that verifies that the outer exception has a cause for which the supplied matcher
+     * evaluates to true.
+     *
+     * @param matcher to apply to the cause of the outer exception
+     * @param <T> type of the outer exception
+     */
     @Factory
-    public static <T extends Throwable> Matcher<T> hasCause(final Matcher<T> matcher) {
+    public static <T extends Throwable> Matcher<T> hasCause(final Matcher<? extends Throwable> matcher) {
         return new ThrowableCauseMatcher<T>(matcher);
     }
 }

--- a/src/test/java/org/junit/internal/matchers/ThrowableCauseMatcherTest.java
+++ b/src/test/java/org/junit/internal/matchers/ThrowableCauseMatcherTest.java
@@ -1,0 +1,18 @@
+package org.junit.internal.matchers;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.internal.matchers.ThrowableCauseMatcher.hasCause;
+
+public class ThrowableCauseMatcherTest {
+
+    @Test
+    public void shouldAllowCauseOfDifferentClassFromRoot() throws Exception {
+        NullPointerException expectedCause = new NullPointerException("expected");
+        Exception actual = new Exception(expectedCause);
+
+        assertThat(actual, hasCause(is(expectedCause)));
+    }
+}

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -6,6 +6,7 @@ import org.junit.AssumptionViolatedExceptionTest;
 import org.junit.experimental.categories.CategoryFilterFactoryTest;
 import org.junit.internal.MethodSorterTest;
 import org.junit.internal.matchers.StacktracePrintingMatcherTest;
+import org.junit.internal.matchers.ThrowableCauseMatcherTest;
 import org.junit.rules.DisableOnDebugTest;
 import org.junit.rules.StopwatchTest;
 import org.junit.runner.FilterFactoriesTest;
@@ -205,7 +206,8 @@ import org.junit.validator.PublicClassValidatorTest;
         TestWithParametersTest.class,
         ParameterizedNamesTest.class,
         PublicClassValidatorTest.class,
-        DisableOnDebugTest.class
+        DisableOnDebugTest.class,
+        ThrowableCauseMatcherTest.class
 })
 public class AllTests {
     public static Test suite() {


### PR DESCRIPTION
Currently, the ThrowableCauseMatcher factory method enforces the same type restrictions on the current exception and the desired cause - this means that the test case in ThrowableCauseMatcherTest in this pull request doesn't even compile, although it makes sense as code.

This change does a few things:
1. Separate the type bounds on the root exception (T in the class definition) from the type bounds on the cause (? extends Throwable).
2. Clarify that the matcher field is used to match against the cause, not the current exception.

I'm not sure if it's possible to get better than Matcher<?>, but I think the current implementation is incorrect. I'm also not 100% sure what impact, if any, this change would have on backwards compatibility of the API.
