### PR TITLE
Disable maven-site-plugin reports that don't add any value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,6 @@
                     <reportSet>
                         <reports>
                             <report>index</report>
-                            <report>summary</report>
                             <report>dependency-info</report>
                             <report>modules</report>
                             <report>license</report>


### PR DESCRIPTION
- Ref -- simply browse the code on GitHub
- changes -- was empty anyways
- GitHub issues -- outdated after ten minutes, simply browse the issues on GitHub
- Surefire -- not useful to look at test results that are days, weeks, or months old
- Maven plugins -- take a look at the POM
- Summary -- says nothing new
