### PR TITLE
Fix swallowed exception in Request.classes(...)

### DIFF
--- a/src/main/java/org/junit/runner/Request.java
+++ b/src/main/java/org/junit/runner/Request.java
@@ -75,8 +75,7 @@ public abstract class Request {
             Runner suite = computer.getSuite(builder, classes);
             return runner(suite);
         } catch (InitializationError e) {
-            throw new RuntimeException(
-                    "Bug in saff's brain: Suite constructor, called as above, should always complete");
+            return runner(new ErrorReportingRunner(e, classes));
         }
     }
 

--- a/src/test/java/org/junit/runner/RequestTest.java
+++ b/src/test/java/org/junit/runner/RequestTest.java
@@ -1,0 +1,63 @@
+package org.junit.runner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerBuilder;
+
+public class RequestTest {
+
+    @Test
+    public void shouldReportFailureWhenSuiteCannotBeInitialized() {
+        RunNotifier notifier = new RunNotifier();
+        final FailureRunListener runListener = new FailureRunListener();
+        notifier.addListener(runListener);
+
+        Request.classes(new FailingComputer(), FooTest.class, BarTest.class)
+               .getRunner()
+               .run(notifier);
+
+        assertThat("There should be exactly one failure for the failed suite and not one for each test class",
+                   runListener.getFailures().size(), equalTo(1));
+    }
+
+    private static class FailingComputer extends Computer {
+
+        @Override
+        public Runner getSuite(RunnerBuilder builder, Class<?>[] classes)
+                throws InitializationError {
+            throw new InitializationError(new IllegalArgumentException());
+        }
+
+    }
+
+    private static class FailureRunListener extends RunListener {
+
+        private List<Failure> failures = new ArrayList<Failure>();
+
+        @Override
+        public void testFailure(Failure failure) throws Exception {
+            failures.add(failure);
+        }
+
+        public List<? extends Failure> getFailures() {
+            return failures;
+        }
+
+    }
+
+    private static class FooTest {
+    }
+
+    private static class BarTest {
+    }
+
+}

--- a/src/test/java/org/junit/tests/internal/runners/ErrorReportingRunnerTest.java
+++ b/src/test/java/org/junit/tests/internal/runners/ErrorReportingRunnerTest.java
@@ -4,8 +4,25 @@ import org.junit.Test;
 import org.junit.internal.runners.ErrorReportingRunner;
 
 public class ErrorReportingRunnerTest {
+    
     @Test(expected = NullPointerException.class)
     public void cannotCreateWithNullClass() {
         new ErrorReportingRunner(null, new RuntimeException());
     }
+    
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateWithNullClass2() {
+        new ErrorReportingRunner(new RuntimeException(), (Class<?>) null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateWithNullClasses() {
+        new ErrorReportingRunner(new RuntimeException(), (Class<?>[]) null);
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void cannotCreateWithoutClass() {
+        new ErrorReportingRunner(new RuntimeException());
+    }
+    
 }


### PR DESCRIPTION
The method [classes(Computer computer, Class<?>... classes)](https://github.com/junit-team/junit/blob/master/src/main/java/org/junit/runner/Request.java#L78) in
org.junit.runner.Request swallows an InitializationError and throws a
new RuntimeException instead when it cannot create a request. This
prevents the user from finding out why the request could not be created.

This change replaces throwing a new RuntimeException with generating a
proper error report. The report contains the causes of the
InitializationError so the user has a chance to find out what is causing
the problem.

Instead of an incomplete stack trace with the message "Bug in saff's brain: Suite constructor, called as above, should always complete" like

```
java.lang.reflect.InvocationTargetException
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    <snip>
Caused by: java.lang.RuntimeException: Bug in saff's brain: Suite constructor, called as above, should always complete
    at org.junit.runner.Request.classes(Request.java:72)
    at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.createRequestAndRun(JUnitCoreWrapper.java:102)
    at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.executeEager(JUnitCoreWrapper.java:85)
    at org.apache.maven.surefire.junitcore.JUnitCoreWrapper.execute(JUnitCoreWrapper.java:54)
    ... 27 more
```

the user gets an error report like

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running ch.acanda.eclipse.pmd.unsupported.ProjectPropertyTesterTest
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.002 sec <<< FAILURE! - in ch.acanda.eclipse.pmd.unsupported.ProjectPropertyTesterTest
initializationError(ch.acanda.eclipse.pmd.unsupported.ProjectPropertyTesterTest)  Time elapsed: 0.002 sec  <<< ERROR!
org.apache.maven.surefire.testset.TestSetFailedException: Unspecified thread-count(s). See the parameters useUnlimitedThreads, threadcount, threadcountsuites, threadcountclasses, threadcountmethods.
    at org.apache.maven.surefire.junitcore.pc.ParallelComputerUtil.resolveConcurrency(ParallelComputerUtil.java:69)
    at org.apache.maven.surefire.junitcore.pc.ParallelComputerBuilder$PC.determineThreadCounts(ParallelComputerBuilder.java:312)
    at org.apache.maven.surefire.junitcore.pc.ParallelComputerBuilder$PC.getSuite(ParallelComputerBuilder.java:272)
    at org.junit.runner.Request.classes(Request.java:75)
    <snip>
    at org.eclipse.equinox.launcher.Main.main(Main.java:1386)


Results :

Tests in error: 
  Unspecified thread-count(s). See the parameters useUnlimitedThreads, threadcount, threadcountsuites, threadcountclasses, threadcountmethods.

Tests run: 1, Failures: 0, Errors: 1, Skipped: 0

```
