### PR TITLE
assertEquals(0.0, -0.0, 0.0) and assertEquals(0.0, -0.0) give different answers

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -108,7 +108,11 @@ public class Assert {
      */
     static public void assertEquals(String message, Object expected,
             Object actual) {
-        if (equalsRegardingNull(expected, actual)) {
+        if (expected instanceof Double && actual instanceof Double) {
+            assertEquals(message, (Double) expected, (Double) actual, 0.0);
+        } else if (expected instanceof Float && actual instanceof Float) {
+            assertEquals(message, (Float) expected, (Float) actual, 0.0);
+        } else if (equalsRegardingNull(expected, actual)) {
             return;
         } else if (expected instanceof String && actual instanceof String) {
             String cleanMessage = message == null ? "" : message;

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -256,6 +256,10 @@ public class AssertionTest {
         assertEquals(1l, 1l);
         assertEquals(1.0, 1.0, 0.0);
         assertEquals(1.0d, 1.0d, 0.0d);
+        assertEquals(new Double(0.0), new Double(-0.0), 0.0d);
+        assertEquals(new Double(0.0), new Double(-0.0));
+        assertEquals(new Float(0.0), new Float(-0.0), 0.0);
+        assertEquals(new Float(0.0), new Float(-0.0));
     }
 
     @Test(expected = AssertionError.class)


### PR DESCRIPTION
If you compare 0.0 and -0.0 with assertEquals you get different answers depending on whether you pass a delta value of 0.0.  I would expect them to give the same answer.  This patch contains a fix for assertEquals and a change to the unit test to verify correctness.
