### PR TITLE
Bugfix/jdk9 build fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,7 @@
                 in jar archive target/junit-*-javadoc.jar.
                 -->
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>2.10.4-SNAPSHOT</version>
                 <configuration>
                     <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>
                     <show>protected</show>
@@ -337,7 +337,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.0.0-SNAPSHOT</version>
                 <configuration>
                     <archive>
                         <addMavenDescriptor>false</addMavenDescriptor>
@@ -397,7 +397,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.1</version>
+                <version>2.10.4-SNAPSHOT</version>
                 <configuration>
                     <destDir>javadoc/latest</destDir>
                     <stylesheetfile>${basedir}/src/main/javadoc/stylesheet.css</stylesheetfile>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     </distributionManagement>
 
     <properties>
-        <jdkVersion>1.5</jdkVersion>
+        <jdkVersion>1.6</jdkVersion>
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
         <arguments />
         <gpg.keyname>67893CC4</gpg.keyname>
@@ -218,7 +218,7 @@
                     <target>${jdkVersion}</target>
                     <testSource>${jdkVersion}</testSource>
                     <testTarget>${jdkVersion}</testTarget>
-                    <compilerVersion>1.5</compilerVersion>
+                    <compilerVersion>1.6</compilerVersion>
                     <showDeprecation>true</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <debug>true</debug>
@@ -243,7 +243,7 @@
                         <configuration>
                             <signature>
                                 <groupId>org.codehaus.mojo.signature</groupId>
-                                <artifactId>java15</artifactId>
+                                <artifactId>java16</artifactId>
                                 <version>1.0</version>
                             </signature>
                         </configuration>


### PR DESCRIPTION
Linked to https://github.com/junit-team/junit/issues/1233

With Java 9, it drops support for Java 5 i.e. -source 1.5 and -target 1.5. So this pull request updates updates the min Java version needed to 1.6.

Two maven plugins, maven-jar-plugin and maven-javadoc-plugin also have issues with Java 9.

Once https://github.com/apache/maven-plugins/pull/76 is merged it will depending on a fixed version of plexus-archiver (see https://github.com/codehaus-plexus/plexus-archiver/pull/12).