### PR TITLE
Added validtion that @ClassRule should only be implementation of TestRule

### DIFF
--- a/src/main/java/org/junit/internal/runners/rules/RuleMemberValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/RuleMemberValidator.java
@@ -34,7 +34,7 @@ public class RuleMemberValidator {
             .withValidator(new DeclaringClassMustBePublic())
             .withValidator(new MemberMustBeStatic())
             .withValidator(new MemberMustBePublic())
-            .withValidator(new FieldMustBeARule())
+            .withValidator(new FieldMustBeATestRule())
             .build();
     /**
      * Validates fields with a {@link Rule} annotation.
@@ -54,7 +54,7 @@ public class RuleMemberValidator {
             .withValidator(new DeclaringClassMustBePublic())
             .withValidator(new MemberMustBeStatic())
             .withValidator(new MemberMustBePublic())
-            .withValidator(new MethodMustBeARule())
+            .withValidator(new MethodMustBeATestRule())
             .build();
 
     /**
@@ -246,6 +246,33 @@ public class RuleMemberValidator {
             if (!isRuleType(member)) {
                 errors.add(new ValidationError(member, annotation,
                         "must return an implementation of MethodRule or TestRule."));
+            }
+        }
+    }
+    
+    /**
+     * Require the member to return an implementation of {@link org.junit.rules.TestRule}
+     */
+    private static final class MethodMustBeATestRule implements RuleValidator {
+        public void validate(FrameworkMember<?> member,
+                Class<? extends Annotation> annotation, List<Throwable> errors) {
+            if (!isTestRule(member)) {
+                errors.add(new ValidationError(member, annotation, 
+                        "must return an implementation of TestRule."));
+            }
+        }
+    }
+    
+    /**
+     * Requires the member is a field implementing {@link org.junit.rules.TestRule}
+     */
+    private static final class FieldMustBeATestRule implements RuleValidator {
+
+        public void validate(FrameworkMember<?> member,
+                Class<? extends Annotation> annotation, List<Throwable> errors) {
+            if (!isTestRule(member)) {
+                errors.add(new ValidationError(member, annotation,
+                        "must implement TestRule."));
             }
         }
     }

--- a/src/test/java/org/junit/tests/experimental/rules/RuleMemberValidatorTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/RuleMemberValidatorTest.java
@@ -71,7 +71,97 @@ public class RuleMemberValidatorTest {
         @ClassRule
         public static TestRule temporaryFolder = new TemporaryFolder();
     }
+    
+    /**
+     * If there is any property annotated with @ClassRule then it must implement
+     * {@link TestRule}
+     * 
+     * <p>This case has been added with 
+     * <a href="https://github.com/junit-team/junit/issues/1019">Issue #1019</a>
+     */
+    @Test
+    public void rejectClassRuleThatIsImplemetationOfMethodRule() {
+        TestClass target = new TestClass(TestWithClassRuleIsImplementationOfMethodRule.class);
+        CLASS_RULE_VALIDATOR.validate(target, errors);
+        assertOneErrorWithMessage("The @ClassRule 'classRule' must implement TestRule.");
+    }
+    
+    public static class TestWithClassRuleIsImplementationOfMethodRule {
+        @ClassRule
+        public static MethodRule classRule = new MethodRule() {
+            
+            public Statement apply(Statement base, FrameworkMethod method, Object target) {
+                return base;
+            }
+        };
+    }
 
+    /**
+     * If there is any method annotated with @ClassRule then it must return an 
+     * implementation of {@link TestRule}
+     * 
+     * <p>This case has been added with 
+     * <a href="https://github.com/junit-team/junit/issues/1019">Issue #1019</a>
+     */
+    @Test
+    public void rejectClassRuleThatReturnsImplementationOfMethodRule() {
+        TestClass target = new TestClass(TestWithClassRuleMethodThatReturnsMethodRule.class);
+        CLASS_RULE_METHOD_VALIDATOR.validate(target, errors);
+        assertOneErrorWithMessage("The @ClassRule 'methodRule' must return an implementation of TestRule.");
+    }
+
+    public static class TestWithClassRuleMethodThatReturnsMethodRule {
+        @ClassRule
+        public static MethodRule methodRule() {
+            return new MethodRule() {
+                
+                public Statement apply(Statement base, FrameworkMethod method, Object target) {
+                    return base;
+                }
+            };
+        }
+    }
+    
+    /**
+     * If there is any property annotated with @ClassRule then it must implement
+     * {@link TestRule}
+     * 
+     * <p>This case has been added with 
+     * <a href="https://github.com/junit-team/junit/issues/1019">Issue #1019</a>
+     */
+    @Test
+    public void rejectClassRuleIsAnArbitraryObject() throws Exception {
+        TestClass target = new TestClass(TestWithClassRuleIsAnArbitraryObject.class);
+        CLASS_RULE_VALIDATOR.validate(target, errors);
+        assertOneErrorWithMessage("The @ClassRule 'arbitraryObject' must implement TestRule.");
+    }
+
+    public static class TestWithClassRuleIsAnArbitraryObject {
+        @ClassRule
+        public static Object arbitraryObject = 1;
+    }
+    
+    /**
+     * If there is any method annotated with @ClassRule then it must return an 
+     * implementation of {@link TestRule}
+     * 
+     * <p>This case has been added with 
+     * <a href="https://github.com/junit-team/junit/issues/1019">Issue #1019</a> 
+     */
+    @Test
+    public void rejectClassRuleMethodReturnsAnArbitraryObject() throws Exception {
+        TestClass target = new TestClass(TestWithClassRuleMethodReturnsAnArbitraryObject.class);
+        CLASS_RULE_METHOD_VALIDATOR.validate(target, errors);
+        assertOneErrorWithMessage("The @ClassRule 'arbitraryObject' must return an implementation of TestRule.");
+    }
+
+    public static class TestWithClassRuleMethodReturnsAnArbitraryObject {
+        @ClassRule
+        public static Object arbitraryObject() {
+            return 1;
+        }
+    }
+    
     @Test
     public void acceptNonStaticTestRule() {
         TestClass target = new TestClass(TestWithNonStaticTestRule.class);


### PR DESCRIPTION
Fixes #1019 
- Added validation that `@ClassRule` must be an implementation of `TestRule`
