### PR TITLE
Replace ArrayList for primitive array in copyArray method

### DIFF
--- a/src/main/java/org/junit/runner/JUnitCommandLineParseResult.java
+++ b/src/main/java/org/junit/runner/JUnitCommandLineParseResult.java
@@ -85,13 +85,11 @@ class JUnitCommandLineParseResult {
     }
 
     private String[] copyArray(String[] args, int from, int to) {
-        ArrayList<String> result = new ArrayList<String>();
-
+        String[] result = new String[to - from];
         for (int j = from; j != to; ++j) {
-            result.add(args[j]);
+            result[j - from] = args[j];
         }
-
-        return result.toArray(new String[result.size()]);
+        return result;
     }
 
     void parseParameters(String[] args) {


### PR DESCRIPTION
at org.junit.runner.JUnitCommandLineParseResult
According to https://github.com/junit-team/junit4/issues/1271 