### PR TITLE
MethodSorter METHOD_ORDER allowing to specify the execution order of test methods

### DIFF
--- a/src/main/java/org/junit/Test.java
+++ b/src/main/java/org/junit/Test.java
@@ -95,4 +95,10 @@ public @interface Test {
      * </p>
      */
     long timeout() default 0L;
+
+    /**
+     * Optionally specify the execution order of a test method. Methods are executed from the lowest <code>order</code>
+     * to the highest.
+     */
+    int order() default 0;
 }

--- a/src/main/java/org/junit/internal/MethodSorter.java
+++ b/src/main/java/org/junit/internal/MethodSorter.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import org.junit.FixMethodOrder;
+import org.junit.Test;
 
 public class MethodSorter {
     /**
@@ -31,6 +32,17 @@ public class MethodSorter {
                 return comparison;
             }
             return m1.toString().compareTo(m2.toString());
+        }
+    };
+
+    /**
+     * Sort order using {@link Test#order()} attributes
+     */
+    public static Comparator<Method> METHOD_ORDER = new Comparator<Method>() {
+        public int compare(Method m1, Method m2) {
+            final Test t1 = m1.getAnnotation(Test.class);
+            final Test t2 = m2.getAnnotation(Test.class);
+            return (t1 != null ? t1.order() : 0) - (t2 != null ? t2.order() : 0);
         }
     };
 

--- a/src/main/java/org/junit/runners/MethodSorters.java
+++ b/src/main/java/org/junit/runners/MethodSorters.java
@@ -3,6 +3,7 @@ package org.junit.runners;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 
+import org.junit.Test;
 import org.junit.internal.MethodSorter;
 
 /**
@@ -17,6 +18,11 @@ public enum MethodSorters {
      * with {@link Method#toString()} used as a tiebreaker
      */
     NAME_ASCENDING(MethodSorter.NAME_ASCENDING),
+
+    /**
+     * Sorts the test methods using {@link Test#order()} attributes
+     */
+    METHOD_ORDER(MethodSorter.METHOD_ORDER),
 
     /**
      * Leaves the test methods in the order returned by the JVM.

--- a/src/test/java/org/junit/internal/MethodSorterTest.java
+++ b/src/test/java/org/junit/internal/MethodSorterTest.java
@@ -179,4 +179,40 @@ public class MethodSorterTest {
         List<String> actual = getDeclaredMethodNames(DummySortWithNameAsc.class);
         assertEquals(expected, actual);
     }
+
+    @FixMethodOrder(MethodSorters.METHOD_ORDER)
+    static class DummySortWithMethodOrder {
+        @Test(order=1)
+        Object alpha(int i, double d, Thread t) {
+            return null;
+        }
+
+        @Test(order=2)
+        void beta(int[][] x) {
+        }
+
+        @Test(order=5)
+        int gamma() {
+            return 0;
+        }
+
+        @Test(order=6)
+        void gamma(boolean b) {
+        }
+
+        @Test(order=3)
+        void delta() {
+        }
+
+        @Test(order=4)
+        void epsilon() {
+        }
+    }
+
+    @Test
+    public void testMethodOrderSorter() {
+        List<String> expected = Arrays.asList(ALPHA, BETA, DELTA, EPSILON, GAMMA_VOID, GAMMA_BOOLEAN);
+        List<String> actual = getDeclaredMethodNames(DummySortWithMethodOrder.class);
+        assertEquals(expected, actual);
+    }
 }


### PR DESCRIPTION
- added attribute order to the Test annotation for specyfing the execution order
- created a new MethodSorter (METHOD_ORDER) and added it to the MethodSorters enum
- created a unit test for this feature