### PR TITLE
Fix ResultMatchers#hasFailureContaining

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <artifactId>hamcrest-core</artifactId>
             <version>1.3</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <dependencies>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-core</artifactId>
+            <artifactId>hamcrest-library</artifactId>
             <version>1.3</version>
         </dependency>
     </dependencies>

--- a/src/main/java/org/junit/experimental/results/ResultMatchers.java
+++ b/src/main/java/org/junit/experimental/results/ResultMatchers.java
@@ -5,8 +5,6 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-
 /**
  * Matchers on a PrintableResult, to enable JUnit self-tests.
  * For example:
@@ -36,21 +34,14 @@ public class ResultMatchers {
      * Matches if there are {@code count} failures
      */
     public static Matcher<PrintableResult> failureCountIs(final int count) {
-        return failureCount(equalTo(count));
-    }
-
-    /**
-     * Matches if the number of failures matches {@code countMatcher}
-     */
-    public static Matcher<PrintableResult> failureCount(final Matcher<Integer> countMatcher) {
         return new TypeSafeMatcher<PrintableResult>() {
             public void describeTo(Description description) {
-                description.appendText("has a number of failures matching " + countMatcher);
+                description.appendText("has " + count + " failures");
             }
 
             @Override
             public boolean matchesSafely(PrintableResult item) {
-                return countMatcher.matches(item.failureCount());
+                return item.failureCount() == count;
             }
         };
     }

--- a/src/main/java/org/junit/experimental/results/ResultMatchers.java
+++ b/src/main/java/org/junit/experimental/results/ResultMatchers.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 /**
  * Matchers on a PrintableResult, to enable JUnit self-tests.
@@ -77,7 +78,7 @@ public class ResultMatchers {
     public static Matcher<PrintableResult> hasFailureContaining(final String string) {
         return new BaseMatcher<PrintableResult>() {
             public boolean matches(Object item) {
-                return item.toString().contains(string);
+                return failureCount(greaterThan(0)).matches(item) && item.toString().contains(string);
             }
 
             public void describeTo(Description description) {

--- a/src/main/java/org/junit/experimental/results/ResultMatchers.java
+++ b/src/main/java/org/junit/experimental/results/ResultMatchers.java
@@ -5,6 +5,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import static org.hamcrest.Matchers.equalTo;
+
 /**
  * Matchers on a PrintableResult, to enable JUnit self-tests.
  * For example:
@@ -34,16 +36,7 @@ public class ResultMatchers {
      * Matches if there are {@code count} failures
      */
     public static Matcher<PrintableResult> failureCountIs(final int count) {
-        return new TypeSafeMatcher<PrintableResult>() {
-            public void describeTo(Description description) {
-                description.appendText("has " + count + " failures");
-            }
-
-            @Override
-            public boolean matchesSafely(PrintableResult item) {
-                return item.failureCount() == count;
-            }
-        };
+        return failureCount(equalTo(count));
     }
 
     /**

--- a/src/main/java/org/junit/experimental/results/ResultMatchers.java
+++ b/src/main/java/org/junit/experimental/results/ResultMatchers.java
@@ -5,8 +5,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 /**
  * Matchers on a PrintableResult, to enable JUnit self-tests.
@@ -76,9 +75,9 @@ public class ResultMatchers {
      * contains {@code string}
      */
     public static Matcher<PrintableResult> hasFailureContaining(final String string) {
-        return new BaseMatcher<PrintableResult>() {
-            public boolean matches(Object item) {
-                return failureCount(greaterThan(0)).matches(item) && item.toString().contains(string);
+        return new TypeSafeMatcher<PrintableResult>() {
+            public boolean matchesSafely(PrintableResult item) {
+                return item.failureCount() > 0 && item.toString().contains(string);
             }
 
             public void describeTo(Description description) {

--- a/src/main/java/org/junit/experimental/results/ResultMatchers.java
+++ b/src/main/java/org/junit/experimental/results/ResultMatchers.java
@@ -47,6 +47,22 @@ public class ResultMatchers {
     }
 
     /**
+     * Matches if the number of failures matches {@code countMatcher}
+     */
+    public static Matcher<PrintableResult> failureCount(final Matcher<Integer> countMatcher) {
+        return new TypeSafeMatcher<PrintableResult>() {
+            public void describeTo(Description description) {
+                description.appendText("has a number of failures matching " + countMatcher);
+            }
+
+            @Override
+            public boolean matchesSafely(PrintableResult item) {
+                return countMatcher.matches(item.failureCount());
+            }
+        };
+    }
+
+    /**
      * Matches if the result has exactly one failure, and it contains {@code string}
      */
     public static Matcher<Object> hasSingleFailureContaining(final String string) {

--- a/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
@@ -37,6 +37,14 @@ public class ResultMatchersTest {
     }
 
     @Test
+    public void hasFailureContaining_givenResultWithOneFailure() {
+        PrintableResult resultWithOneFailure = new PrintableResult(Collections.singletonList(
+                new Failure(Description.EMPTY, new RuntimeException("my failure"))));
+
+        assertThat(ResultMatchers.hasFailureContaining("my failure").matches(resultWithOneFailure), is(true));
+    }
+
+    @Test
     public void testFailureCount() {
         PrintableResult resultWithOneFailure = new PrintableResult(Collections.singletonList(
                 new Failure(Description.EMPTY, new RuntimeException("failure 1"))));

--- a/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
@@ -4,11 +4,15 @@ import org.junit.Test;
 import org.junit.experimental.results.PrintableResult;
 import org.junit.experimental.results.ResultMatchers;
 import org.junit.experimental.theories.Theory;
+import org.junit.runner.Description;
 import org.junit.runner.notification.Failure;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class ResultMatchersTest {
@@ -26,14 +30,18 @@ public class ResultMatchersTest {
     }
 
     @Test
-    public void hasFailureContaining_givenNonMatchingScenario() {
+    public void hasFailureContaining_givenResultWithNoFailures() {
         PrintableResult resultWithNoFailures = new PrintableResult(new ArrayList<Failure>());
+
         assertThat(ResultMatchers.hasFailureContaining("").matches(resultWithNoFailures), is(false));
     }
 
     @Test
-    public void failureCount_nonMatchingScenario() {
-        PrintableResult resultWithNoFailures = new PrintableResult(new ArrayList<Failure>());
-        assertThat(ResultMatchers.failureCount(greaterThanOrEqualTo(3)).matches(resultWithNoFailures), is(false));
+    public void testFailureCount() {
+        PrintableResult resultWithOneFailure = new PrintableResult(Collections.singletonList(
+                new Failure(Description.EMPTY, new RuntimeException("failure 1"))));
+
+        assertThat(ResultMatchers.failureCount(equalTo(3)).matches(resultWithOneFailure), is(false));
+        assertThat(ResultMatchers.failureCount(equalTo(1)).matches(resultWithOneFailure), is(true));
     }
 }

--- a/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
@@ -12,10 +12,11 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class ResultMatchersTest {
+
     @Test
     public void hasFailuresHasGoodDescription() {
         assertThat(ResultMatchers.failureCountIs(3).toString(),
-                is("has 3 failures"));
+                is("has a number of failures matching <3>"));
     }
 
     @Theory

--- a/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
@@ -42,6 +42,7 @@ public class ResultMatchersTest {
                 new Failure(Description.EMPTY, new RuntimeException("my failure"))));
 
         assertThat(ResultMatchers.hasFailureContaining("my failure").matches(resultWithOneFailure), is(true));
+        assertThat(ResultMatchers.hasFailureContaining("his failure").matches(resultWithOneFailure), is(false));
     }
 
     @Test

--- a/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -20,7 +19,7 @@ public class ResultMatchersTest {
     @Test
     public void hasFailuresHasGoodDescription() {
         assertThat(ResultMatchers.failureCountIs(3).toString(),
-                is("has a number of failures matching <3>"));
+                is("has 3 failures"));
     }
 
     @Theory
@@ -43,14 +42,5 @@ public class ResultMatchersTest {
 
         assertThat(ResultMatchers.hasFailureContaining("my failure").matches(resultWithOneFailure), is(true));
         assertThat(ResultMatchers.hasFailureContaining("his failure").matches(resultWithOneFailure), is(false));
-    }
-
-    @Test
-    public void testFailureCount() {
-        PrintableResult resultWithOneFailure = new PrintableResult(Collections.singletonList(
-                new Failure(Description.EMPTY, new RuntimeException("failure 1"))));
-
-        assertThat(ResultMatchers.failureCount(equalTo(3)).matches(resultWithOneFailure), is(false));
-        assertThat(ResultMatchers.failureCount(equalTo(1)).matches(resultWithOneFailure), is(true));
     }
 }

--- a/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
@@ -1,12 +1,16 @@
 package org.junit.tests.experimental.results;
 
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.junit.experimental.results.ResultMatchers;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.notification.Failure;
+
+import java.util.ArrayList;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-
-import org.junit.Test;
-import org.junit.experimental.results.ResultMatchers;
-import org.junit.experimental.theories.Theory;
 
 public class ResultMatchersTest {
     @Test
@@ -19,5 +23,11 @@ public class ResultMatchersTest {
     public void hasFailuresDescriptionReflectsInput(int i) {
         assertThat(ResultMatchers.failureCountIs(i).toString(),
                 containsString("" + i));
+    }
+
+    @Test
+    public void hasFailureContaining_givenNonMatchingScenario() {
+        PrintableResult resultWithNoFailures = new PrintableResult(new ArrayList<Failure>());
+        assertThat(ResultMatchers.hasFailureContaining("").matches(resultWithNoFailures), is(false));
     }
 }

--- a/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
@@ -8,8 +8,7 @@ import org.junit.runner.notification.Failure;
 
 import java.util.ArrayList;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class ResultMatchersTest {
@@ -29,5 +28,11 @@ public class ResultMatchersTest {
     public void hasFailureContaining_givenNonMatchingScenario() {
         PrintableResult resultWithNoFailures = new PrintableResult(new ArrayList<Failure>());
         assertThat(ResultMatchers.hasFailureContaining("").matches(resultWithNoFailures), is(false));
+    }
+
+    @Test
+    public void failureCount_nonMatchingScenario() {
+        PrintableResult resultWithNoFailures = new PrintableResult(new ArrayList<Failure>());
+        assertThat(ResultMatchers.failureCount(greaterThanOrEqualTo(3)).matches(resultWithNoFailures), is(false));
     }
 }


### PR DESCRIPTION
It should *not* match when the given PrintableResult has no failures.

Please note that this change replaces the dependency hamcrest-core with hamcrest-library. I'm not sure if you are happy with that. If you are, we probably also need to update another couple of lines in the pom, see e.g. https://github.com/junit-team/junit4/blob/master/pom.xml#L308