### PR TITLE
Fix mvn surefire config: better test output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
 
     <properties>
         <jdkVersion>1.5</jdkVersion>
+        <surefireVersion>2.19.1</surefireVersion>
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
         <arguments />
         <gpg.keyname>67893CC4</gpg.keyname>
@@ -256,7 +257,7 @@
                 our junit suite "AllTests" after the sources are compiled.
                 -->
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>${surefireVersion}</version>
                 <configuration>
                     <test>org/junit/tests/AllTests.java</test>
                     <useSystemClassLoader>true</useSystemClassLoader>
@@ -266,7 +267,7 @@
                     <dependency>
                         <groupId>org.apache.maven.surefire</groupId>
                         <artifactId>surefire-junit47</artifactId>
-                        <version>2.19.1</version>
+                        <version>${surefireVersion}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,13 @@
                     <useSystemClassLoader>true</useSystemClassLoader>
                     <enableAssertions>false</enableAssertions>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>2.19.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <!--
@@ -552,13 +559,6 @@
                             <parallel>classes</parallel>
                             <threadCountClasses>2</threadCountClasses>
                         </configuration>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.apache.maven.surefire</groupId>
-                                <artifactId>surefire-junit47</artifactId>
-                                <version>2.18</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,7 @@
                 our junit suite "AllTests" after the sources are compiled.
                 -->
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>2.19.1</version>
                 <configuration>
                     <test>org/junit/tests/AllTests.java</test>
                     <useSystemClassLoader>true</useSystemClassLoader>

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -101,8 +101,8 @@ public class AssumptionTest {
 
     @Test
     public void assumeNotNullThrowsException() {
-        Object[] objects = {1, 2, null};
         try {
+            Object[] objects = {1, 2, null};
             assumeNotNull(objects);
             fail("should throw AssumptionViolatedException");
         } catch (AssumptionViolatedException e) {

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -77,14 +77,9 @@ public class AssumptionTest {
         assertThat(result.getFailureCount(), is(1));
     }
 
-    @Test
+    @Test(expected = AssumptionViolatedException.class)
     public void assumeThatWorks() {
-        try {
-            assumeThat(1, is(2));
-            fail("should throw AssumptionViolatedException");
-        } catch (AssumptionViolatedException e) {
-            // expected
-        }
+        assumeThat(1, is(2));
     }
 
     @Test
@@ -99,15 +94,10 @@ public class AssumptionTest {
         assertCompletesNormally();
     }
 
-    @Test
+    @Test(expected = AssumptionViolatedException.class)
     public void assumeNotNullThrowsException() {
-        try {
-            Object[] objects = {1, 2, null};
-            assumeNotNull(objects);
-            fail("should throw AssumptionViolatedException");
-        } catch (AssumptionViolatedException e) {
-            // expected
-        }
+        Object[] objects = {1, 2, null};
+        assumeNotNull(objects);
     }
 
     @Test
@@ -143,14 +133,9 @@ public class AssumptionTest {
     private void assertCompletesNormally() {
     }
 
-    @Test
+    @Test(expected = AssumptionViolatedException.class)
     public void assumeTrueWorks() {
-        try {
-            Assume.assumeTrue(false);
-            fail("should throw AssumptionViolatedException");
-        } catch (AssumptionViolatedException e) {
-            // expected
-        }
+        Assume.assumeTrue(false);
     }
 
     public static class HasFailingAssumeInBefore {

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -101,8 +101,8 @@ public class AssumptionTest {
 
     @Test
     public void assumeNotNullThrowsException() {
+        Object[] objects = {1, 2, null};
         try {
-            Object[] objects = {1, 2, null};
             assumeNotNull(objects);
             fail("should throw AssumptionViolatedException");
         } catch (AssumptionViolatedException e) {

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -77,9 +77,14 @@ public class AssumptionTest {
         assertThat(result.getFailureCount(), is(1));
     }
 
-    @Test(expected = AssumptionViolatedException.class)
+    @Test
     public void assumeThatWorks() {
-        assumeThat(1, is(2));
+        try {
+            assumeThat(1, is(2));
+            fail("should throw AssumptionViolatedException");
+        } catch (AssumptionViolatedException e) {
+            // expected
+        }
     }
 
     @Test
@@ -94,10 +99,15 @@ public class AssumptionTest {
         assertCompletesNormally();
     }
 
-    @Test(expected = AssumptionViolatedException.class)
+    @Test
     public void assumeNotNullThrowsException() {
-        Object[] objects = {1, 2, null};
-        assumeNotNull(objects);
+        try {
+            Object[] objects = {1, 2, null};
+            assumeNotNull(objects);
+            fail("should throw AssumptionViolatedException");
+        } catch (AssumptionViolatedException e) {
+            // expected
+        }
     }
 
     @Test
@@ -133,9 +143,14 @@ public class AssumptionTest {
     private void assertCompletesNormally() {
     }
 
-    @Test(expected = AssumptionViolatedException.class)
+    @Test
     public void assumeTrueWorks() {
-        Assume.assumeTrue(false);
+        try {
+            Assume.assumeTrue(false);
+            fail("should throw AssumptionViolatedException");
+        } catch (AssumptionViolatedException e) {
+            // expected
+        }
     }
 
     public static class HasFailingAssumeInBefore {


### PR DESCRIPTION
Mvn test output is now more detailed and helpful.

> Fix mvn surefire config: force surefire-junit47 as the surefire provider
> Previously surefire-junit3 was used.
> See also https://maven.apache.org/surefire/maven-surefire-plugin/examples/providers.html

Before:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.junit.tests.AllTests
Tests run: 940, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.58 sec - in org.junit.tests.AllTests

Results :

Tests run: 940, Failures: 0, Errors: 0, Skipped: 0
```

After:

```
[INFO] --- maven-surefire-plugin:2.19.1:test (default-test) @ junit ---

-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.junit.tests.assertion.AssertionTest
Tests run: 86, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.028 sec - in org.junit.tests.assertion.AssertionTest
Running org.junit.tests.assertion.ComparisonFailureTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.assertion.ComparisonFailureTest
Running org.junit.tests.assertion.MultipleFailureExceptionTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.assertion.MultipleFailureExceptionTest
Running org.junit.tests.deprecated.JUnit4ClassRunnerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.deprecated.JUnit4ClassRunnerTest
Running org.junit.tests.description.AnnotatedDescriptionTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.junit.tests.description.AnnotatedDescriptionTest
Running org.junit.tests.description.SuiteDescriptionTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.description.SuiteDescriptionTest
Running org.junit.tests.description.TestDescriptionMethodNameTest
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.description.TestDescriptionMethodNameTest
Running org.junit.tests.description.TestDescriptionTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.description.TestDescriptionTest
Running org.junit.experimental.categories.CategoriesAndParameterizedTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 sec - in org.junit.experimental.categories.CategoriesAndParameterizedTest
Running org.junit.experimental.categories.CategoryFilterFactoryTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.experimental.categories.CategoryFilterFactoryTest
Running org.junit.experimental.categories.CategoryTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.055 sec - in org.junit.experimental.categories.CategoryTest
Running org.junit.experimental.categories.CategoryValidatorTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.experimental.categories.CategoryValidatorTest
Running org.junit.experimental.categories.JavadocTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.junit.experimental.categories.JavadocTest
Running org.junit.experimental.categories.MultiCategoryTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 sec - in org.junit.experimental.categories.MultiCategoryTest
Running org.junit.tests.experimental.max.DescriptionTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.junit.tests.experimental.max.DescriptionTest
Running org.junit.tests.experimental.max.JUnit38SortingTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 sec - in org.junit.tests.experimental.max.JUnit38SortingTest
Running org.junit.tests.experimental.max.MaxStarterTest
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.535 sec - in org.junit.tests.experimental.max.MaxStarterTest
Running org.junit.tests.experimental.parallel.ParallelClassTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.tests.experimental.parallel.ParallelClassTest
Running org.junit.tests.experimental.parallel.ParallelMethodTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.tests.experimental.parallel.ParallelMethodTest
Running org.junit.tests.experimental.results.PrintableResultTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.034 sec - in org.junit.tests.experimental.results.PrintableResultTest
Running org.junit.tests.experimental.results.ResultMatchersTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.results.ResultMatchersTest
Running org.junit.tests.experimental.theories.internal.AllMembersSupplierTest
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.experimental.theories.internal.AllMembersSupplierTest
Running org.junit.tests.experimental.theories.internal.ParameterizedAssertionErrorTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.junit.tests.experimental.theories.internal.ParameterizedAssertionErrorTest
Running org.junit.tests.experimental.theories.internal.SpecificDataPointsSupplierTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in org.junit.tests.experimental.theories.internal.SpecificDataPointsSupplierTest
Running org.junit.tests.experimental.theories.runner.FailingDataPointMethods
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec - in org.junit.tests.experimental.theories.runner.FailingDataPointMethods
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$StaticPublicNonDataPoints
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$StaticPublicNonDataPoints
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$OneTestTwoAnnotations
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$OneTestTwoAnnotations
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$BeforeAndAfterEachTime
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$BeforeAndAfterEachTime
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$DifferentTypesInConstructor
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$DifferentTypesInConstructor
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveIntsWithMethodParams
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveIntsWithMethodParams
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveIntsWithNegativeField
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveIntsWithNegativeField
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveInts
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveInts
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$NewObjectEachTime
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$NewObjectEachTime
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$BeforeAndAfterOnSameInstance
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$BeforeAndAfterOnSameInstance
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$HasATwoParameterTheory
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$HasATwoParameterTheory
Running org.junit.tests.experimental.theories.runner.TheoriesPerformanceTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.TheoriesPerformanceTest
Running org.junit.tests.experimental.theories.runner.TypeMatchingBetweenMultiDataPointsMethod
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.TypeMatchingBetweenMultiDataPointsMethod
Running org.junit.tests.experimental.theories.runner.UnsuccessfulWithDataPointFields
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.049 sec - in org.junit.tests.experimental.theories.runner.UnsuccessfulWithDataPointFields
Running org.junit.tests.experimental.theories.runner.WhenNoParametersMatch
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec - in org.junit.tests.experimental.theories.runner.WhenNoParametersMatch
Running org.junit.tests.experimental.theories.runner.WithAutoGeneratedDataPoints
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.163 sec - in org.junit.tests.experimental.theories.runner.WithAutoGeneratedDataPoints
Running org.junit.tests.experimental.theories.runner.WithDataPointMethod
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec - in org.junit.tests.experimental.theories.runner.WithDataPointMethod
Running org.junit.tests.experimental.theories.runner.WithExtendedParameterSources
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.039 sec - in org.junit.tests.experimental.theories.runner.WithExtendedParameterSources
Running org.junit.tests.experimental.theories.runner.WithNamedDataPoints
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.WithNamedDataPoints
Running org.junit.tests.experimental.theories.runner.WithOnlyTestAnnotations
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.03 sec - in org.junit.tests.experimental.theories.runner.WithOnlyTestAnnotations
Running org.junit.tests.experimental.theories.runner.WithParameterSupplier
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.WithParameterSupplier
Running org.junit.tests.experimental.theories.runner.WithUnresolvedGenericTypeVariablesOnTheoryParms
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.07 sec - in org.junit.tests.experimental.theories.runner.WithUnresolvedGenericTypeVariablesOnTheoryParms
Running org.junit.tests.experimental.theories.ParameterSignatureTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.tests.experimental.theories.ParameterSignatureTest
Running org.junit.tests.experimental.theories.TestedOnSupplierTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.experimental.theories.TestedOnSupplierTest
Running org.junit.tests.experimental.theories.AssumingInTheoriesTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.experimental.theories.AssumingInTheoriesTest
Running org.junit.tests.experimental.theories.PotentialAssignmentTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.experimental.theories.PotentialAssignmentTest
Running org.junit.tests.experimental.AssumptionTest
Tests run: 18, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 0.017 sec - in org.junit.tests.experimental.AssumptionTest
Running org.junit.tests.experimental.MatcherTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 sec - in org.junit.tests.experimental.MatcherTest
Running org.junit.tests.experimental.theories.extendingwithstubs.StubbedTheoriesTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.tests.experimental.theories.extendingwithstubs.StubbedTheoriesTest
Running org.junit.internal.builders.AnnotatedBuilderTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.internal.builders.AnnotatedBuilderTest
Running org.junit.internal.runners.ErrorReportingRunnerTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.internal.runners.ErrorReportingRunnerTest
Running org.junit.internal.runners.statements.FailOnTimeoutTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.79 sec - in org.junit.internal.runners.statements.FailOnTimeoutTest
Running org.junit.internal.MethodSorterTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.internal.MethodSorterTest
Running org.junit.internal.matchers.StacktracePrintingMatcherTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.internal.matchers.StacktracePrintingMatcherTest
Running org.junit.internal.matchers.ThrowableCauseMatcherTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.internal.matchers.ThrowableCauseMatcherTest
Running org.junit.tests.junit3compatibility.AllTestsTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 sec - in org.junit.tests.junit3compatibility.AllTestsTest
Running org.junit.tests.junit3compatibility.ClassRequestTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.junit3compatibility.ClassRequestTest
Running org.junit.tests.junit3compatibility.ForwardCompatibilityPrintingTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 sec - in org.junit.tests.junit3compatibility.ForwardCompatibilityPrintingTest
Running org.junit.tests.junit3compatibility.ForwardCompatibilityTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.junit.tests.junit3compatibility.ForwardCompatibilityTest
Running org.junit.tests.junit3compatibility.InitializationErrorForwardCompatibilityTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.junit3compatibility.InitializationErrorForwardCompatibilityTest
Running org.junit.tests.junit3compatibility.JUnit38ClassRunnerTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.034 sec - in org.junit.tests.junit3compatibility.JUnit38ClassRunnerTest
Running org.junit.tests.junit3compatibility.OldTestClassAdaptingListenerTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.junit3compatibility.OldTestClassAdaptingListenerTest
Running junit.tests.framework.TestCaseTest
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in junit.tests.framework.TestCaseTest
Running junit.tests.framework.SuiteTest
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.041 sec - in junit.tests.framework.SuiteTest
Running junit.tests.framework.TestListenerTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.framework.TestListenerTest
Running junit.tests.framework.AssertionFailedErrorTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.framework.AssertionFailedErrorTest
Running junit.tests.framework.AssertTest
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in junit.tests.framework.AssertTest
Running junit.tests.framework.TestImplementorTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.framework.TestImplementorTest
Running junit.tests.framework.NoArgTestCaseTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in junit.tests.framework.NoArgTestCaseTest
Running junit.tests.framework.ComparisonCompactorTest
Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in junit.tests.framework.ComparisonCompactorTest
Running junit.tests.framework.ComparisonFailureTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.framework.ComparisonFailureTest
Running junit.tests.framework.DoublePrecisionAssertTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.framework.DoublePrecisionAssertTest
Running junit.tests.framework.FloatAssertTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in junit.tests.framework.FloatAssertTest
Running junit.tests.runner.StackFilterTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.runner.StackFilterTest
Running junit.tests.runner.ResultTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.107 sec - in junit.tests.runner.ResultTest
Running junit.tests.runner.BaseTestRunnerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in junit.tests.runner.BaseTestRunnerTest
Running junit.tests.runner.TextFeedbackTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in junit.tests.runner.TextFeedbackTest
Running junit.tests.runner.TextRunnerSingleMethodTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.runner.TextRunnerSingleMethodTest
Running junit.tests.runner.TextRunnerTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.31 sec - in junit.tests.runner.TextRunnerTest
Running junit.tests.extensions.ExtensionTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.extensions.ExtensionTest
Running junit.tests.extensions.ActiveTestTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.234 sec - in junit.tests.extensions.ActiveTestTest
Running junit.tests.extensions.RepeatedTestTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in junit.tests.extensions.RepeatedTestTest
Running org.junit.tests.junit3compatibility.SuiteMethodTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.junit3compatibility.SuiteMethodTest
Running org.junit.tests.listening.ListenerTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.listening.ListenerTest
Running org.junit.tests.listening.RunnerTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.listening.RunnerTest
Running org.junit.tests.listening.TestListenerTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.listening.TestListenerTest
Running org.junit.tests.listening.TextListenerTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.listening.TextListenerTest
Running org.junit.tests.listening.UserStopTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.listening.UserStopTest
Running org.junit.tests.manipulation.FilterableTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.manipulation.FilterableTest
Running org.junit.tests.manipulation.FilterTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.manipulation.FilterTest
Running org.junit.tests.manipulation.SingleMethodTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec - in org.junit.tests.manipulation.SingleMethodTest
Running org.junit.tests.manipulation.SortableTest$UnsortableRunnersAreHandledWithoutCrashing
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.manipulation.SortableTest$UnsortableRunnersAreHandledWithoutCrashing
Running org.junit.tests.manipulation.SortableTest$TestClassRunnerIsSortableWithSuiteMethod
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.manipulation.SortableTest$TestClassRunnerIsSortableWithSuiteMethod
Running org.junit.tests.manipulation.SortableTest$TestClassRunnerIsSortable
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.tests.manipulation.SortableTest$TestClassRunnerIsSortable
Running org.junit.rules.BlockJUnit4ClassRunnerOverrideTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.junit.rules.BlockJUnit4ClassRunnerOverrideTest
Running org.junit.rules.ClassRulesTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 sec - in org.junit.rules.ClassRulesTest
Running org.junit.rules.DisableOnDebugTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.rules.DisableOnDebugTest
Running org.junit.rules.ExpectedExceptionTest
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 sec - in org.junit.rules.ExpectedExceptionTest
Running org.junit.rules.ExternalResourceRuleTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.rules.ExternalResourceRuleTest
Running org.junit.rules.MethodRulesTest
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 sec - in org.junit.rules.MethodRulesTest
Running org.junit.rules.NameRulesTest$BeforeAndAfterTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.rules.NameRulesTest$BeforeAndAfterTest
Running org.junit.rules.NameRulesTest$TestNames
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.rules.NameRulesTest$TestNames
Running org.junit.rules.RuleChainTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.rules.RuleChainTest
Running org.junit.rules.RuleMemberValidatorTest
Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.junit.rules.RuleMemberValidatorTest
Running org.junit.rules.StopwatchTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.rules.StopwatchTest
Running org.junit.rules.TempFolderRuleTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.024 sec - in org.junit.rules.TempFolderRuleTest
Running org.junit.rules.TemporaryFolderRuleAssuredDeletionTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.rules.TemporaryFolderRuleAssuredDeletionTest
Running org.junit.rules.TemporaryFolderUsageTest
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec - in org.junit.rules.TemporaryFolderUsageTest
Running org.junit.rules.TestRuleTest
Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 sec - in org.junit.rules.TestRuleTest
Running org.junit.rules.TestWatcherTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 sec - in org.junit.rules.TestWatcherTest
Running org.junit.rules.TestWatchmanTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.rules.TestWatchmanTest
Running org.junit.rules.TimeoutRuleTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.064 sec - in org.junit.rules.TimeoutRuleTest
Running org.junit.rules.VerifierRuleTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 sec - in org.junit.rules.VerifierRuleTest
Running org.junit.runners.model.FrameworkFieldTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.runners.model.FrameworkFieldTest
Running org.junit.runners.model.FrameworkMethodTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.runners.model.FrameworkMethodTest
Running org.junit.runners.model.TestClassTest
Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.junit.runners.model.TestClassTest
Running org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParametersTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParametersTest
Running org.junit.runners.parameterized.ParameterizedNamesTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.runners.parameterized.ParameterizedNamesTest
Running org.junit.runners.parameterized.TestWithParametersTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.runners.parameterized.TestWithParametersTest
Running org.junit.runners.CustomBlockJUnit4ClassRunnerTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.runners.CustomBlockJUnit4ClassRunnerTest
Running org.junit.runner.notification.ConcurrentRunNotifierTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.057 sec - in org.junit.runner.notification.ConcurrentRunNotifierTest
Running org.junit.runner.notification.RunNotifierTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.runner.notification.RunNotifierTest
Running org.junit.runner.notification.SynchronizedRunListenerTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.runner.notification.SynchronizedRunListenerTest
Running org.junit.runner.FilterFactoriesTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in org.junit.runner.FilterFactoriesTest
Running org.junit.runner.FilterOptionIntegrationTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec - in org.junit.runner.FilterOptionIntegrationTest
Running org.junit.runner.JUnitCommandLineParseResultTest
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.runner.JUnitCommandLineParseResultTest
Running org.junit.runner.JUnitCoreTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in org.junit.runner.JUnitCoreTest
Running org.junit.tests.running.classes.BlockJUnit4ClassRunnerTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.running.classes.BlockJUnit4ClassRunnerTest
Running org.junit.tests.running.classes.ClassLevelMethodsWithIgnoredTestsTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.running.classes.ClassLevelMethodsWithIgnoredTestsTest
Running org.junit.tests.running.classes.EnclosedTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.tests.running.classes.EnclosedTest
Running org.junit.tests.running.classes.IgnoreClassTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.running.classes.IgnoreClassTest
Running org.junit.tests.running.classes.ParameterizedTestTest
Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 sec - in org.junit.tests.running.classes.ParameterizedTestTest
Running org.junit.tests.running.classes.ParentRunnerFilteringTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.running.classes.ParentRunnerFilteringTest
Running org.junit.tests.running.classes.ParentRunnerTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.tests.running.classes.ParentRunnerTest
Running org.junit.tests.running.classes.RunWithTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.tests.running.classes.RunWithTest
Running org.junit.tests.running.classes.SuiteTest
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.junit.tests.running.classes.SuiteTest
Running org.junit.tests.running.classes.UseSuiteAsASuperclassTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.running.classes.UseSuiteAsASuperclassTest
Running org.junit.tests.running.core.CommandLineTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 sec - in org.junit.tests.running.core.CommandLineTest
Running org.junit.tests.running.core.JUnitCoreReturnsCorrectExitCodeTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec - in org.junit.tests.running.core.JUnitCoreReturnsCorrectExitCodeTest
Running org.junit.tests.running.core.SystemExitTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.064 sec - in org.junit.tests.running.core.SystemExitTest
Running org.junit.tests.running.methods.AnnotationTest
Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.running.methods.AnnotationTest
Running org.junit.tests.running.methods.ExpectedTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.running.methods.ExpectedTest
Running org.junit.tests.running.methods.InheritedTestTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.running.methods.InheritedTestTest
Running org.junit.tests.running.methods.ParameterizedTestMethodTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.running.methods.ParameterizedTestMethodTest
Running org.junit.tests.running.methods.TestMethodTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.tests.running.methods.TestMethodTest
Running org.junit.tests.running.methods.TimeoutTest
Tests run: 13, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.882 sec - in org.junit.tests.running.methods.TimeoutTest
Running org.junit.samples.ListTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.samples.ListTest
Running org.junit.samples.money.MoneyTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.samples.money.MoneyTest
Running org.junit.tests.validation.BadlyFormedClassesTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.tests.validation.BadlyFormedClassesTest
Running org.junit.tests.validation.FailedConstructionTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.validation.FailedConstructionTest
Running org.junit.tests.validation.ValidationTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.validation.ValidationTest
Running org.junit.validator.AnnotationsValidatorTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 sec - in org.junit.validator.AnnotationsValidatorTest
Running org.junit.validator.AnnotationValidatorFactoryTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.validator.AnnotationValidatorFactoryTest
Running org.junit.validator.PublicClassValidatorTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.validator.PublicClassValidatorTest
Running org.junit.AssumptionViolatedExceptionTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 sec - in org.junit.AssumptionViolatedExceptionTest
Running org.junit.tests.ObjectContractTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec - in org.junit.tests.ObjectContractTest

Results :

Tests run: 942, Failures: 0, Errors: 0, Skipped: 7
```

Also, in case of a failing test, the output was pretty bad:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.junit.tests.AllTests
Tests run: 941, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 6.984 sec <<< FAILURE! - in org.junit.tests.AllTests
failingTest(org.junit.tests.description.TestDescriptionTest)  Time elapsed: 0.003 sec  <<< ERROR!
java.lang.AssertionError: purposefully failing test
	at org.junit.tests.description.TestDescriptionTest.failingTest(TestDescriptionTest.java:27)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:88)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:58)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at junit.framework.JUnit4TestAdapter.run(JUnit4TestAdapter.java:38)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.junit.JUnitTestSet.execute(JUnitTestSet.java:99)
	at org.apache.maven.surefire.junit.JUnit3Provider.executeTestSet(JUnit3Provider.java:130)
	at org.apache.maven.surefire.junit.JUnit3Provider.invoke(JUnit3Provider.java:107)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:203)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:155)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)


Results :

Tests in error: 
  junit.framework.JUnit4TestCaseFacade#UNKNOWN  purposefully failing test

Tests run: 941, Failures: 0, Errors: 1, Skipped: 0
```

https://travis-ci.org/alb-i986/junit/jobs/129797694

But now:

```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.junit.tests.assertion.AssertionTest
Tests run: 86, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.036 sec - in org.junit.tests.assertion.AssertionTest
Running org.junit.tests.assertion.ComparisonFailureTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.tests.assertion.ComparisonFailureTest
Running org.junit.tests.assertion.MultipleFailureExceptionTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.assertion.MultipleFailureExceptionTest
Running org.junit.tests.deprecated.JUnit4ClassRunnerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.deprecated.JUnit4ClassRunnerTest
Running org.junit.tests.description.AnnotatedDescriptionTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.description.AnnotatedDescriptionTest
Running org.junit.tests.description.SuiteDescriptionTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 sec - in org.junit.tests.description.SuiteDescriptionTest
Running org.junit.tests.description.TestDescriptionMethodNameTest
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.description.TestDescriptionMethodNameTest
Running org.junit.tests.description.TestDescriptionTest
Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec <<< FAILURE! - in org.junit.tests.description.TestDescriptionTest
failingTest(org.junit.tests.description.TestDescriptionTest)  Time elapsed: 0.001 sec  <<< FAILURE!
java.lang.AssertionError: purposefully failing test
	at org.junit.tests.description.TestDescriptionTest.failingTest(TestDescriptionTest.java:27)

Running org.junit.experimental.categories.CategoriesAndParameterizedTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 sec - in org.junit.experimental.categories.CategoriesAndParameterizedTest
Running org.junit.experimental.categories.CategoryFilterFactoryTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.experimental.categories.CategoryFilterFactoryTest
Running org.junit.experimental.categories.CategoryTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.055 sec - in org.junit.experimental.categories.CategoryTest
Running org.junit.experimental.categories.CategoryValidatorTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.experimental.categories.CategoryValidatorTest
Running org.junit.experimental.categories.JavadocTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.experimental.categories.JavadocTest
Running org.junit.experimental.categories.MultiCategoryTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.017 sec - in org.junit.experimental.categories.MultiCategoryTest
Running org.junit.tests.experimental.max.DescriptionTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.tests.experimental.max.DescriptionTest
Running org.junit.tests.experimental.max.JUnit38SortingTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 sec - in org.junit.tests.experimental.max.JUnit38SortingTest
Running org.junit.tests.experimental.max.MaxStarterTest
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.523 sec - in org.junit.tests.experimental.max.MaxStarterTest
Running org.junit.tests.experimental.parallel.ParallelClassTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in org.junit.tests.experimental.parallel.ParallelClassTest
Running org.junit.tests.experimental.parallel.ParallelMethodTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.experimental.parallel.ParallelMethodTest
Running org.junit.tests.experimental.results.PrintableResultTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 sec - in org.junit.tests.experimental.results.PrintableResultTest
Running org.junit.tests.experimental.results.ResultMatchersTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.results.ResultMatchersTest
Running org.junit.tests.experimental.theories.internal.AllMembersSupplierTest
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.internal.AllMembersSupplierTest
Running org.junit.tests.experimental.theories.internal.ParameterizedAssertionErrorTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 sec - in org.junit.tests.experimental.theories.internal.ParameterizedAssertionErrorTest
Running org.junit.tests.experimental.theories.internal.SpecificDataPointsSupplierTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec - in org.junit.tests.experimental.theories.internal.SpecificDataPointsSupplierTest
Running org.junit.tests.experimental.theories.runner.FailingDataPointMethods
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.junit.tests.experimental.theories.runner.FailingDataPointMethods
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$StaticPublicNonDataPoints
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$StaticPublicNonDataPoints
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$OneTestTwoAnnotations
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$OneTestTwoAnnotations
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$BeforeAndAfterEachTime
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$BeforeAndAfterEachTime
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$DifferentTypesInConstructor
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$DifferentTypesInConstructor
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveIntsWithMethodParams
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveIntsWithMethodParams
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveIntsWithNegativeField
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveIntsWithNegativeField
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveInts
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$PositiveInts
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$NewObjectEachTime
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$NewObjectEachTime
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$BeforeAndAfterOnSameInstance
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$BeforeAndAfterOnSameInstance
Running org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$HasATwoParameterTheory
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.SuccessfulWithDataPointFields$HasATwoParameterTheory
Running org.junit.tests.experimental.theories.runner.TheoriesPerformanceTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.TheoriesPerformanceTest
Running org.junit.tests.experimental.theories.runner.TypeMatchingBetweenMultiDataPointsMethod
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.TypeMatchingBetweenMultiDataPointsMethod
Running org.junit.tests.experimental.theories.runner.UnsuccessfulWithDataPointFields
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.066 sec - in org.junit.tests.experimental.theories.runner.UnsuccessfulWithDataPointFields
Running org.junit.tests.experimental.theories.runner.WhenNoParametersMatch
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in org.junit.tests.experimental.theories.runner.WhenNoParametersMatch
Running org.junit.tests.experimental.theories.runner.WithAutoGeneratedDataPoints
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.tests.experimental.theories.runner.WithAutoGeneratedDataPoints
Running org.junit.tests.experimental.theories.runner.WithDataPointMethod
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.WithDataPointMethod
Running org.junit.tests.experimental.theories.runner.WithExtendedParameterSources
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 sec - in org.junit.tests.experimental.theories.runner.WithExtendedParameterSources
Running org.junit.tests.experimental.theories.runner.WithNamedDataPoints
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.WithNamedDataPoints
Running org.junit.tests.experimental.theories.runner.WithOnlyTestAnnotations
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.037 sec - in org.junit.tests.experimental.theories.runner.WithOnlyTestAnnotations
Running org.junit.tests.experimental.theories.runner.WithParameterSupplier
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.runner.WithParameterSupplier
Running org.junit.tests.experimental.theories.runner.WithUnresolvedGenericTypeVariablesOnTheoryParms
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.069 sec - in org.junit.tests.experimental.theories.runner.WithUnresolvedGenericTypeVariablesOnTheoryParms
Running org.junit.tests.experimental.theories.ParameterSignatureTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.experimental.theories.ParameterSignatureTest
Running org.junit.tests.experimental.theories.TestedOnSupplierTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.TestedOnSupplierTest
Running org.junit.tests.experimental.theories.AssumingInTheoriesTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.experimental.theories.AssumingInTheoriesTest
Running org.junit.tests.experimental.theories.PotentialAssignmentTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.junit.tests.experimental.theories.PotentialAssignmentTest
Running org.junit.tests.experimental.AssumptionTest
Tests run: 18, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 0.023 sec - in org.junit.tests.experimental.AssumptionTest
Running org.junit.tests.experimental.MatcherTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.junit.tests.experimental.MatcherTest
Running org.junit.tests.experimental.theories.extendingwithstubs.StubbedTheoriesTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.tests.experimental.theories.extendingwithstubs.StubbedTheoriesTest
Running org.junit.internal.builders.AnnotatedBuilderTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 sec - in org.junit.internal.builders.AnnotatedBuilderTest
Running org.junit.internal.runners.ErrorReportingRunnerTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.internal.runners.ErrorReportingRunnerTest
Running org.junit.internal.runners.statements.FailOnTimeoutTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.789 sec - in org.junit.internal.runners.statements.FailOnTimeoutTest
Running org.junit.internal.MethodSorterTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.internal.MethodSorterTest
Running org.junit.internal.matchers.StacktracePrintingMatcherTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.internal.matchers.StacktracePrintingMatcherTest
Running org.junit.internal.matchers.ThrowableCauseMatcherTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 sec - in org.junit.internal.matchers.ThrowableCauseMatcherTest
Running org.junit.tests.junit3compatibility.AllTestsTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.019 sec - in org.junit.tests.junit3compatibility.AllTestsTest
Running org.junit.tests.junit3compatibility.ClassRequestTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.junit3compatibility.ClassRequestTest
Running org.junit.tests.junit3compatibility.ForwardCompatibilityPrintingTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in org.junit.tests.junit3compatibility.ForwardCompatibilityPrintingTest
Running org.junit.tests.junit3compatibility.ForwardCompatibilityTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.041 sec - in org.junit.tests.junit3compatibility.ForwardCompatibilityTest
Running org.junit.tests.junit3compatibility.InitializationErrorForwardCompatibilityTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.tests.junit3compatibility.InitializationErrorForwardCompatibilityTest
Running org.junit.tests.junit3compatibility.JUnit38ClassRunnerTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 sec - in org.junit.tests.junit3compatibility.JUnit38ClassRunnerTest
Running org.junit.tests.junit3compatibility.OldTestClassAdaptingListenerTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.junit3compatibility.OldTestClassAdaptingListenerTest
Running junit.tests.framework.TestCaseTest
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in junit.tests.framework.TestCaseTest
Running junit.tests.framework.SuiteTest
Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.039 sec - in junit.tests.framework.SuiteTest
Running junit.tests.framework.TestListenerTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.framework.TestListenerTest
Running junit.tests.framework.AssertionFailedErrorTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.framework.AssertionFailedErrorTest
Running junit.tests.framework.AssertTest
Tests run: 16, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in junit.tests.framework.AssertTest
Running junit.tests.framework.TestImplementorTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in junit.tests.framework.TestImplementorTest
Running junit.tests.framework.NoArgTestCaseTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.framework.NoArgTestCaseTest
Running junit.tests.framework.ComparisonCompactorTest
Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in junit.tests.framework.ComparisonCompactorTest
Running junit.tests.framework.ComparisonFailureTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in junit.tests.framework.ComparisonFailureTest
Running junit.tests.framework.DoublePrecisionAssertTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in junit.tests.framework.DoublePrecisionAssertTest
Running junit.tests.framework.FloatAssertTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in junit.tests.framework.FloatAssertTest
Running junit.tests.runner.StackFilterTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.runner.StackFilterTest
Running junit.tests.runner.ResultTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.038 sec - in junit.tests.runner.ResultTest
Running junit.tests.runner.BaseTestRunnerTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.runner.BaseTestRunnerTest
Running junit.tests.runner.TextFeedbackTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in junit.tests.runner.TextFeedbackTest
Running junit.tests.runner.TextRunnerSingleMethodTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in junit.tests.runner.TextRunnerSingleMethodTest
Running junit.tests.runner.TextRunnerTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.446 sec - in junit.tests.runner.TextRunnerTest
Running junit.tests.extensions.ExtensionTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in junit.tests.extensions.ExtensionTest
Running junit.tests.extensions.ActiveTestTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.156 sec - in junit.tests.extensions.ActiveTestTest
Running junit.tests.extensions.RepeatedTestTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in junit.tests.extensions.RepeatedTestTest
Running org.junit.tests.junit3compatibility.SuiteMethodTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.junit3compatibility.SuiteMethodTest
Running org.junit.tests.listening.ListenerTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.listening.ListenerTest
Running org.junit.tests.listening.RunnerTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.listening.RunnerTest
Running org.junit.tests.listening.TestListenerTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.listening.TestListenerTest
Running org.junit.tests.listening.TextListenerTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.listening.TextListenerTest
Running org.junit.tests.listening.UserStopTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.listening.UserStopTest
Running org.junit.tests.manipulation.FilterableTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.manipulation.FilterableTest
Running org.junit.tests.manipulation.FilterTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.manipulation.FilterTest
Running org.junit.tests.manipulation.SingleMethodTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.manipulation.SingleMethodTest
Running org.junit.tests.manipulation.SortableTest$UnsortableRunnersAreHandledWithoutCrashing
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.manipulation.SortableTest$UnsortableRunnersAreHandledWithoutCrashing
Running org.junit.tests.manipulation.SortableTest$TestClassRunnerIsSortableWithSuiteMethod
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.manipulation.SortableTest$TestClassRunnerIsSortableWithSuiteMethod
Running org.junit.tests.manipulation.SortableTest$TestClassRunnerIsSortable
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 sec - in org.junit.tests.manipulation.SortableTest$TestClassRunnerIsSortable
Running org.junit.rules.BlockJUnit4ClassRunnerOverrideTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.junit.rules.BlockJUnit4ClassRunnerOverrideTest
Running org.junit.rules.ClassRulesTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.012 sec - in org.junit.rules.ClassRulesTest
Running org.junit.rules.DisableOnDebugTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec - in org.junit.rules.DisableOnDebugTest
Running org.junit.rules.ExpectedExceptionTest
Tests run: 22, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 sec - in org.junit.rules.ExpectedExceptionTest
Running org.junit.rules.ExternalResourceRuleTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.rules.ExternalResourceRuleTest
Running org.junit.rules.MethodRulesTest
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 sec - in org.junit.rules.MethodRulesTest
Running org.junit.rules.NameRulesTest$BeforeAndAfterTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.rules.NameRulesTest$BeforeAndAfterTest
Running org.junit.rules.NameRulesTest$TestNames
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.rules.NameRulesTest$TestNames
Running org.junit.rules.RuleChainTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.rules.RuleChainTest
Running org.junit.rules.RuleMemberValidatorTest
Tests run: 21, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 sec - in org.junit.rules.RuleMemberValidatorTest
Running org.junit.rules.StopwatchTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.junit.rules.StopwatchTest
Running org.junit.rules.TempFolderRuleTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.021 sec - in org.junit.rules.TempFolderRuleTest
Running org.junit.rules.TemporaryFolderRuleAssuredDeletionTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.rules.TemporaryFolderRuleAssuredDeletionTest
Running org.junit.rules.TemporaryFolderUsageTest
Tests run: 18, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 sec - in org.junit.rules.TemporaryFolderUsageTest
Running org.junit.rules.TestRuleTest
Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 sec - in org.junit.rules.TestRuleTest
Running org.junit.rules.TestWatcherTest
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.009 sec - in org.junit.rules.TestWatcherTest
Running org.junit.rules.TestWatchmanTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.rules.TestWatchmanTest
Running org.junit.rules.TimeoutRuleTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.055 sec - in org.junit.rules.TimeoutRuleTest
Running org.junit.rules.VerifierRuleTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.016 sec - in org.junit.rules.VerifierRuleTest
Running org.junit.runners.model.FrameworkFieldTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.runners.model.FrameworkFieldTest
Running org.junit.runners.model.FrameworkMethodTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.runners.model.FrameworkMethodTest
Running org.junit.runners.model.TestClassTest
Tests run: 19, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.junit.runners.model.TestClassTest
Running org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParametersTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParametersTest
Running org.junit.runners.parameterized.ParameterizedNamesTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.runners.parameterized.ParameterizedNamesTest
Running org.junit.runners.parameterized.TestWithParametersTest
Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.runners.parameterized.TestWithParametersTest
Running org.junit.runners.CustomBlockJUnit4ClassRunnerTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.runners.CustomBlockJUnit4ClassRunnerTest
Running org.junit.runner.notification.ConcurrentRunNotifierTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.056 sec - in org.junit.runner.notification.ConcurrentRunNotifierTest
Running org.junit.runner.notification.RunNotifierTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.runner.notification.RunNotifierTest
Running org.junit.runner.notification.SynchronizedRunListenerTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.runner.notification.SynchronizedRunListenerTest
Running org.junit.runner.FilterFactoriesTest
Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.runner.FilterFactoriesTest
Running org.junit.runner.FilterOptionIntegrationTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.008 sec - in org.junit.runner.FilterOptionIntegrationTest
Running org.junit.runner.JUnitCommandLineParseResultTest
Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.runner.JUnitCommandLineParseResultTest
Running org.junit.runner.JUnitCoreTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.runner.JUnitCoreTest
Running org.junit.tests.running.classes.BlockJUnit4ClassRunnerTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.running.classes.BlockJUnit4ClassRunnerTest
Running org.junit.tests.running.classes.ClassLevelMethodsWithIgnoredTestsTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.tests.running.classes.ClassLevelMethodsWithIgnoredTestsTest
Running org.junit.tests.running.classes.EnclosedTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.running.classes.EnclosedTest
Running org.junit.tests.running.classes.IgnoreClassTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.running.classes.IgnoreClassTest
Running org.junit.tests.running.classes.ParameterizedTestTest
Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.014 sec - in org.junit.tests.running.classes.ParameterizedTestTest
Running org.junit.tests.running.classes.ParentRunnerFilteringTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 sec - in org.junit.tests.running.classes.ParentRunnerFilteringTest
Running org.junit.tests.running.classes.ParentRunnerTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 sec - in org.junit.tests.running.classes.ParentRunnerTest
Running org.junit.tests.running.classes.RunWithTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.029 sec - in org.junit.tests.running.classes.RunWithTest
Running org.junit.tests.running.classes.SuiteTest
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec - in org.junit.tests.running.classes.SuiteTest
Running org.junit.tests.running.classes.UseSuiteAsASuperclassTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.004 sec - in org.junit.tests.running.classes.UseSuiteAsASuperclassTest
Running org.junit.tests.running.core.CommandLineTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 sec - in org.junit.tests.running.core.CommandLineTest
Running org.junit.tests.running.core.JUnitCoreReturnsCorrectExitCodeTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.007 sec - in org.junit.tests.running.core.JUnitCoreReturnsCorrectExitCodeTest
Running org.junit.tests.running.core.SystemExitTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.052 sec - in org.junit.tests.running.core.SystemExitTest
Running org.junit.tests.running.methods.AnnotationTest
Tests run: 27, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.013 sec - in org.junit.tests.running.methods.AnnotationTest
Running org.junit.tests.running.methods.ExpectedTest
Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.tests.running.methods.ExpectedTest
Running org.junit.tests.running.methods.InheritedTestTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.running.methods.InheritedTestTest
Running org.junit.tests.running.methods.ParameterizedTestMethodTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.running.methods.ParameterizedTestMethodTest
Running org.junit.tests.running.methods.TestMethodTest
Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.running.methods.TestMethodTest
Running org.junit.tests.running.methods.TimeoutTest
Tests run: 13, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 0.891 sec - in org.junit.tests.running.methods.TimeoutTest
Running org.junit.samples.ListTest
Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.samples.ListTest
Running org.junit.samples.money.MoneyTest
Tests run: 23, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.samples.money.MoneyTest
Running org.junit.tests.validation.BadlyFormedClassesTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.006 sec - in org.junit.tests.validation.BadlyFormedClassesTest
Running org.junit.tests.validation.FailedConstructionTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.validation.FailedConstructionTest
Running org.junit.tests.validation.ValidationTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.junit.tests.validation.ValidationTest
Running org.junit.validator.AnnotationsValidatorTest
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.validator.AnnotationsValidatorTest
Running org.junit.validator.AnnotationValidatorFactoryTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.002 sec - in org.junit.validator.AnnotationValidatorFactoryTest
Running org.junit.validator.PublicClassValidatorTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 sec - in org.junit.validator.PublicClassValidatorTest
Running org.junit.AssumptionViolatedExceptionTest
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.018 sec - in org.junit.AssumptionViolatedExceptionTest
Running org.junit.tests.ObjectContractTest
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.026 sec - in org.junit.tests.ObjectContractTest

Results :

Failed tests: 
  TestDescriptionTest.failingTest:27 purposefully failing test

Tests run: 943, Failures: 1, Errors: 0, Skipped: 7
```
https://travis-ci.org/alb-i986/junit/jobs/129797962

The only downside, as you can see, is that it's not so easy to see the stack trace for the failing test, buried among the tens of test classes. I think it should rather be reported at the very end, as it was with the old surefire junit3 provider. But this is a UX bug of surefire.

Please note that the test count is a bit different now.

Before:

    Tests run: 940, Failures: 0, Errors: 0, Skipped: 0

After: 

    Tests run: 942, Failures: 0, Errors: 0, Skipped: 7