### PR TITLE
Added "RANDOM" method sorting method.

### DIFF
--- a/src/main/java/org/junit/Seed.java
+++ b/src/main/java/org/junit/Seed.java
@@ -1,0 +1,47 @@
+package org.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This class allows the user to seed the random number generator
+ * used when executing tests in random order.
+ * 
+ * <p>Seeding the random number generator in this way allows tests that
+ * were executed in random order (using MethodSorters.RANDOM) 
+ * to be re-run in the same order on a subsequent test.
+ * 
+ * <p>For example, suppose one has a test class like the following:
+ * 
+ * <pre>
+ * &#064;FixMethodOrder(MethodSorters.RANDOM) 
+ * public class MyTest {
+ * }
+ * </pre>
+ * 
+ * <p>Now suppose the tests are run. At the beginning of the test run,
+ * JUnit will print the random number generator seed it used to run the
+ * tests. Now suppose one of the tests fails and it is desired to run the
+ * tests in the same order as the previous run. The user then adds a Seed
+ * annotation to the test class to specify the same random number seed
+ * used in the last run (0xab84b37cb8abc82fL in this example).
+ * <pre>
+ * &#064;FixMethodOrder(MethodSorters.RANDOM)
+ * &#064;Seed(0xab84b37cb8abc82fL)
+ * </pre>
+ * 
+ * @see org.junit.FixMethodOrder
+ * @see org.junit.runners.MethodSorters
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Seed {
+    /**
+     * Seed for random number generator for use in applying a random method
+     * sort order.
+     */
+    long value();
+}
+

--- a/src/main/java/org/junit/runners/MethodSorters.java
+++ b/src/main/java/org/junit/runners/MethodSorters.java
@@ -1,9 +1,10 @@
 package org.junit.runners;
 
+import org.junit.internal.MethodSorter;
+
 import java.lang.reflect.Method;
 import java.util.Comparator;
 
-import org.junit.internal.MethodSorter;
 
 /**
  * Sort the methods into a specified execution order.
@@ -23,6 +24,13 @@ public enum MethodSorters {
      * Note that the order from the JVM may vary from run to run
      */
     JVM(null),
+
+    /**
+     * Sorts the test methods in pseudo-random order.
+     * This sort option generates and displays (to stdout) a
+     * seed value for the random number generator.
+     */
+    RANDOM(MethodSorter.DEFAULT),
 
     /**
      * Sorts the test methods in a deterministic, but not predictable, order

--- a/src/test/java/org/junit/internal/MethodSorterTest.java
+++ b/src/test/java/org/junit/internal/MethodSorterTest.java
@@ -7,8 +7,11 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.Assert;
+import static org.junit.Assert.assertNotEquals;
 
 import org.junit.FixMethodOrder;
+import org.junit.Seed;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
@@ -179,4 +182,104 @@ public class MethodSorterTest {
         List<String> actual = getDeclaredMethodNames(DummySortWithNameAsc.class);
         assertEquals(expected, actual);
     }
+
+    @FixMethodOrder(MethodSorters.RANDOM)
+    static class DummySortRandom {
+        Object alpha(int i, double d, Thread t) {
+            return null;
+        }
+
+        void beta(int[][] x) {
+        }
+
+        int gamma() {
+            return 0;
+        }
+
+        void gamma(boolean b) {
+        }
+
+        void delta() {
+        }
+
+        void epsilon() {
+        }
+    }
+
+    @Test(timeout = 1000)
+    public void testRandomMethodSorter() {
+        List<String> original = Arrays.asList(ALPHA, BETA, DELTA, EPSILON, 
+            GAMMA_VOID, GAMMA_BOOLEAN);
+
+        List<String> result1;
+        do{ 
+        result1 = getDeclaredMethodNames(DummySortRandom.class);
+        } while(original.equals(result1));
+
+        List<String> result2;
+        do {
+            result2 = getDeclaredMethodNames(DummySortRandom.class);
+        } while(result1.equals(result2));
+    }
+
+    @FixMethodOrder(MethodSorters.RANDOM)
+    @Seed(0x36dfe8cab7342fL)
+    static class DummySortSeed {
+        Object alpha(int i, double d, Thread t) {
+            return null;
+        }
+
+        void beta(int[][] x) {
+        }
+
+        int gamma() {
+            return 0;
+        }
+
+        void gamma(boolean b) {
+        }
+
+        void delta() {
+        }
+
+        void epsilon() {
+        }
+    }
+
+    @FixMethodOrder(MethodSorters.RANDOM)
+    @Seed(0x3456789abcdef0L)
+    static class DummySortSeed2 {
+        Object alpha(int i, double d, Thread t) {
+            return null;
+        }
+
+        void beta(int[][] x) {
+        }
+
+        int gamma() {
+            return 0;
+        }
+
+        void gamma(boolean b) {
+        }
+
+        void delta() {
+        }
+
+        void epsilon() {
+        }
+    }
+
+    @Test
+    public void testSeededRandomMethodSorter() {
+        List<String> original = Arrays.asList(ALPHA, BETA, DELTA, EPSILON, 
+            GAMMA_VOID, GAMMA_BOOLEAN);
+        List<String> result1 = getDeclaredMethodNames(DummySortSeed.class);
+        assertNotEquals(original, result1);
+        List<String> result2 = getDeclaredMethodNames(DummySortSeed.class);
+        assertEquals(result1, result2);
+        List<String> otherSeed = getDeclaredMethodNames(DummySortSeed2.class);
+        assertNotEquals(otherSeed, result2);
+    }
+
 }


### PR DESCRIPTION
Closes issue #1194.

This commit creates an additional method sorting option called "RANDOM," which uses a random number generator (java.util.Random) to cause JUnit to execute tests in random order. It also adds another annotation, "@Seed," which allows the random number generator's seed to be set to a pre-defined value (so a previous random ordering can be applied repeatedly). If no "@Seed" annotation is included, JUnit will generate a seed. In any event, if "RANDOM" ordering is applied, the seed used will be written to stdout so that a failed randomly ordered test run (even one using a JUnit-supplied seed) can be re-run in the same order.

The code uses the Knuth/Fisher-Yates shuffle algorithm to do the reordering.