### PR TITLE
In getRunner method of FilterRequest class,when runner is already an ErrorReporingRunner,skip filtering.

### DIFF
--- a/src/main/java/org/junit/internal/requests/FilterRequest.java
+++ b/src/main/java/org/junit/internal/requests/FilterRequest.java
@@ -34,6 +34,10 @@ public final class FilterRequest extends Request {
     public Runner getRunner() {
         try {
             Runner runner = request.getRunner();
+            if (runner instanceof ErrorReportingRunner) {
+                // runner is already an ErrorReportingRunner
+                return runner;
+            }
             fFilter.apply(runner);
             return runner;
         } catch (NoTestsRemainException e) {


### PR DESCRIPTION
fix #1277