### PR TITLE
JavaDoc of TemperaryFolder: folder not guaranteed to be deleted

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -6,10 +6,12 @@ import java.io.IOException;
 import org.junit.Rule;
 
 /**
- * The TemporaryFolder Rule allows creation of files and folders that are
- * guaranteed to be deleted when the test method finishes (whether it passes or
- * fails):
+ * The TemporaryFolder Rule allows creation of files and folders that should
+ * be deleted when the test method finishes (whether it passes or
+ * fails). Whether the deletion is successful or not is not checked by this rule.
+ * No exception will be thrown in case the deletion fails.
  *
+ * <p>Example of usage:
  * <pre>
  * public static class HasTempFolder {
  *  &#064;Rule


### PR DESCRIPTION
This adjusts the JavaDoc of `TemporaryFolder` to make it clear that the folders created by the rule are not guaranteed to be deleted after the test finishes, cf. discussion in #1001 and #616.
