### PR TITLE
Remove unused constructors in the external AssumptionViolatedException.

### DIFF
--- a/src/main/java/org/junit/Assume.java
+++ b/src/main/java/org/junit/Assume.java
@@ -101,9 +101,9 @@ public class Assume {
      * If not, the test halts and is ignored.
      * Example:
      * <pre>:
-     *   assumeThat(1, is(1)); // passes
+     *   assumeThat("alwaysPasses", 1, is(1)); // passes
      *   foo(); // will execute
-     *   assumeThat(0, is(1)); // assumption failure! test halts
+     *   assumeThat("alwaysFails", 0, is(1)); // assumption failure! test halts
      *   int x = 1 / 0; // will never execute
      * </pre>
      *

--- a/src/main/java/org/junit/AssumptionViolatedException.java
+++ b/src/main/java/org/junit/AssumptionViolatedException.java
@@ -8,35 +8,33 @@ import org.hamcrest.Matcher;
  * fails should not generate a test case failure.
  *
  * @see org.junit.Assume
+ * @since 4.12
  */
+@SuppressWarnings("deprecation")
 public class AssumptionViolatedException extends org.junit.internal.AssumptionViolatedException {
     private static final long serialVersionUID = 1L;
 
-    public AssumptionViolatedException(String assumption, boolean valueMatcher, Object value, Matcher<?> matcher) {
-        super(assumption, valueMatcher, value, matcher);
+    /**
+     * An assumption exception with the given <i>actual</i> value and a <i>matcher</i> describing 
+     * the expectation that failed.
+     */
+    public <T> AssumptionViolatedException(T actual, Matcher<T> matcher) {
+        super(actual, matcher);
     }
 
     /**
-     * An assumption exception with the given <i>value</i> (String or
-     * Throwable) and an additional failing {@link Matcher}.
+     * An assumption exception with a message with the given <i>actual</i> value and a
+     * <i>matcher</i> describing the expectation that failed.
      */
-    public AssumptionViolatedException(Object value, Matcher<?> matcher) {
-        super(value, matcher);
-    }
-
-    /**
-     * An assumption exception with the given <i>value</i> (String or
-     * Throwable) and an additional failing {@link Matcher}.
-     */
-    public AssumptionViolatedException(String assumption, Object value, Matcher<?> matcher) {
-        super(assumption, value, matcher);
+    public <T> AssumptionViolatedException(String message, T expected, Matcher<T> matcher) {
+        super(message, expected, matcher);
     }
 
     /**
      * An assumption exception with the given message only.
      */
-    public AssumptionViolatedException(String assumption) {
-        super(assumption);
+    public AssumptionViolatedException(String message) {
+        super(message);
     }
 
     /**

--- a/src/main/java/org/junit/internal/AssumptionViolatedException.java
+++ b/src/main/java/org/junit/internal/AssumptionViolatedException.java
@@ -11,10 +11,7 @@ import org.hamcrest.StringDescription;
  * fails should not generate a test case failure.
  *
  * @see org.junit.Assume
- *
- * @deprecated Please use {@link org.junit.AssumptionViolatedException} instead.
  */
-@Deprecated
 public class AssumptionViolatedException extends RuntimeException implements SelfDescribing {
     private static final long serialVersionUID = 2L;
 
@@ -28,11 +25,15 @@ public class AssumptionViolatedException extends RuntimeException implements Sel
     private final Object fValue;
     private final Matcher<?> fMatcher;
 
-    public AssumptionViolatedException(String assumption, boolean valueMatcher, Object value, Matcher<?> matcher) {
+    /**
+     * @deprecated Please use {@link org.junit.AssumptionViolatedException} instead.
+     */
+    @Deprecated
+    public AssumptionViolatedException(String assumption, boolean hasValue, Object value, Matcher<?> matcher) {
         this.fAssumption = assumption;
         this.fValue = value;
         this.fMatcher = matcher;
-        this.fValueMatcher = valueMatcher;
+        this.fValueMatcher = hasValue;
 
         if (value instanceof Throwable) {
           initCause((Throwable) value);
@@ -42,7 +43,10 @@ public class AssumptionViolatedException extends RuntimeException implements Sel
     /**
      * An assumption exception with the given <i>value</i> (String or
      * Throwable) and an additional failing {@link Matcher}.
+     *
+     * @deprecated Please use {@link org.junit.AssumptionViolatedException} instead.
      */
+    @Deprecated
     public AssumptionViolatedException(Object value, Matcher<?> matcher) {
         this(null, true, value, matcher);
     }
@@ -50,23 +54,33 @@ public class AssumptionViolatedException extends RuntimeException implements Sel
     /**
      * An assumption exception with the given <i>value</i> (String or
      * Throwable) and an additional failing {@link Matcher}.
+     *
+     * @deprecated Please use {@link org.junit.AssumptionViolatedException} instead.
      */
+    @Deprecated
     public AssumptionViolatedException(String assumption, Object value, Matcher<?> matcher) {
         this(assumption, true, value, matcher);
     }
 
     /**
      * An assumption exception with the given message only.
+     *
+     * @deprecated Please use {@link org.junit.AssumptionViolatedException} instead.
      */
+    @Deprecated
     public AssumptionViolatedException(String assumption) {
         this(assumption, false, null, null);
     }
 
     /**
      * An assumption exception with the given message and a cause.
+     *
+     * @deprecated Please use {@link org.junit.AssumptionViolatedException} instead.
      */
+    @Deprecated
     public AssumptionViolatedException(String assumption, Throwable e) {
-        this(assumption, false, e, null);
+        this(assumption, false, null, null);
+        initCause(e);
     }
 
     @Override
@@ -80,6 +94,7 @@ public class AssumptionViolatedException extends RuntimeException implements Sel
         }
 
         if (fValueMatcher) {
+            // a value was passed in when this instance was constructed; print it
             if (fAssumption != null) {
                 description.appendText(": ");
             }

--- a/src/test/java/org/junit/AssumptionViolatedExceptionTest.java
+++ b/src/test/java/org/junit/AssumptionViolatedExceptionTest.java
@@ -3,9 +3,9 @@ package org.junit;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
-
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.junit.experimental.theories.DataPoint;
@@ -16,23 +16,23 @@ import org.junit.runner.RunWith;
 @RunWith(Theories.class)
 public class AssumptionViolatedExceptionTest {
     @DataPoint
-    public static Object TWO = 2;
+    public static Integer TWO = 2;
 
     @DataPoint
-    public static Matcher<?> IS_THREE = is(3);
+    public static Matcher<Integer> IS_THREE = is(3);
 
     @DataPoint
-    public static Matcher<?> NULL = null;
+    public static Matcher<Integer> NULL = null;
 
     @Theory
-    public void toStringReportsMatcher(Object actual, Matcher<?> matcher) {
+    public void toStringReportsMatcher(Integer actual, Matcher<Integer> matcher) {
         assumeThat(matcher, notNullValue());
         assertThat(new AssumptionViolatedException(actual, matcher).toString(),
                 containsString(matcher.toString()));
     }
 
     @Theory
-    public void toStringReportsValue(Object actual, Matcher<?> matcher) {
+    public void toStringReportsValue(Integer actual, Matcher<Integer> matcher) {
         assertThat(new AssumptionViolatedException(actual, matcher).toString(),
                 containsString(String.valueOf(actual)));
     }
@@ -58,26 +58,32 @@ public class AssumptionViolatedExceptionTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void canSetCauseWithInstanceCreatedWithObjectAndMatcher() {
       Throwable testObject = new Exception();
-      AssumptionViolatedException e = new AssumptionViolatedException(testObject, containsString("test matcher"));
+      org.junit.internal.AssumptionViolatedException e
+              = new org.junit.internal.AssumptionViolatedException(
+                      testObject, containsString("test matcher"));
       assertThat(e.getCause(), is(testObject));
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void canSetCauseWithInstanceCreatedWithAssumptionObjectAndMatcher() {
       Throwable testObject = new Exception();
-      AssumptionViolatedException e = new AssumptionViolatedException(
-          "sample assumption", testObject, containsString("test matcher"));
-
+      org.junit.internal.AssumptionViolatedException e
+              = new org.junit.internal.AssumptionViolatedException(
+                      "sample assumption", testObject, containsString("test matcher"));
       assertThat(e.getCause(), is(testObject));
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     public void canSetCauseWithInstanceCreatedWithMainConstructor() {
       Throwable testObject = new Exception();
-      AssumptionViolatedException e = new AssumptionViolatedException(
-          "sample assumption", false, testObject, containsString("test matcher"));
+      org.junit.internal.AssumptionViolatedException e
+              = new org.junit.internal.AssumptionViolatedException(
+                      "sample assumption", false, testObject, containsString("test matcher"));
       assertThat(e.getCause(), is(testObject));
     }
 


### PR DESCRIPTION
Remove unused constructors in the external AssumptionViolatedException.
Rename fields of internal AssumptionViolatedException so we don't break serialization with JUnit 4.11
