### PR TITLE
Improve ParentRunner's javadoc

### DIFF
--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -45,13 +45,16 @@ import org.junit.validator.TestClassValidator;
 /**
  * Provides most of the functionality specific to a Runner that implements a
  * "parent node" in the test tree, with children defined by objects of some data
- * type {@code T}. (For {@link BlockJUnit4ClassRunner}, {@code T} is
- * {@link Method} . For {@link Suite}, {@code T} is {@link Class}.) Subclasses
- * must implement finding the children of the node, describing each child, and
+ * type {@code T}.
+ * Subclasses must implement finding the children of the node, describing each child, and
  * running each child. ParentRunner will filter and sort children, handle
  * {@code @BeforeClass} and {@code @AfterClass} methods,
  * handle annotated {@link ClassRule}s, create a composite
  * {@link Description}, and run children sequentially.
+ *
+ * @param <T> the type of the children of this Runner.
+ *           For {@link BlockJUnit4ClassRunner}, {@code T} is {@link Method}.
+ *           For {@link Suite}, {@code T} is {@link Class}.
  *
  * @since 4.5
  */


### PR DESCRIPTION
Info about the type parameter should go into its own "@param <T>" section.