### PR TITLE
Ensure serialization compatibility where possible

### DIFF
--- a/src/main/java/org/junit/ComparisonFailure.java
+++ b/src/main/java/org/junit/ComparisonFailure.java
@@ -18,8 +18,13 @@ public class ComparisonFailure extends AssertionError {
     private static final int MAX_CONTEXT_LENGTH = 20;
     private static final long serialVersionUID = 1L;
 
-    private String expected;
-    private String actual;
+    /*
+     * We have to use the f prefix until the next major release to ensure
+     * serialization compatibility. 
+     * See https://github.com/junit-team/junit/issues/976
+     */
+    private String fExpected;
+    private String fActual;
 
     /**
      * Constructs a comparison failure.
@@ -30,8 +35,8 @@ public class ComparisonFailure extends AssertionError {
      */
     public ComparisonFailure(String message, String expected, String actual) {
         super(message);
-        this.expected = expected;
-        this.actual = actual;
+        this.fExpected = expected;
+        this.fActual = actual;
     }
 
     /**
@@ -41,7 +46,7 @@ public class ComparisonFailure extends AssertionError {
      */
     @Override
     public String getMessage() {
-        return new ComparisonCompactor(MAX_CONTEXT_LENGTH, expected, actual).compact(super.getMessage());
+        return new ComparisonCompactor(MAX_CONTEXT_LENGTH, fExpected, fActual).compact(super.getMessage());
     }
 
     /**
@@ -50,7 +55,7 @@ public class ComparisonFailure extends AssertionError {
      * @return the actual string value
      */
     public String getActual() {
-        return actual;
+        return fActual;
     }
 
     /**
@@ -59,7 +64,7 @@ public class ComparisonFailure extends AssertionError {
      * @return the expected string value
      */
     public String getExpected() {
-        return expected;
+        return fExpected;
     }
 
     private static class ComparisonCompactor {

--- a/src/main/java/org/junit/experimental/max/MaxHistory.java
+++ b/src/main/java/org/junit/experimental/max/MaxHistory.java
@@ -61,41 +61,44 @@ public class MaxHistory implements Serializable {
         }
     }
 
-    private final Map<String, Long> durations = new HashMap<String, Long>();
-
-    private final Map<String, Long> failureTimestamps = new HashMap<String, Long>();
-
-    private final File historyStore;
+    /*
+     * We have to use the f prefix until the next major release to ensure
+     * serialization compatibility. 
+     * See https://github.com/junit-team/junit/issues/976
+     */
+    private final Map<String, Long> fDurations = new HashMap<String, Long>();
+    private final Map<String, Long> fFailureTimestamps = new HashMap<String, Long>();
+    private final File fHistoryStore;
 
     private MaxHistory(File storedResults) {
-        historyStore = storedResults;
+        fHistoryStore = storedResults;
     }
 
     private void save() throws IOException {
         ObjectOutputStream stream = new ObjectOutputStream(new FileOutputStream(
-                historyStore));
+                fHistoryStore));
         stream.writeObject(this);
         stream.close();
     }
 
     Long getFailureTimestamp(Description key) {
-        return failureTimestamps.get(key.toString());
+        return fFailureTimestamps.get(key.toString());
     }
 
     void putTestFailureTimestamp(Description key, long end) {
-        failureTimestamps.put(key.toString(), end);
+        fFailureTimestamps.put(key.toString(), end);
     }
 
     boolean isNewTest(Description key) {
-        return !durations.containsKey(key.toString());
+        return !fDurations.containsKey(key.toString());
     }
 
     Long getTestDuration(Description key) {
-        return durations.get(key.toString());
+        return fDurations.get(key.toString());
     }
 
     void putTestDuration(Description description, long duration) {
-        durations.put(description.toString(), duration);
+        fDurations.put(description.toString(), duration);
     }
 
     private final class RememberingListener extends RunListener {

--- a/src/main/java/org/junit/internal/ArrayComparisonFailure.java
+++ b/src/main/java/org/junit/internal/ArrayComparisonFailure.java
@@ -14,8 +14,13 @@ public class ArrayComparisonFailure extends AssertionError {
 
     private static final long serialVersionUID = 1L;
 
-    private final List<Integer> indices = new ArrayList<Integer>();
-    private final String message;
+    /*
+     * We have to use the f prefix until the next major release to ensure
+     * serialization compatibility. 
+     * See https://github.com/junit-team/junit/issues/976
+     */
+    private final List<Integer> fIndices = new ArrayList<Integer>();
+    private final String fMessage;
 
     /**
      * Construct a new <code>ArrayComparisonFailure</code> with an error text and the array's
@@ -26,23 +31,23 @@ public class ArrayComparisonFailure extends AssertionError {
      * @see Assert#assertArrayEquals(String, Object[], Object[])
      */
     public ArrayComparisonFailure(String message, AssertionError cause, int index) {
-        this.message = message;
+        this.fMessage = message;
         initCause(cause);
         addDimension(index);
     }
 
     public void addDimension(int index) {
-        indices.add(0, index);
+        fIndices.add(0, index);
     }
 
     @Override
     public String getMessage() {
         StringBuilder sb = new StringBuilder();
-        if (message != null) {
-            sb.append(message);
+        if (fMessage != null) {
+            sb.append(fMessage);
         }
         sb.append("arrays first differed at element ");
-        for (int each : indices) {
+        for (int each : fIndices) {
             sb.append("[");
             sb.append(each);
             sb.append("]");

--- a/src/main/java/org/junit/internal/AssumptionViolatedException.java
+++ b/src/main/java/org/junit/internal/AssumptionViolatedException.java
@@ -18,18 +18,21 @@ import org.hamcrest.StringDescription;
 public class AssumptionViolatedException extends RuntimeException implements SelfDescribing {
     private static final long serialVersionUID = 2L;
 
-    private final String assumption;
-
-    private final boolean valueMatcher;
-    private final Object value;
-
-    private final Matcher<?> matcher;
+    /*
+     * We have to use the f prefix until the next major release to ensure
+     * serialization compatibility. 
+     * See https://github.com/junit-team/junit/issues/976
+     */
+    private final String fAssumption;
+    private final boolean fValueMatcher;
+    private final Object fValue;
+    private final Matcher<?> fMatcher;
 
     public AssumptionViolatedException(String assumption, boolean valueMatcher, Object value, Matcher<?> matcher) {
-        this.assumption = assumption;
-        this.value = value;
-        this.matcher = matcher;
-        this.valueMatcher = valueMatcher;
+        this.fAssumption = assumption;
+        this.fValue = value;
+        this.fMatcher = matcher;
+        this.fValueMatcher = valueMatcher;
 
         if (value instanceof Throwable) {
           initCause((Throwable) value);
@@ -72,21 +75,21 @@ public class AssumptionViolatedException extends RuntimeException implements Sel
     }
 
     public void describeTo(Description description) {
-        if (assumption != null) {
-            description.appendText(assumption);
+        if (fAssumption != null) {
+            description.appendText(fAssumption);
         }
 
-        if (valueMatcher) {
-            if (assumption != null) {
+        if (fValueMatcher) {
+            if (fAssumption != null) {
                 description.appendText(": ");
             }
 
             description.appendText("got: ");
-            description.appendValue(value);
+            description.appendValue(fValue);
 
-            if (matcher != null) {
+            if (fMatcher != null) {
                 description.appendText(", expected: ");
-                description.appendDescriptionOf(matcher);
+                description.appendDescriptionOf(fMatcher);
             }
         }
     }

--- a/src/main/java/org/junit/internal/runners/InitializationError.java
+++ b/src/main/java/org/junit/internal/runners/InitializationError.java
@@ -11,10 +11,16 @@ import java.util.List;
 @Deprecated
 public class InitializationError extends Exception {
     private static final long serialVersionUID = 1L;
-    private final List<Throwable> errors;
+
+    /*
+     * We have to use the f prefix until the next major release to ensure
+     * serialization compatibility. 
+     * See https://github.com/junit-team/junit/issues/976
+     */
+    private final List<Throwable> fErrors;
 
     public InitializationError(List<Throwable> errors) {
-        this.errors = errors;
+        this.fErrors = errors;
     }
 
     public InitializationError(Throwable... errors) {
@@ -26,6 +32,6 @@ public class InitializationError extends Exception {
     }
 
     public List<Throwable> getCauses() {
-        return errors;
+        return fErrors;
     }
 }

--- a/src/main/java/org/junit/runner/Description.java
+++ b/src/main/java/org/junit/runner/Description.java
@@ -136,11 +136,16 @@ public class Description implements Serializable {
      */
     public static final Description TEST_MECHANISM = new Description(null, "Test mechanism");
 
-    private final Collection<Description> children = new ConcurrentLinkedQueue<Description>();
-    private final String displayName;
-    private final Serializable uniqueId;
-    private final Annotation[] annotations;
-    private volatile /* write-once */ Class<?> testClass;
+    /*
+     * We have to use the f prefix until the next major release to ensure
+     * serialization compatibility. 
+     * See https://github.com/junit-team/junit/issues/976
+     */
+    private final Collection<Description> fChildren = new ConcurrentLinkedQueue<Description>();
+    private final String fDisplayName;
+    private final Serializable fUniqueId;
+    private final Annotation[] fAnnotations;
+    private volatile /* write-once */ Class<?> fTestClass;
 
     private Description(Class<?> clazz, String displayName, Annotation... annotations) {
         this(clazz, displayName, displayName, annotations);
@@ -155,17 +160,17 @@ public class Description implements Serializable {
             throw new IllegalArgumentException(
                     "The unique id must not be null.");
         }
-        this.testClass = testClass;
-        this.displayName = displayName;
-        this.uniqueId = uniqueId;
-        this.annotations = annotations;
+        this.fTestClass = testClass;
+        this.fDisplayName = displayName;
+        this.fUniqueId = uniqueId;
+        this.fAnnotations = annotations;
     }
 
     /**
      * @return a user-understandable label
      */
     public String getDisplayName() {
-        return displayName;
+        return fDisplayName;
     }
 
     /**
@@ -174,7 +179,7 @@ public class Description implements Serializable {
      * @param description the soon-to-be child.
      */
     public void addChild(Description description) {
-        children.add(description);
+        fChildren.add(description);
     }
 
     /**
@@ -182,7 +187,7 @@ public class Description implements Serializable {
      * Returns an empty list if there are no children.
      */
     public ArrayList<Description> getChildren() {
-        return new ArrayList<Description>(children);
+        return new ArrayList<Description>(fChildren);
     }
 
     /**
@@ -196,7 +201,7 @@ public class Description implements Serializable {
      * @return <code>true</code> if the receiver is an atomic test
      */
     public boolean isTest() {
-        return children.isEmpty();
+        return fChildren.isEmpty();
     }
 
     /**
@@ -207,7 +212,7 @@ public class Description implements Serializable {
             return 1;
         }
         int result = 0;
-        for (Description child : children) {
+        for (Description child : fChildren) {
             result += child.testCount();
         }
         return result;
@@ -215,7 +220,7 @@ public class Description implements Serializable {
 
     @Override
     public int hashCode() {
-        return uniqueId.hashCode();
+        return fUniqueId.hashCode();
     }
 
     @Override
@@ -224,7 +229,7 @@ public class Description implements Serializable {
             return false;
         }
         Description d = (Description) obj;
-        return uniqueId.equals(d.uniqueId);
+        return fUniqueId.equals(d.fUniqueId);
     }
 
     @Override
@@ -244,7 +249,7 @@ public class Description implements Serializable {
      *         children will be added back)
      */
     public Description childlessCopy() {
-        return new Description(testClass, displayName, annotations);
+        return new Description(fTestClass, fDisplayName, fAnnotations);
     }
 
     /**
@@ -252,7 +257,7 @@ public class Description implements Serializable {
      *         or null if none exists
      */
     public <T extends Annotation> T getAnnotation(Class<T> annotationType) {
-        for (Annotation each : annotations) {
+        for (Annotation each : fAnnotations) {
             if (each.annotationType().equals(annotationType)) {
                 return annotationType.cast(each);
             }
@@ -264,7 +269,7 @@ public class Description implements Serializable {
      * @return all of the annotations attached to this description node
      */
     public Collection<Annotation> getAnnotations() {
-        return Arrays.asList(annotations);
+        return Arrays.asList(fAnnotations);
     }
 
     /**
@@ -272,16 +277,16 @@ public class Description implements Serializable {
      *         the class of the test instance.
      */
     public Class<?> getTestClass() {
-        if (testClass != null) {
-            return testClass;
+        if (fTestClass != null) {
+            return fTestClass;
         }
         String name = getClassName();
         if (name == null) {
             return null;
         }
         try {
-            testClass = Class.forName(name, false, getClass().getClassLoader());
-            return testClass;
+            fTestClass = Class.forName(name, false, getClass().getClassLoader());
+            return fTestClass;
         } catch (ClassNotFoundException e) {
             return null;
         }
@@ -292,7 +297,7 @@ public class Description implements Serializable {
      *         the name of the class of the test instance
      */
     public String getClassName() {
-        return testClass != null ? testClass.getName() : methodAndClassNamePatternGroupOrDefault(2, toString());
+        return fTestClass != null ? fTestClass.getName() : methodAndClassNamePatternGroupOrDefault(2, toString());
     }
 
     /**

--- a/src/main/java/org/junit/runner/notification/Failure.java
+++ b/src/main/java/org/junit/runner/notification/Failure.java
@@ -17,8 +17,14 @@ import org.junit.runner.Description;
  */
 public class Failure implements Serializable {
     private static final long serialVersionUID = 1L;
-    private final Description description;
-    private final Throwable thrownException;
+
+    /*
+     * We have to use the f prefix until the next major release to ensure
+     * serialization compatibility. 
+     * See https://github.com/junit-team/junit/issues/976
+     */
+    private final Description fDescription;
+    private final Throwable fThrownException;
 
     /**
      * Constructs a <code>Failure</code> with the given description and exception.
@@ -27,22 +33,22 @@ public class Failure implements Serializable {
      * @param thrownException the exception that was thrown while running the test
      */
     public Failure(Description description, Throwable thrownException) {
-        this.thrownException = thrownException;
-        this.description = description;
+        this.fThrownException = thrownException;
+        this.fDescription = description;
     }
 
     /**
      * @return a user-understandable label for the test
      */
     public String getTestHeader() {
-        return description.getDisplayName();
+        return fDescription.getDisplayName();
     }
 
     /**
      * @return the raw description of the context of the failure.
      */
     public Description getDescription() {
-        return description;
+        return fDescription;
     }
 
     /**
@@ -50,12 +56,12 @@ public class Failure implements Serializable {
      */
 
     public Throwable getException() {
-        return thrownException;
+        return fThrownException;
     }
 
     @Override
     public String toString() {
-        return getTestHeader() + ": " + thrownException.getMessage();
+        return getTestHeader() + ": " + fThrownException.getMessage();
     }
 
     /**

--- a/src/main/java/org/junit/runners/model/InitializationError.java
+++ b/src/main/java/org/junit/runners/model/InitializationError.java
@@ -10,14 +10,20 @@ import java.util.List;
  */
 public class InitializationError extends Exception {
     private static final long serialVersionUID = 1L;
-    private final List<Throwable> errors;
+
+    /*
+     * We have to use the f prefix until the next major release to ensure
+     * serialization compatibility. 
+     * See https://github.com/junit-team/junit/issues/976
+     */
+    private final List<Throwable> fErrors;
 
     /**
      * Construct a new {@code InitializationError} with one or more
      * errors {@code errors} as causes
      */
     public InitializationError(List<Throwable> errors) {
-        this.errors = errors;
+        this.fErrors = errors;
     }
 
     public InitializationError(Throwable error) {
@@ -36,6 +42,6 @@ public class InitializationError extends Exception {
      * Returns one or more Throwables that led to this initialization error.
      */
     public List<Throwable> getCauses() {
-        return errors;
+        return fErrors;
     }
 }

--- a/src/main/java/org/junit/runners/model/MultipleFailureException.java
+++ b/src/main/java/org/junit/runners/model/MultipleFailureException.java
@@ -14,21 +14,26 @@ import org.junit.internal.Throwables;
 public class MultipleFailureException extends Exception {
     private static final long serialVersionUID = 1L;
 
-    private final List<Throwable> errors;
+    /*
+     * We have to use the f prefix until the next major release to ensure
+     * serialization compatibility. 
+     * See https://github.com/junit-team/junit/issues/976
+     */
+    private final List<Throwable> fErrors;
 
     public MultipleFailureException(List<Throwable> errors) {
-        this.errors = new ArrayList<Throwable>(errors);
+        this.fErrors = new ArrayList<Throwable>(errors);
     }
 
     public List<Throwable> getFailures() {
-        return Collections.unmodifiableList(errors);
+        return Collections.unmodifiableList(fErrors);
     }
 
     @Override
     public String getMessage() {
         StringBuilder sb = new StringBuilder(
-                String.format("There were %d errors:", errors.size()));
-        for (Throwable e : errors) {
+                String.format("There were %d errors:", fErrors.size()));
+        for (Throwable e : fErrors) {
             sb.append(String.format("\n  %s(%s)", e.getClass().getName(), e.getMessage()));
         }
         return sb.toString();


### PR DESCRIPTION
Not possible for `org.junit.runner.Result`. Potential fix for #976 (needs manual test to confirm).
