### PR TITLE
Random @FixMethodOrder with seed

### DIFF
--- a/src/main/java/junit/framework/TestSuite.java
+++ b/src/main/java/junit/framework/TestSuite.java
@@ -1,5 +1,8 @@
 package junit.framework;
 
+import org.junit.internal.MethodSorter;
+import org.junit.runners.MethodSorters;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.reflect.Constructor;
@@ -10,8 +13,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
-
-import org.junit.internal.MethodSorter;
 
 /**
  * A <code>TestSuite</code> is a <code>Composite</code> of Tests.
@@ -146,7 +147,15 @@ public class TestSuite implements Test {
         Class<?> superClass = theClass;
         List<String> names = new ArrayList<String>();
         while (Test.class.isAssignableFrom(superClass)) {
-            for (Method each : MethodSorter.getDeclaredMethods(superClass)) {
+            MethodSorter.SortedMethods sortedMethods = MethodSorter.getDeclaredMethods(superClass);
+            //TODO: how to display order and seed to user? addTest(warning) won't do the good job
+            if (sortedMethods.getMethodSorter() != MethodSorters.DEFAULT && sortedMethods.getMethodSorter() != MethodSorters.RANDOM) {
+                addTest(warning("Tests sorted with " + sortedMethods.getMethodSorter().name() + " order"));
+            }
+            if (sortedMethods.getMethodSorter() == MethodSorters.RANDOM) {
+                addTest(warning("Tests sorted with " + sortedMethods.getMethodSorter().name() + " order and seed " + sortedMethods.getSeed()));
+            }
+            for (Method each : sortedMethods.getMethods()) {
                 addTestMethod(each, names, theClass);
             }
             superClass = superClass.getSuperclass();

--- a/src/main/java/org/junit/FixMethodOrder.java
+++ b/src/main/java/org/junit/FixMethodOrder.java
@@ -1,11 +1,11 @@
 package org.junit;
 
+import org.junit.runners.MethodSorters;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import org.junit.runners.MethodSorters;
 
 /**
  * This class allows the user to choose the order of execution of the methods within a test class.
@@ -38,4 +38,9 @@ public @interface FixMethodOrder {
      * Optionally specify <code>value</code> to have the methods executed in a particular order
      */
     MethodSorters value() default MethodSorters.DEFAULT;
+
+    /**
+     * Optionally specify <code>seed</code> for random order
+     */
+    String seed() default "";
 }

--- a/src/main/java/org/junit/internal/matchers/TypeSafeMatcher.java
+++ b/src/main/java/org/junit/internal/matchers/TypeSafeMatcher.java
@@ -1,9 +1,9 @@
 package org.junit.internal.matchers;
 
-import java.lang.reflect.Method;
-
 import org.hamcrest.BaseMatcher;
 import org.junit.internal.MethodSorter;
+
+import java.lang.reflect.Method;
 
 /**
  * Convenient base class for Matchers that require a non-null value of a specific type.
@@ -29,7 +29,7 @@ public abstract class TypeSafeMatcher<T> extends BaseMatcher<T> {
 
     private static Class<?> findExpectedType(Class<?> fromClass) {
         for (Class<?> c = fromClass; c != Object.class; c = c.getSuperclass()) {
-            for (Method method : MethodSorter.getDeclaredMethods(c)) {
+            for (Method method : MethodSorter.getDeclaredMethods(c).getMethods()) {
                 if (isMatchesSafelyMethod(method)) {
                     return method.getParameterTypes()[0];
                 }

--- a/src/main/java/org/junit/internal/runners/TestClass.java
+++ b/src/main/java/org/junit/internal/runners/TestClass.java
@@ -1,18 +1,18 @@
 package org.junit.internal.runners;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.internal.MethodSorter;
 import org.junit.runners.BlockJUnit4ClassRunner;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @deprecated Included for backwards compatibility with JUnit 4.4. Will be
@@ -42,7 +42,7 @@ public class TestClass {
     public List<Method> getAnnotatedMethods(Class<? extends Annotation> annotationClass) {
         List<Method> results = new ArrayList<Method>();
         for (Class<?> eachClass : getSuperClasses(klass)) {
-            Method[] methods = MethodSorter.getDeclaredMethods(eachClass);
+            Method[] methods = MethodSorter.getDeclaredMethods(eachClass).getMethods();
             for (Method eachMethod : methods) {
                 Annotation annotation = eachMethod.getAnnotation(annotationClass);
                 if (annotation != null && !isShadowed(eachMethod, results)) {

--- a/src/main/java/org/junit/runners/MethodSorters.java
+++ b/src/main/java/org/junit/runners/MethodSorters.java
@@ -1,9 +1,9 @@
 package org.junit.runners;
 
+import org.junit.internal.MethodSorter;
+
 import java.lang.reflect.Method;
 import java.util.Comparator;
-
-import org.junit.internal.MethodSorter;
 
 /**
  * Sort the methods into a specified execution order.
@@ -27,7 +27,14 @@ public enum MethodSorters {
     /**
      * Sorts the test methods in a deterministic, but not predictable, order
      */
-    DEFAULT(MethodSorter.DEFAULT);
+    DEFAULT(MethodSorter.DEFAULT),
+
+    /**
+     * Shuffles the test methods.
+     * Note that random seed that was used to shuffle is displayed,
+     * so you should be able to reproduce it later.
+     */
+    RANDOM(null);
 
     private final Comparator<Method> comparator;
 

--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -1,27 +1,19 @@
 package org.junit.runners.model;
 
-import static java.lang.reflect.Modifier.isStatic;
-import static org.junit.internal.MethodSorter.NAME_ASCENDING;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.internal.MethodSorter;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.internal.MethodSorter;
+import static java.lang.reflect.Modifier.isStatic;
+import static org.junit.internal.MethodSorter.NAME_ASCENDING;
 
 /**
  * Wraps a class to be run, providing method validation and annotation searching
@@ -62,7 +54,7 @@ public class TestClass implements Annotatable {
 
     protected void scanAnnotatedMembers(Map<Class<? extends Annotation>, List<FrameworkMethod>> methodsForAnnotations, Map<Class<? extends Annotation>, List<FrameworkField>> fieldsForAnnotations) {
         for (Class<?> eachClass : getSuperClasses(clazz)) {
-            for (Method eachMethod : MethodSorter.getDeclaredMethods(eachClass)) {
+            for (Method eachMethod : MethodSorter.getDeclaredMethods(eachClass).getMethods()) {
                 addToAnnotationLists(new FrameworkMethod(eachMethod), methodsForAnnotations);
             }
             // ensuring fields are sorted to make sure that entries are inserted
@@ -108,7 +100,7 @@ public class TestClass implements Annotatable {
     /**
      * Returns, efficiently, all the non-overridden methods in this class and
      * its superclasses that are annotated}.
-     * 
+     *
      * @since 4.12
      */
     public List<FrameworkMethod> getAnnotatedMethods() {
@@ -129,7 +121,7 @@ public class TestClass implements Annotatable {
     /**
      * Returns, efficiently, all the non-overridden fields in this class and its
      * superclasses that are annotated.
-     * 
+     *
      * @since 4.12
      */
     public List<FrameworkField> getAnnotatedFields() {

--- a/src/test/java/org/junit/internal/MethodSorterTest.java
+++ b/src/test/java/org/junit/internal/MethodSorterTest.java
@@ -1,16 +1,16 @@
 package org.junit.internal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Random;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
-import org.junit.runners.MethodSorters;
+import static org.junit.Assert.*;
 
 public class MethodSorterTest {
     private static final String ALPHA = "java.lang.Object alpha(int,double,java.lang.Thread)";
@@ -55,7 +55,7 @@ public class MethodSorterTest {
     }
 
     private List<String> getDeclaredMethodNames(Class<?> clazz) {
-        Method[] actualMethods = MethodSorter.getDeclaredMethods(clazz);
+        Method[] actualMethods = MethodSorter.getDeclaredMethods(clazz).getMethods();
 
         // Obtain just the names instead of the full methods.
         List<String> names = new ArrayList<String>();
@@ -65,7 +65,7 @@ public class MethodSorterTest {
                 names.add(m.toString().replace(clazz.getName() + '.', ""));
         	}
         }
-        
+
         return names;
     }
 
@@ -75,14 +75,14 @@ public class MethodSorterTest {
         List<String> actual = getDeclaredMethodNames(DummySortWithoutAnnotation.class);
         assertEquals(expected, actual);
     }
-    
+
     @Test
     public void testMethodsNullSorterSuper() {
         List<String> expected = Arrays.asList(SUPER_METHOD);
         List<String> actual = getDeclaredMethodNames(Super.class);
         assertEquals(expected, actual);
     }
-    
+
     @Test
     public void testMethodsNullSorterSub() {
         List<String> expected = Arrays.asList(SUB_METHOD);
@@ -146,7 +146,7 @@ public class MethodSorterTest {
     @Test
     public void testJvmMethodSorter() {
         Method[] fromJvmWithSynthetics = DummySortJvm.class.getDeclaredMethods();
-        Method[] sorted = MethodSorter.getDeclaredMethods(DummySortJvm.class);
+        Method[] sorted = MethodSorter.getDeclaredMethods(DummySortJvm.class).getMethods();
         assertArrayEquals(fromJvmWithSynthetics, sorted);
     }
 
@@ -177,6 +177,66 @@ public class MethodSorterTest {
     public void testAscendingMethodSorter() {
         List<String> expected = Arrays.asList(ALPHA, BETA, DELTA, EPSILON, GAMMA_VOID, GAMMA_BOOLEAN);
         List<String> actual = getDeclaredMethodNames(DummySortWithNameAsc.class);
+        assertEquals(expected, actual);
+    }
+
+    @FixMethodOrder(MethodSorters.RANDOM)
+    static class DummyRandomWithoutSeed {
+        Object alpha(int i, double d, Thread t) {
+            return null;
+        }
+
+        void beta(int[][] x) {
+        }
+
+        int gamma() {
+            return 0;
+        }
+
+        void gamma(boolean b) {
+        }
+
+        void delta() {
+        }
+
+        void epsilon() {
+        }
+    }
+
+    @Test
+    public void testRandomWithoutSeed() {
+        List<String> expected = Arrays.asList(ALPHA, BETA, DELTA, EPSILON, GAMMA_VOID, GAMMA_BOOLEAN);
+        List<String> actual = getDeclaredMethodNames(DummyRandomWithoutSeed.class);
+        assertTrue(actual.containsAll(expected));
+    }
+
+    @FixMethodOrder(value = MethodSorters.RANDOM, seed = "7246")
+    static class DummyRandomWithSeed {
+        Object alpha(int i, double d, Thread t) {
+            return null;
+        }
+
+        void beta(int[][] x) {
+        }
+
+        int gamma() {
+            return 0;
+        }
+
+        void gamma(boolean b) {
+        }
+
+        void delta() {
+        }
+
+        void epsilon() {
+        }
+    }
+
+    @Test
+    public void testRandomWithSeed() {
+        List<String> expected = Arrays.asList(GAMMA_BOOLEAN, BETA, GAMMA_VOID, DELTA, EPSILON, ALPHA);
+        List<String> actual = getDeclaredMethodNames(DummyRandomWithSeed.class);
         assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
This is my draft proposal for new @FixMethodOrder(RANDOM) option. It allows you to shuffle test methods order within test suite. Then it's easier to detect tests that has side effects and affect other test. Typical scenario is when you have a test suite that passes with deterministic and predictable order on one JVM, but fails on other. Random order gives you more confidence that your tests don't rely on each order.

Each test suite has it's own random seed and this seed is displayed. Later on you can recreate the same shuffled order using displayed seed. You can achieve that with new @FixMethodOrder parameter - seed. This is guaranteed by Java Random implementation: "If two instances of Random are created with the same seed, and the same sequence of method calls is made for each, they will generate and return identical sequences of numbers".

I have one problem with this draft. I cannot find a proper way to communicate generated seed to user. There are many runners with different purposes and I'm not sure which solution would be fine here. I've marked these places with TODO mark.

If you like my implementation, please help me with that last point.
