### PR TITLE
Link to Maven-generated Javadoc

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -88,7 +88,7 @@
             <li><a href="https://github.com/junit-team/junit/wiki/Maintainer-documentation">Maintainer Documentation</a></li>
             <li><a href="https://github.com/junit-team/junit/wiki/I-want-to-help%21">I want to help!</a></li>
             <li><a href="http://stackoverflow.com/questions/tagged/junit">Latest JUnit Questions on StackOverflow</a></li>
-<li>JavaDocs</li>
+            <li><a href="./apidocs/">JavaDocs</a></li>
             <li><a href="./faq.html">Frequently asked questions</a></li>
             <li><a href="https://github.com/junit-team/junit/wiki">Wiki</a></li>
           </ul>


### PR DESCRIPTION
This is related to #1023 but we still do not provide browsable Javadocs for old versions.
