### PR TITLE
#669 Cutting on stack call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,6 @@
                     <reportSet>
                         <reports>
                             <report>index</report>
-                            <report>summary</report>
                             <report>dependency-info</report>
                             <report>modules</report>
                             <report>license</report>
@@ -360,21 +359,7 @@
                             <report>dependencies</report>
                             <report>dependency-convergence</report>
                             <report>cim</report>
-                            <report>plugin-management</report>
-                            <report>plugins</report>
                             <report>distribution-management</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
-            </plugin>
-            <plugin>
-                <artifactId>maven-changes-plugin</artifactId>
-                <version>2.10</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>changes-report</report>
-                            <report>github-report</report>
                         </reports>
                     </reportSet>
                 </reportSets>
@@ -418,14 +403,6 @@
                         </reports>
                     </reportSet>
                 </reportSets>
-            </plugin>
-            <plugin>
-                <artifactId>maven-jxr-plugin</artifactId>
-                <version>2.4</version>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>2.17</version>
             </plugin>
         </plugins>
     </reporting>

--- a/src/main/java/junit/runner/stackfilter/Packages.java
+++ b/src/main/java/junit/runner/stackfilter/Packages.java
@@ -1,0 +1,38 @@
+package junit.runner.stackfilter;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+public final class Packages implements Iterable<String> {
+    
+    private Set<String> packageSet = new HashSet<String>();
+
+    public Packages(String[] pkgs) {
+        add(pkgs);
+    }
+    
+    public void add(String[] pkgs) {
+        for (String pkg : pkgs) {
+            packageSet.add(pkg);
+        }
+    }
+    
+    public static Packages defaultPackages() {
+        return new Packages(new String[]{
+            "junit.framework.TestCase",
+            "junit.framework.TestResult",
+            "junit.framework.TestSuite",
+            "junit.swingui.TestRunner",
+            "junit.awtui.TestRunner",
+            "junit.textui.TestRunner",
+            "sun.reflect",
+            "java.lang.reflect.Method.invoke"});
+    }
+
+    public Iterator<String> iterator() {
+        return packageSet.iterator();
+    }
+    
+}
+

--- a/src/main/java/junit/runner/stackfilter/TraceFilter.java
+++ b/src/main/java/junit/runner/stackfilter/TraceFilter.java
@@ -1,0 +1,49 @@
+package junit.runner.stackfilter;
+
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+public class TraceFilter {
+    
+    private static Packages packages;
+    
+    private TraceFilter() {
+        super();
+    } 
+
+    public static String filter(String trace) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        StringReader sr = new StringReader(trace);
+        BufferedReader br = new BufferedReader(sr);
+
+        String line;
+        try {
+            while ((line = br.readLine()) != null) {
+                if (!filterLine(line)) {
+                    pw.println(line);
+                }
+            }
+        } catch (Exception IOException) {
+            return trace;
+        }
+        
+        return sw.toString();
+    }
+    
+    private static boolean filterLine(String line) {
+        for (String pkg : packages) {
+            if (line.indexOf(pkg) > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    public static void setPackages(Packages pkgs) {
+        packages = pkgs;
+    }
+    
+}

--- a/src/main/java/junit/textui/TestRunner.java
+++ b/src/main/java/junit/textui/TestRunner.java
@@ -2,6 +2,8 @@ package junit.textui;
 
 
 import java.io.PrintStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -9,6 +11,8 @@ import junit.framework.TestResult;
 import junit.framework.TestSuite;
 import junit.runner.BaseTestRunner;
 import junit.runner.Version;
+import junit.runner.stackfilter.Packages;
+import junit.runner.stackfilter.TraceFilter;
 
 /**
  * A command line based tool to run tests.
@@ -164,6 +168,10 @@ public class TestRunner extends BaseTestRunner {
                 int lastIndex = arg.lastIndexOf('.');
                 testCase = arg.substring(0, lastIndex);
                 method = arg.substring(lastIndex + 1);
+            }
+            else if (args[i].contains("-filterstack")) {
+                setPreference("filterstack", "true");
+                parsePackages(args[i]);
             } else if (args[i].equals("-v")) {
                 System.err.println("JUnit " + Version.id() + " by Kent Beck and Erich Gamma");
             } else {
@@ -184,6 +192,18 @@ public class TestRunner extends BaseTestRunner {
         } catch (Exception e) {
             throw new Exception("Could not create and run test suite: " + e);
         }
+    }
+
+    private void parsePackages(String pkgs) {
+        Pattern pattern = Pattern.compile("\\[(.*?)\\]");
+        Matcher matcher = pattern.matcher(pkgs);
+        
+        if (matcher.find()) {
+            String[] parsedPkgs = matcher.group(1).split(",");
+            TraceFilter.setPackages(new Packages(parsedPkgs));
+        } else {
+            TraceFilter.setPackages(Packages.defaultPackages());
+        }        
     }
 
     protected TestResult runSingleMethod(String testCase, String method, boolean wait) throws Exception {

--- a/src/test/java/junit/tests/runner/StackFilterTest.java
+++ b/src/test/java/junit/tests/runner/StackFilterTest.java
@@ -5,6 +5,8 @@ import java.io.StringWriter;
 
 import junit.framework.TestCase;
 import junit.runner.BaseTestRunner;
+import junit.runner.stackfilter.Packages;
+import junit.runner.stackfilter.TraceFilter;
 
 public class StackFilterTest extends TestCase {
     String fFiltered;
@@ -41,6 +43,8 @@ public class StackFilterTest extends TestCase {
     }
 
     public void testFilter() {
+        TraceFilter.setPackages(new Packages(new String[]{"junit", "java.lang.reflect"}));
+        BaseTestRunner.setPreference("filterstack", "true");
         assertEquals(fFiltered, BaseTestRunner.getFilteredTrace(fUnfiltered));
     }
 }


### PR DESCRIPTION
The class Packages represents the packages that must be filtered when the stacktrace will be printed, an instance of packages are passed to the Tracefilter, that do the filtering....

- If the user pass -filterstack argument, the stack will be filtered with some "default packages".
- If they pass -filterstack [pkg1, pkg2, pkg3], the pkg1, pkg2, pkg3 will be filtered from the trace (-filterstack [java.lang, junit.framework, ...]