### PR TITLE
Make ErrorCollector#checkSucceeds() generic

### DIFF
--- a/src/main/java/org/junit/rules/ErrorCollector.java
+++ b/src/main/java/org/junit/rules/ErrorCollector.java
@@ -73,7 +73,7 @@ public class ErrorCollector extends Verifier {
      * Execution continues, but the test will fail at the end if
      * {@code callable} threw an exception.
      */
-    public Object checkSucceeds(Callable<Object> callable) {
+    public <T> T checkSucceeds(Callable<? extends T> callable) {
         try {
             return callable.call();
         } catch (Throwable e) {

--- a/src/test/java/org/junit/tests/experimental/rules/VerifierRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/VerifierRuleTest.java
@@ -84,11 +84,17 @@ public class VerifierRuleTest {
                     throw new RuntimeException("first!");
                 }
             });
-            collector.checkSucceeds(new Callable<Object>() {
-                public Object call() throws Exception {
+            collector.checkSucceeds(new Callable<Integer>() {
+                public Integer call() throws Exception {
                     throw new RuntimeException("second!");
                 }
             });
+            Integer result = collector.checkSucceeds(new Callable<Integer>() {
+                public Integer call() throws Exception {
+                    return 1;
+                }
+            });
+            assertEquals(Integer.valueOf(1), result);
         }
     }
 


### PR DESCRIPTION
This brings the signatures in line with others like Assert.assertThat.
Especially the checkSucceeds would be hardly usable in languages with target typing (Java8/Xtend) otherwise.
