### PR TITLE
Make JUnit look for `@Test` annotated methods in interfaces as well

### DIFF
--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -61,7 +62,11 @@ public class TestClass implements Annotatable {
     }
 
     protected void scanAnnotatedMembers(Map<Class<? extends Annotation>, List<FrameworkMethod>> methodsForAnnotations, Map<Class<? extends Annotation>, List<FrameworkField>> fieldsForAnnotations) {
-        for (Class<?> eachClass : getSuperClasses(clazz)) {
+        List<Class<?>> classList = new ArrayList<Class<?>>();
+        getSuperClasses(clazz, classList);
+        getInterfaces(clazz, classList);
+
+        for (Class<?> eachClass : classList) {
             for (Method eachMethod : MethodSorter.getDeclaredMethods(eachClass)) {
                 addToAnnotationLists(new FrameworkMethod(eachMethod), methodsForAnnotations);
             }
@@ -167,14 +172,23 @@ public class TestClass implements Annotatable {
                 || annotation.equals(BeforeClass.class);
     }
 
-    private static List<Class<?>> getSuperClasses(Class<?> testClass) {
-        List<Class<?>> results = new ArrayList<Class<?>>();
+    private static void getSuperClasses(Class<?> testClass, Collection<Class<?>> into) {
         Class<?> current = testClass;
         while (current != null) {
-            results.add(current);
+            into.add(current);
             current = current.getSuperclass();
         }
-        return results;
+    }
+
+    private static void getInterfaces(Class<?> testClass, Collection<Class<?>> into) {
+        if (testClass == null) {
+            return;
+        }
+        Class<?>[] interfaces = testClass.getInterfaces();
+        for (Class<?> iface : interfaces) {
+            into.add(iface);
+            getInterfaces(iface, into);
+        }
     }
 
     /**

--- a/src/test/java/org/junit/runners/model/TestClassTest.java
+++ b/src/test/java/org/junit/runners/model/TestClassTest.java
@@ -105,8 +105,8 @@ public class TestClassTest {
         TestClass tc= new TestClass(FieldAnnotated.class);
         List<FrameworkField> annotatedFields= tc.getAnnotatedFields();
         assertThat("Wrong number of annotated fields.", annotatedFields.size(), is(3));
-        assertThat("First annotated field is wrong.", annotatedFields
-            .iterator().next().getName(), is("fieldA"));
+        assertThat("First annotated field is wrong.",
+            annotatedFields.iterator().next().getName(), is("fieldA"));
     }
 
     @Test
@@ -134,26 +134,26 @@ public class TestClassTest {
         @Test
         public int methodB() {
             return 0;
-    	}
+        }
     }
 
     @Test
     public void providesAnnotatedMethodsSortedByName() {
-    	TestClass tc = new TestClass(MethodsAnnotated.class);
-    	List<FrameworkMethod> annotatedMethods = tc.getAnnotatedMethods();
-    	assertThat("Wrong number of annotated methods.",
-    	    annotatedMethods.size(), is(3));
-    	assertThat("First annotated method is wrong.",
-          annotatedMethods.iterator().next().getName(), is("methodA"));
+        TestClass tc = new TestClass(MethodsAnnotated.class);
+        List<FrameworkMethod> annotatedMethods = tc.getAnnotatedMethods();
+        assertThat("Wrong number of annotated methods.",
+            annotatedMethods.size(), is(3));
+        assertThat("First annotated method is wrong.",
+            annotatedMethods.iterator().next().getName(), is("methodA"));
     }
 
     @Test
     public void annotatedMethodValues() {
-    	TestClass tc = new TestClass(MethodsAnnotated.class);
-    	List<String> values = tc.getAnnotatedMethodValues(
-    	    new MethodsAnnotated(), Ignore.class, String.class);
-    	assertThat(values, hasItem("jupiter"));
-    	assertThat(values.size(), is(1));
+        TestClass tc = new TestClass(MethodsAnnotated.class);
+        List<String> values = tc.getAnnotatedMethodValues(
+            new MethodsAnnotated(), Ignore.class, String.class);
+        assertThat(values, hasItem("jupiter"));
+        assertThat(values.size(), is(1));
     }
 
     @Test


### PR DESCRIPTION
Previously, the JUnit4 runner looked for `@Test` annotated methods to run, in the concrete test class, and in all of its super-classes.

This change makes JUnit also look for `@Test` annotated methods in all the interfaces that a test class implements.

For instance, the following now works, in that the `abstractBehaviour()` test method is now executed as part of the `ConcreteTest`:

```java
    public interface AbstractTests {
        @Test
        public void abstractBehaviour();
    }
    public class ConcreteTest implements AbstractTests {
        public void abstractBehaviour() {
            // assertions...
        }
    }
```

This is particularly useful on Java8, because it allows us to use interfaces as test mix-ins:

```java
    public interface CollectionTestFixture {
        Collection<Object> create();
    }
    public interface CollectionAddition extends CollectionTestFixture {
        @Test
        default void mustContainAddedItem() {
            Object obj = new Object();
            Collection<Object> coll = create();
            coll.add(obj);
            assertTrue(coll.contains(obj));
        }
    }
    public interface CollectionRemove extends CollectionTestFixture {
        @Test
        default void removeOfAddedItemMustSucceed() {
            Object obj = new Object();
            Collection<Object> coll = create();
            coll.add(obj);
            assertTrue(coll.remove(obj));
        }
    }
    public class ArrayListTest implements CollectionAddition, CollectionRemove {
        @Override
        public Collection<Object> create() {
            return new ArrayList<>();
        }
    }
    public class LinkedListTest implements CollectionAddition, CollectionRemove {
        @Override
        public Collection<Object> create() {
            return new LinkedList<>();
        }
    }
```

Of course, the above example is most likely better written as a parameterised test, but there might be other cases where this mix-in pattern is more appropriate.
