### PR TITLE
Catch SecurityException in addition to IOException.

### DIFF
--- a/src/main/java/junit/runner/BaseTestRunner.java
+++ b/src/main/java/junit/runner/BaseTestRunner.java
@@ -233,6 +233,7 @@ public abstract class BaseTestRunner implements TestListener {
             setPreferences(new Properties(getPreferences()));
             getPreferences().load(is);
         } catch (IOException ignored) {
+        } catch (SecurityException ignored) {
         } finally {
             try {
                 if (is != null) {


### PR DESCRIPTION
Fixes #1213, not by adding the doPrivileged, but by coping with lack of access to the file by pretending it doesn't exist.