### PR TITLE
Added Codecov.io coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
+before_install: sudo pip install codecov
 script: mvn verify javadoc:javadoc
 jdk:
   - oraclejdk7
   - oraclejdk8
   - openjdk7
   - openjdk6
+after_success: codecov

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ For more information, please visit:
 
 [![Built on DEV@cloud](http://www.cloudbees.com/sites/default/files/Button-Built-on-CB-1.png)](http://www.cloudbees.com/foss/foss-dev.cb)
 
+[![codecov.io](https://codecov.io/github/junit-team/junit/coverage.svg?branch=master)](https://codecov.io/github/junit-team/junit?branch=master)

--- a/pom.xml
+++ b/pom.xml
@@ -332,6 +332,25 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.5.8.201207111220</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Hey Friends! I'm from [Codecov.io](https://codecov.io/) and I wanted to personally add our coverage reporting tools to junit.

You can see the reports **now** here: [codecov.io/github/stevepeak/junit](https://codecov.io/github/stevepeak/junit) 

[![codecov.io](https://codecov.io/github/stevepeak/junit/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/junit?branch=master)

I'm excited to hear your feedback! Thank you for your time.