### PR TITLE
Closing ObjectOutputStream before calling toByteArray on the underlying ByteArrayOutputStream

### DIFF
--- a/src/test/java/junit/tests/runner/ResultTest.java
+++ b/src/test/java/junit/tests/runner/ResultTest.java
@@ -31,7 +31,9 @@ public class ResultTest extends TestCase {
 
     private void assertResultSerializable(Result result) throws IOException, ClassNotFoundException {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        new ObjectOutputStream(byteArrayOutputStream).writeObject(result);
+        ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+        objectOutputStream.writeObject(result);
+        objectOutputStream.flush();
         byte[] bytes = byteArrayOutputStream.toByteArray();
         ObjectInputStream objectInputStream = new ObjectInputStream(new ByteArrayInputStream(bytes));
         Result fromStream = (Result) objectInputStream.readObject();


### PR DESCRIPTION
When an ObjectOutputStream instance wraps an underlying ByteArrayOutputStream instance,
it is recommended to flush or close the ObjectOutputStream before invoking the underlying instances's toByteArray(). Although in this case, this is not strictly necessary because the writeObject method is invoked right before toByteArray, and writeObject internally calls flush/drain.  However, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a flush method before calling toByteArray().