### PR TITLE
Fix Incompatibility with JDK5 source level

### DIFF
--- a/src/test/java/org/junit/tests/experimental/rules/MethodRulesTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/MethodRulesTest.java
@@ -294,8 +294,6 @@ public class MethodRulesTest {
     
     public static class HasMethodReturningMethodRule {
         private MethodRule methodRule = new MethodRule() {
-            
-            @Override
             public Statement apply(final Statement base, FrameworkMethod method, Object target) {
                 return new Statement() {
                     
@@ -371,8 +369,6 @@ public class MethodRulesTest {
         int callCount = 0;
         
         private static class Dummy implements MethodRule {
-            
-            @Override
             public Statement apply(final Statement base, FrameworkMethod method, Object target) {
                 return new Statement() {
                     


### PR DESCRIPTION
This was introduced by #1015 and only discovered now because CloudBees broke our Jenkins build by updating Jenkins which apparently no longer supports Maven builds running on JDK5... :scream: 
