### PR TITLE
Fix typo in assertEmptyThrowsMultipleFailureExceptionForManyThrowables()

### DIFF
--- a/src/main/java/org/junit/runner/JUnitCommandLineParseResult.java
+++ b/src/main/java/org/junit/runner/JUnitCommandLineParseResult.java
@@ -15,11 +15,6 @@ class JUnitCommandLineParseResult {
     private final List<Throwable> parserErrors = new ArrayList<Throwable>();
 
     /**
-     * Do not use. Testing purposes only.
-     */
-    JUnitCommandLineParseResult() {}
-
-    /**
      * Returns filter specs parsed from command line.
      */
     public List<String> getFilterSpecs() {

--- a/src/test/java/org/junit/tests/assertion/MultipleFailureExceptionTest.java
+++ b/src/test/java/org/junit/tests/assertion/MultipleFailureExceptionTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runners.model.MultipleFailureException;
 
+
 /**
  * Tests for {@link org.junit.runners.model.MultipleFailureException}
  *
@@ -37,7 +38,7 @@ public class MultipleFailureExceptionTest {
             assertSame(e, exception);
         }
     }
-    
+
     @Test
     public void assertEmptyRethrowsSingleError() throws Exception {
         Throwable exception= new AnnotationFormatError("changeo");
@@ -51,7 +52,7 @@ public class MultipleFailureExceptionTest {
     }
 
     @Test
-    public void assertEmptyThrowsMutipleFailureExceptionForManyThrowables() throws Exception {
+    public void assertEmptyThrowsMultipleFailureExceptionForManyThrowables() throws Exception {
         List<Throwable> errors = new ArrayList<Throwable>();
         errors.add(new ExpectedException("basil"));
         errors.add(new RuntimeException("garlic"));


### PR DESCRIPTION
at MultipleFailureExceptionTest.

I had problems with the other branch and I had to delete it.
Sorry for opening a new pull request.