### PR TITLE
Parameterized reuses testclass

### DIFF
--- a/src/main/java/org/junit/experimental/theories/Theories.java
+++ b/src/main/java/org/junit/experimental/theories/Theories.java
@@ -215,7 +215,7 @@ public class Theories extends BlockJUnit4ClassRunner {
 
         protected void runWithCompleteAssignment(final Assignments complete)
                 throws Throwable {
-            new BlockJUnit4ClassRunner(getTestClass().getJavaClass()) {
+            new BlockJUnit4ClassRunner(getTestClass()) {
                 @Override
                 protected void collectInitializationErrors(
                         List<Throwable> errors) {

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -29,6 +29,7 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
 
 /**
  * Implements the JUnit 4 standard test case class model, as defined by the
@@ -63,6 +64,16 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
      */
     public BlockJUnit4ClassRunner(Class<?> klass) throws InitializationError {
         super(klass);
+    }
+
+    /**
+     * Creates a BlockJUnit4ClassRunner to run {@code testClass}.
+     *
+     * @throws InitializationError if the test class is malformed.
+     * @since 4.13
+     */
+    public BlockJUnit4ClassRunner(TestClass testClass) throws InitializationError {
+        super(testClass);
     }
 
     //

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -84,6 +84,20 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
         validate();
     }
 
+    /**
+     * Constructs a new {@code ParentRunner} that will run the {@code TestClass}.
+     * @since 4.13
+     */
+    protected ParentRunner(TestClass testClass) throws InitializationError {
+        this.testClass = testClass;
+        validate();
+    }
+
+    /**
+     * @deprecated Please use {@link #ParentRunner(org.junit.runners.model.TestClass)}.
+     * @since 4.12
+     */
+    @Deprecated
     protected TestClass createTestClass(Class<?> testClass) {
         return new TestClass(testClass);
     }

--- a/src/main/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParameters.java
+++ b/src/main/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParameters.java
@@ -24,7 +24,7 @@ public class BlockJUnit4ClassRunnerWithParameters extends
 
     public BlockJUnit4ClassRunnerWithParameters(TestWithParameters test)
             throws InitializationError {
-        super(test.getTestClass().getJavaClass());
+        super(test.getTestClass());
         parameters = test.getParameters().toArray(
                 new Object[test.getParameters().size()]);
         name = test.getName();


### PR DESCRIPTION
The `BlockJUnit4ClassRunnerWithParameters` created a new instance of `TestClass` for each parameter set. This lead to repeated class scanning and noticeable memory allocation. Reusing the `TestClass` avoids theses side effects. `TestClass` is reused by the Theories runner, too, because it is now possible.

Fixes #1046.
