### PR TITLE
PR to utilize 'use' option for cross-referencing javadoc pages #1035

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
                     <detectLinks>false</detectLinks>
                     <linksource>true</linksource>
                     <keywords>true</keywords>
-                    <use>false</use>
+                    <use>true</use>
                     <windowtitle>JUnit API</windowtitle>
                     <encoding>UTF-8</encoding>
                     <locale>en</locale>
@@ -391,7 +391,7 @@
                     <detectLinks>false</detectLinks>
                     <linksource>true</linksource>
                     <keywords>true</keywords>
-                    <use>false</use>
+                    <use>true</use>
                     <windowtitle>JUnit API</windowtitle>
                     <encoding>UTF-8</encoding>
                     <locale>en</locale>


### PR DESCRIPTION
I have updated pom.xml to utilize the "use" option as per #1035 
