### PR TITLE
MultipleFailureException: expose the stacktrace of the nested exceptions in getMessage

### DIFF
--- a/src/main/java/org/junit/internal/Throwables.java
+++ b/src/main/java/org/junit/internal/Throwables.java
@@ -1,5 +1,8 @@
 package org.junit.internal;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 /**
  * Miscellaneous functions dealing with {@code Throwable}.
  *
@@ -38,5 +41,14 @@ public final class Throwables {
     @SuppressWarnings("unchecked")
     private static <T extends Throwable> void rethrow(Throwable e) throws T {
         throw (T) e;
+    }
+
+    /**
+     * Gets the stack trace from a Throwable as a String.
+     */
+    public static String getStackTrace(Throwable throwable) {
+        StringWriter sw = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(sw, true));
+        return sw.toString();
     }
 }

--- a/src/main/java/org/junit/runners/model/MultipleFailureException.java
+++ b/src/main/java/org/junit/runners/model/MultipleFailureException.java
@@ -32,10 +32,14 @@ public class MultipleFailureException extends Exception {
     @Override
     public String getMessage() {
         StringBuilder sb = new StringBuilder(
-                String.format("There were %d errors:", fErrors.size()));
+                String.format("There were %d errors:\n", fErrors.size()));
+
+        int i = 1;
         for (Throwable e : fErrors) {
-            sb.append(String.format("\n  %s(%s)", e.getClass().getName(), e.getMessage()));
+            sb.append(String.format("\n  %d. %s", i, Throwables.getStackTrace(e)));
+            i++;
         }
+
         return sb.toString();
     }
 

--- a/src/test/java/org/junit/internal/ThrowablesTest.java
+++ b/src/test/java/org/junit/internal/ThrowablesTest.java
@@ -1,0 +1,16 @@
+package org.junit.internal;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ThrowablesTest {
+
+    @Test
+    public void testGetStackTrace() {
+        Throwable t = new Throwable("message");
+        assertThat(Throwables.getStackTrace(t), startsWith("java.lang.Throwable: message\n" +
+                        "\tat org.junit.internal.ThrowablesTest.testGetStackTrace(ThrowablesTest.java:"));
+    }
+}

--- a/src/test/java/org/junit/tests/assertion/MultipleFailureExceptionTest.java
+++ b/src/test/java/org/junit/tests/assertion/MultipleFailureExceptionTest.java
@@ -7,12 +7,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.lang.annotation.AnnotationFormatError;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/src/test/java/org/junit/tests/assertion/MultipleFailureExceptionTest.java
+++ b/src/test/java/org/junit/tests/assertion/MultipleFailureExceptionTest.java
@@ -1,6 +1,10 @@
 package org.junit.tests.assertion;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -8,6 +12,7 @@ import static org.junit.Assert.fail;
 
 import java.lang.annotation.AnnotationFormatError;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -62,12 +67,28 @@ public class MultipleFailureExceptionTest {
             fail();
         } catch (MultipleFailureException expected) {
             assertThat(expected.getFailures(), equalTo(errors));
-            assertTrue(expected.getMessage().startsWith("There were 2 errors:\n"));
-            assertTrue(expected.getMessage().contains("ExpectedException(basil)\n"));
-            assertTrue(expected.getMessage().contains("RuntimeException(garlic)"));
+            assertThat(expected.getMessage(), allOf(
+                    startsWith("There were 2 errors:\n"),
+                    containsString("ExpectedException: basil\n"),
+                    containsString("RuntimeException: garlic\n")
+            ));
         }
     }
 
+    @Test
+    public void getMessageShouldGiveTheStacktraceOfEachFailure() throws Exception {
+        List<Throwable> failures = asList(new Throwable("first failure"), new RuntimeException("second failure"));
+        MultipleFailureException sut = new MultipleFailureException(failures);
+
+        assertThat(sut.getMessage(), allOf(
+                startsWith("There were 2 errors:\n"),
+                containsString("1. java.lang.Throwable: first failure\n" +
+                        "\tat org.junit.tests.assertion.MultipleFailureExceptionTest.getMessageShouldGiveTheStacktraceOfEachFailure"),
+                containsString("2. java.lang.RuntimeException: second failure\n" +
+                        "\tat org.junit.tests.assertion.MultipleFailureExceptionTest.getMessageShouldGiveTheStacktraceOfEachFailure")
+                )
+        );
+    }
 
     private static class ExpectedException extends RuntimeException {
         private static final long serialVersionUID = 1L;


### PR DESCRIPTION
This makes it possible to debug tests failing with a MultipleFailureException made up of many exceptions.