### PR TITLE
Skip symlinks in recursive temp-dir cleanup, and add test-case

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.Rule;
 
@@ -268,7 +269,9 @@ public class TemporaryFolder extends ExternalResource {
         File[] files = file.listFiles();
         if (files != null) {
             for (File each : files) {
-                result = result && recursiveDelete(each);
+                if (!Files.isSymbolicLink(each.toPath())) {
+                    result = result && recursiveDelete(each);
+                }
             }
         }
         return result && file.delete();

--- a/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TempFolderRuleTest.java
@@ -12,6 +12,7 @@ import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 import org.junit.After;
@@ -173,6 +174,23 @@ public class TempFolderRuleTest {
         folder.create();
         folder.delete();
         assertFalse(folder.getRoot().exists());
+    }
+
+    @Test
+    public void recursiveDeleteDoesntDescendViaSymlinks() throws IOException {
+        TemporaryFolder folderOfUntouchable = new TemporaryFolder();
+        folderOfUntouchable.create();
+        File untouchable = new File(folderOfUntouchable.getRoot(), "untouchable");
+        untouchable.createNewFile();
+
+        TemporaryFolder folder = new TemporaryFolder();
+        folder.create();
+        Files.createSymbolicLink(
+                folder.getRoot().toPath().resolve("symlink"),
+                folderOfUntouchable.getRoot().toPath());
+        folder.delete();
+
+        assertTrue(untouchable.exists());
     }
 
     public static class NameClashes {


### PR DESCRIPTION
BUG: TemporaryFolder.delete() follows symlinks when recursing, which can lead to all sorts of havoc.

The equivalent bug was fixed in Apache IO here (http://svn.apache.org/viewvc/commons/proper/io/trunk/src/main/java/org/apache/commons/io/FileUtils.java?r1=661658&r2=684715&diff_format=h).  I'm not sure whether Files.isSymbolicLink() is sufficient here, or whether to just copy their implementation.