### PR TITLE
Add suite start/finish events to listener

### DIFF
--- a/src/main/java/org/junit/internal/runners/model/EachTestNotifier.java
+++ b/src/main/java/org/junit/internal/runners/model/EachTestNotifier.java
@@ -45,4 +45,27 @@ public class EachTestNotifier {
     public void fireTestIgnored() {
         notifier.fireTestIgnored(description);
     }
+
+    /**
+     * Calls {@link RunNotifier#fireTestSuiteStarted(Description)}, passing the
+     * {@link Description} that was passed to the {@code EachTestNotifier} constructor.
+     * This should be called when a test suite is about to be started.
+     * @see RunNotifier#fireTestSuiteStarted(Description)
+     * @since 4.13
+     */
+    public void fireTestSuiteStarted() {
+        notifier.fireTestSuiteStarted(description);
+    }
+
+    /**
+     * Calls {@link RunNotifier#fireTestSuiteFinished(Description)}, passing the
+     * {@link Description} that was passed to the {@code EachTestNotifier} constructor.
+     * This should be called when a test suite has finished, whether the test suite succeeds
+     * or fails.
+     * @see RunNotifier#fireTestSuiteFinished(Description)
+     * @since 4.13
+     */
+    public void fireTestSuiteFinished() {
+        notifier.fireTestSuiteFinished(description);
+    }
 }

--- a/src/main/java/org/junit/runner/notification/RunListener.java
+++ b/src/main/java/org/junit/runner/notification/RunListener.java
@@ -70,6 +70,25 @@ public class RunListener {
     }
 
     /**
+     * Called when a test suite is about to be started.
+     *
+     * @param description the description of the test suite that is about to be run
+     *                    (generally a class name)
+     * @since 4.13
+     */
+    public void testSuiteStarted(Description description) throws Exception {
+    }
+
+    /**
+     * Called when a test suite has finished, whether the test suite succeeds or fails.
+     *
+     * @param description the description of the test suite that just ran
+     * @since 4.13
+     */
+    public void testSuiteFinished(Description description) throws Exception {
+    }
+
+    /**
      * Called when an atomic test is about to be started.
      *
      * @param description the description of the test that is about to be run

--- a/src/main/java/org/junit/runner/notification/RunNotifier.java
+++ b/src/main/java/org/junit/runner/notification/RunNotifier.java
@@ -106,6 +106,38 @@ public class RunNotifier {
     }
 
     /**
+     * Invoke to tell listeners that a test suite is about to start.
+     *
+     * @param description the description of the suite test (generally a class name)
+     * @since 4.13
+     */
+    public void fireTestSuiteStarted(final Description description) {
+        new SafeNotifier() {
+            @Override
+            protected void notifyListener(RunListener each) throws Exception {
+                each.testSuiteStarted(description);
+            }
+        }.run();
+    }
+
+    /**
+     * Invoke to tell listeners that a test suite is about to finish. Always invoke
+     * this method if you invoke {@link #fireTestSuiteStarted(Description)}
+     * as listeners are likely to expect them to come in pairs.
+     *
+     * @param description the description of the suite test (generally a class name)
+     * @since 4.13
+     */
+    public void fireTestSuiteFinished(final Description description) {
+        new SafeNotifier() {
+            @Override
+            protected void notifyListener(RunListener each) throws Exception {
+                each.testSuiteFinished(description);
+            }
+        }.run();
+    }
+
+    /**
      * Invoke to tell listeners that an atomic test is about to start.
      *
      * @param description the description of the atomic test (generally a class and method name)

--- a/src/main/java/org/junit/runner/notification/SynchronizedRunListener.java
+++ b/src/main/java/org/junit/runner/notification/SynchronizedRunListener.java
@@ -43,6 +43,37 @@ final class SynchronizedRunListener extends RunListener {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Synchronized decorator for {@link RunListener#testSuiteStarted(Description)}.
+     * @param description the description of the test suite that is about to be run
+     *                    (generally a class name).
+     * @throws Exception if any occurs.
+     * @since 4.13
+     */
+    @Override
+    public void testSuiteStarted(Description description) throws Exception {
+        synchronized (monitor) {
+            listener.testSuiteStarted(description);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p/>
+     * Synchronized decorator for {@link RunListener#testSuiteFinished(Description)}.
+     * @param description the description of the test suite that just ran.
+     * @throws Exception
+     * @since 4.13
+     */
+    @Override
+    public void testSuiteFinished(Description description) throws Exception {
+        synchronized (monitor) {
+            listener.testSuiteFinished(description);
+        }
+    }
+
     @Override
     public void testStarted(Description description) throws Exception {
         synchronized (monitor) {

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -358,6 +358,7 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
     public void run(final RunNotifier notifier) {
         EachTestNotifier testNotifier = new EachTestNotifier(notifier,
                 getDescription());
+        testNotifier.fireTestSuiteStarted();
         try {
             Statement statement = classBlock(notifier);
             statement.evaluate();
@@ -367,6 +368,8 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
             throw e;
         } catch (Throwable e) {
             testNotifier.addFailure(e);
+        } finally {
+            testNotifier.fireTestSuiteFinished();
         }
     }
 

--- a/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
@@ -167,9 +167,14 @@ public class ParentRunnerTest {
     @Test
     public void assertionErrorAtParentLevelTest() throws InitializationError {
         CountingRunListener countingRunListener = runTestWithParentRunner(AssertionErrorAtParentLevelTest.class);
+        Assert.assertEquals(1, countingRunListener.testSuiteStarted);
+        Assert.assertEquals(1, countingRunListener.testSuiteFinished);
+        Assert.assertEquals(1, countingRunListener.testSuiteFailure);
+        Assert.assertEquals(0, countingRunListener.testSuiteAssumptionFailure);
+
         Assert.assertEquals(0, countingRunListener.testStarted);
         Assert.assertEquals(0, countingRunListener.testFinished);
-        Assert.assertEquals(1, countingRunListener.testFailure);
+        Assert.assertEquals(0, countingRunListener.testFailure);
         Assert.assertEquals(0, countingRunListener.testAssumptionFailure);
         Assert.assertEquals(0, countingRunListener.testIgnored);
     }
@@ -188,10 +193,15 @@ public class ParentRunnerTest {
     @Test
     public void assumptionViolatedAtParentLevel() throws InitializationError {
         CountingRunListener countingRunListener = runTestWithParentRunner(AssumptionViolatedAtParentLevelTest.class);
+        Assert.assertEquals(1, countingRunListener.testSuiteStarted);
+        Assert.assertEquals(1, countingRunListener.testSuiteFinished);
+        Assert.assertEquals(0, countingRunListener.testSuiteFailure);
+        Assert.assertEquals(1, countingRunListener.testSuiteAssumptionFailure);
+
         Assert.assertEquals(0, countingRunListener.testStarted);
         Assert.assertEquals(0, countingRunListener.testFinished);
         Assert.assertEquals(0, countingRunListener.testFailure);
-        Assert.assertEquals(1, countingRunListener.testAssumptionFailure);
+        Assert.assertEquals(0, countingRunListener.testAssumptionFailure);
         Assert.assertEquals(0, countingRunListener.testIgnored);
     }
 
@@ -218,6 +228,11 @@ public class ParentRunnerTest {
     @Test
     public void parentRunnerTestMethods() throws InitializationError {
         CountingRunListener countingRunListener = runTestWithParentRunner(TestTest.class);
+        Assert.assertEquals(1, countingRunListener.testSuiteStarted);
+        Assert.assertEquals(1, countingRunListener.testSuiteFinished);
+        Assert.assertEquals(0, countingRunListener.testSuiteFailure);
+        Assert.assertEquals(0, countingRunListener.testSuiteAssumptionFailure);
+
         Assert.assertEquals(3, countingRunListener.testStarted);
         Assert.assertEquals(3, countingRunListener.testFinished);
         Assert.assertEquals(1, countingRunListener.testFailure);
@@ -235,11 +250,26 @@ public class ParentRunnerTest {
     }
 
     private static class CountingRunListener extends RunListener {
+        private int testSuiteStarted = 0;
+        private int testSuiteFinished = 0;
+        private int testSuiteFailure = 0;
+        private int testSuiteAssumptionFailure = 0;
+
         private int testStarted = 0;
         private int testFinished = 0;
         private int testFailure = 0;
         private int testAssumptionFailure = 0;
         private int testIgnored = 0;
+
+        @Override
+        public void testSuiteStarted(Description description) throws Exception {
+            testSuiteStarted++;
+        }
+
+        @Override
+        public void testSuiteFinished(Description description) throws Exception {
+            testSuiteFinished++;
+        }
 
         @Override
         public void testStarted(Description description) throws Exception {
@@ -253,12 +283,20 @@ public class ParentRunnerTest {
 
         @Override
         public void testFailure(Failure failure) throws Exception {
-            testFailure++;
+            if (failure.getDescription().isSuite()) {
+                testSuiteFailure++;
+            } else {
+                testFailure++;
+            }
         }
 
         @Override
         public void testAssumptionFailure(Failure failure) {
-            testAssumptionFailure++;
+            if (failure.getDescription().isSuite()) {
+                testSuiteAssumptionFailure++;
+            } else {
+                testAssumptionFailure++;
+            }
         }
 
         @Override


### PR DESCRIPTION
Hi guys! 

This pull request adds ability to handle suite start/finish events via `RunListener`.

Maybe better to use `testStarted` and `testFinished` events instead new ones but I am afraid to break backwards compatibility. Tests will be added later. 

What are you guys think?