### PR TITLE
Add Result#getAssumptionFailureCount

### DIFF
--- a/src/main/java/org/junit/runner/Result.java
+++ b/src/main/java/org/junit/runner/Result.java
@@ -28,6 +28,7 @@ public class Result implements Serializable {
             ObjectStreamClass.lookup(SerializedForm.class).getFields();
     private final AtomicInteger count;
     private final AtomicInteger ignoreCount;
+    private final AtomicInteger assumptionFailureCount;
     private final CopyOnWriteArrayList<Failure> failures;
     private final AtomicLong runTime;
     private final AtomicLong startTime;
@@ -38,6 +39,7 @@ public class Result implements Serializable {
     public Result() {
         count = new AtomicInteger();
         ignoreCount = new AtomicInteger();
+        assumptionFailureCount = new AtomicInteger();
         failures = new CopyOnWriteArrayList<Failure>();
         runTime = new AtomicLong();
         startTime = new AtomicLong();
@@ -46,6 +48,7 @@ public class Result implements Serializable {
     private Result(SerializedForm serializedForm) {
         count = serializedForm.fCount;
         ignoreCount = serializedForm.fIgnoreCount;
+        assumptionFailureCount = serializedForm.assumptionFailureCount;
         failures = new CopyOnWriteArrayList<Failure>(serializedForm.fFailures);
         runTime = new AtomicLong(serializedForm.fRunTime);
         startTime = new AtomicLong(serializedForm.fStartTime);
@@ -84,6 +87,13 @@ public class Result implements Serializable {
      */
     public int getIgnoreCount() {
         return ignoreCount.get();
+    }
+
+    /**
+     * @return the number of tests skipped because of an assumption failure
+     */
+    public int getAssumptionFailureCount() {
+        return assumptionFailureCount.get();
     }
 
     /**
@@ -137,7 +147,7 @@ public class Result implements Serializable {
 
         @Override
         public void testAssumptionFailure(Failure failure) {
-            // do nothing: same as passing (for 4.5; may change in 4.6)
+            assumptionFailureCount.getAndIncrement();
         }
     }
 
@@ -156,6 +166,7 @@ public class Result implements Serializable {
         private static final long serialVersionUID = 1L;
         private final AtomicInteger fCount;
         private final AtomicInteger fIgnoreCount;
+        private final AtomicInteger assumptionFailureCount;
         private final List<Failure> fFailures;
         private final long fRunTime;
         private final long fStartTime;
@@ -163,6 +174,7 @@ public class Result implements Serializable {
         public SerializedForm(Result result) {
             fCount = result.count;
             fIgnoreCount = result.ignoreCount;
+            assumptionFailureCount = result.assumptionFailureCount;
             fFailures = Collections.synchronizedList(new ArrayList<Failure>(result.failures));
             fRunTime = result.runTime.longValue();
             fStartTime = result.startTime.longValue();
@@ -172,6 +184,7 @@ public class Result implements Serializable {
         private SerializedForm(ObjectInputStream.GetField fields) throws IOException {
             fCount = (AtomicInteger) fields.get("fCount", null);
             fIgnoreCount = (AtomicInteger) fields.get("fIgnoreCount", null);
+            assumptionFailureCount = (AtomicInteger) fields.get("assumptionFailureCount", null);
             fFailures = (List<Failure>) fields.get("fFailures", null);
             fRunTime = fields.get("fRunTime", 0L);
             fStartTime = fields.get("fStartTime", 0L);

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -188,9 +188,18 @@ public class AssumptionTest {
         assertThat(testResult(AssumptionFailureInConstructor.class), isSuccessful());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void assumeWithExpectedException() {
-        assumeTrue(false);
+    public static class TestClassWithAssumptionFailure {
+
+        @Test(expected = IllegalArgumentException.class)
+        public void assumeWithExpectedException() {
+            assumeTrue(false);
+        }
+    }
+
+    @Test
+    public void assumeWithExpectedExceptionShouldThrowAssumptionViolatedException() {
+        Result result = JUnitCore.runClasses(TestClassWithAssumptionFailure.class);
+        assertThat(result.getAssumptionFailureCount(), is(1));
     }
 
     final static String message = "Some random message string.";


### PR DESCRIPTION
My original intent was to fix unit test assumeWithExpectedException: it was throwing AssumptionViolatedException thus being skipped (see #98).

It led me to adding Result#getAssumptionFailureCount.
