### PR TITLE
Fix Yahoo Groups URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <mailingList>
             <name>JUnit Mailing List</name>
             <post>junit@yahoogroups.com</post>
-            <archive>http://tech.groups.yahoo.com/group/junit/</archive>
+            <archive>https://groups.yahoo.com/neo/groups/junit/info</archive>
         </mailingList>
     </mailingLists>
 


### PR DESCRIPTION
The URL is shown on our website and broken at the moment.
