### PR TITLE
Add ReducedStackTrace rule for easier interpretation of stack traces on the command line

### DIFF
--- a/src/main/java/org/junit/rules/ReducedStackTrace.java
+++ b/src/main/java/org/junit/rules/ReducedStackTrace.java
@@ -1,0 +1,78 @@
+package org.junit.rules;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * The {code ReducedStackTrace} rule allows you to remove stack frames leading to
+ * your test method from junit's error logs.
+ *
+ * <h3>Usage</h3>
+ * <pre> public class SimpleFailingTest {
+ *     &#064;Rule
+ *     public ReducedStackTrace reducer = new ReducedStackTrace();
+ *
+ *     &#064;Test
+ *     public void throwsException() {
+ *         throw new NullPointerException();
+ *     }
+ * }</pre>
+ *
+ * <p>
+ * You have to add {@code ReducedStackTrace} rule to your test. The only noticable
+ * change should be that stack traces on failing tests is now reduced so that errors
+ * could be identified more quickly (esp. when working from the command line).
+ */
+public class ReducedStackTrace implements TestRule {
+  public Statement apply(Statement base, Description description) {
+    return new ReducedStackTraceStatement(base, description);
+  }
+
+  private class ReducedStackTraceStatement extends Statement {
+    private static final int FRAME_NOT_FOUND = -1;
+
+    private final Statement base;
+    private final Description description;
+
+    public ReducedStackTraceStatement(Statement base, Description description) {
+      this.base = base;
+      this.description = description;
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+      try {
+        base.evaluate();
+      } catch (Throwable e) {
+        StackTraceElement[] stack = e.getStackTrace();
+        int upperFrame = getUppermostTestFrame(stack) + 1; // Inclusive.
+
+        if (upperFrame != FRAME_NOT_FOUND) {
+          // Arrays.copyOfRange() is only available in Java 6 and onwards...
+          StackTraceElement[] copyOfStack = new StackTraceElement[upperFrame];
+          System.arraycopy(stack, 0, copyOfStack, 0, upperFrame);
+          e.setStackTrace(copyOfStack);
+        }
+
+        throw e;
+      }
+    }
+
+    /**
+     * Get the highest stack frame containing the test method.
+     */
+    private int getUppermostTestFrame(StackTraceElement[] stack) {
+      int frameIndex;
+
+      // Traverse the stack in reverse order to catch the earliest call
+      // to the test method.
+      for (frameIndex = stack.length - 1; frameIndex >= 0; frameIndex--) {
+        if (stack[frameIndex].getMethodName().equals(description.getMethodName())) {
+          return frameIndex;
+        }
+      }
+
+      return FRAME_NOT_FOUND;
+    }
+  }
+}

--- a/src/test/java/org/junit/rules/ReducedStackTraceTest.java
+++ b/src/test/java/org/junit/rules/ReducedStackTraceTest.java
@@ -1,0 +1,52 @@
+package org.junit.rules;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+
+public class ReducedStackTraceTest {
+
+  public static class StandardThrowingTest {
+    @Test
+    public void throwsException() {
+      fail("Simulate a failing test");
+    }
+  }
+
+  public static class ReducedStackThrowingTest extends StandardThrowingTest {
+    @Rule
+    public ReducedStackTrace reducer = new ReducedStackTrace();
+  }
+
+  @Test
+  public void whenRuleIsAppliedStackTraceShouldStartWithTestName() {
+    JUnitCore core = new JUnitCore();
+    Result result = core.run(ReducedStackThrowingTest.class);
+
+    assertEquals("Should have failures", 1, result.getFailureCount());
+
+    StackTraceElement frame = last(result.getFailures().get(0).getException().getStackTrace());
+    assertEquals("Should start with test method name", "throwsException", frame.getMethodName());
+  }
+
+  @Test
+  public void whenRuleIsNotAppliedStackTraceDoesNotStartWithTestName() {
+    JUnitCore core = new JUnitCore();
+    Result result = core.run(StandardThrowingTest.class);
+
+    assertEquals("Should have failures", 1, result.getFailureCount());
+
+    StackTraceElement frame = last(result.getFailures().get(0).getException().getStackTrace());
+    assertNotEquals("Should not start with test method name", "throwsException", frame.getMethodName());
+  }
+
+  private StackTraceElement last(StackTraceElement[] stack) {
+    return stack[stack.length - 1];
+  }
+
+}

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -9,6 +9,7 @@ import org.junit.internal.MethodSorterTest;
 import org.junit.internal.matchers.StacktracePrintingMatcherTest;
 import org.junit.internal.matchers.ThrowableCauseMatcherTest;
 import org.junit.rules.DisableOnDebugTest;
+import org.junit.rules.ReducedStackTraceTest;
 import org.junit.rules.StopwatchTest;
 import org.junit.runner.FilterFactoriesTest;
 import org.junit.runner.FilterOptionIntegrationTest;
@@ -192,6 +193,7 @@ import org.junit.validator.PublicClassValidatorTest;
         NameRulesTest.class,
         ClassRulesTest.class,
         ExpectedExceptionTest.class,
+        ReducedStackTraceTest.class,
         TempFolderRuleTest.class,
         TemporaryFolderUsageTest.class,
         ExternalResourceRuleTest.class,


### PR DESCRIPTION
When a test fails JUnit reports the failed test and the full stack trace associated with the failure. That's great, except that most of this trace consists of frames related to JUnit internals. 

The following simple test (extreme case, I know):
```Java
@RunWith(JUnit4.class)
public class MyTest {
  @Test
  public void throwsException() {
    fail("Simulate a failing test");
  }
}
```

Would result in a huge stack trace (most of which is useless for the developer):
```
JUnit version 4.13-SNAPSHOT
.E
Time: 0.005
There was 1 failure:
1) throwsException(MyTest)
java.lang.AssertionError: Simulate a failing test
	at org.junit.Assert.fail(Assert.java:88)
	at MyTest.throwsException(MyTest.java:17)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:52)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:88)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:58)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.runner.JUnitCore.runMain(JUnitCore.java:77)
	at org.junit.runner.JUnitCore.main(JUnitCore.java:36)

FAILURES!!!
Tests run: 1,  Failures: 1
```

This pull request offers an alternative. You can add the `ReducedStackTrace` rule to your test:
```Java
@RunWith(JUnit4.class)
public class MyTest {
  @Rule
  public ReducedStackTrace reducer = new ReducedStackTrace();

  @Test
  public void throwsException() {
    fail("Simulate a failing test");
  }
}
```

And get a much cleaner report:
```
JUnit version 4.13-SNAPSHOT
.E
Time: 0.006
There was 1 failure:
1) throwsException(MyTest)
java.lang.AssertionError: Simulate a failing test
	at org.junit.Assert.fail(Assert.java:88)
	at MyTest.throwsException(MyTest.java:17)

FAILURES!!!
Tests run: 1,  Failures: 1
```