### PR TITLE
Overload ResultMatchers.failureCountIs: take a Matcher of integer

### DIFF
--- a/src/main/java/org/junit/experimental/results/ResultMatchers.java
+++ b/src/main/java/org/junit/experimental/results/ResultMatchers.java
@@ -46,6 +46,8 @@ public class ResultMatchers {
 
     /**
      * Matches if the number of failures matches {@code countMatcher}
+     *
+     * @since 4.13
      */
     public static Matcher<PrintableResult> failureCountIs(Matcher<? super Integer> countMatcher) {
         return new FailureCountMatcher(countMatcher);

--- a/src/main/java/org/junit/experimental/results/ResultMatchers.java
+++ b/src/main/java/org/junit/experimental/results/ResultMatchers.java
@@ -5,6 +5,8 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+
 /**
  * Matchers on a PrintableResult, to enable JUnit self-tests.
  * For example:
@@ -34,16 +36,19 @@ public class ResultMatchers {
      * Matches if there are {@code count} failures
      */
     public static Matcher<PrintableResult> failureCountIs(final int count) {
-        return new TypeSafeMatcher<PrintableResult>() {
+        return new FailureCountMatcher(equalTo(count)) {
+            @Override
             public void describeTo(Description description) {
                 description.appendText("has " + count + " failures");
             }
-
-            @Override
-            public boolean matchesSafely(PrintableResult item) {
-                return item.failureCount() == count;
-            }
         };
+    }
+
+    /**
+     * Matches if the number of failures matches {@code countMatcher}
+     */
+    public static Matcher<PrintableResult> failureCountIs(Matcher<? super Integer> countMatcher) {
+        return new FailureCountMatcher(countMatcher);
     }
 
     /**
@@ -75,5 +80,22 @@ public class ResultMatchers {
                 description.appendText("has failure containing " + string);
             }
         };
+    }
+
+    private static class FailureCountMatcher extends TypeSafeMatcher<PrintableResult> {
+        private final Matcher<? super Integer> countMatcher;
+
+        public FailureCountMatcher(Matcher<? super Integer> countMatcher) {
+            this.countMatcher = countMatcher;
+        }
+
+        public void describeTo(Description description) {
+            description.appendText("has a number of failures matching " + countMatcher);
+        }
+
+        @Override
+        public boolean matchesSafely(PrintableResult item) {
+            return countMatcher.matches(item.failureCount());
+        }
     }
 }

--- a/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
@@ -1,14 +1,23 @@
 package org.junit.tests.experimental.results;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Matcher;
 import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
 import org.junit.experimental.results.ResultMatchers;
 import org.junit.experimental.theories.Theory;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+
+import java.util.Collections;
 
 public class ResultMatchersTest {
+
     @Test
     public void hasFailuresHasGoodDescription() {
         assertThat(ResultMatchers.failureCountIs(3).toString(),
@@ -19,5 +28,30 @@ public class ResultMatchersTest {
     public void hasFailuresDescriptionReflectsInput(int i) {
         assertThat(ResultMatchers.failureCountIs(i).toString(),
                 containsString("" + i));
+    }
+
+    @Test
+    public void testFailureCountIsTakingMatcher_givenResultWithOneFailure() {
+        PrintableResult resultWithOneFailure = new PrintableResult(Collections.singletonList(
+                new Failure(Description.createTestDescription("class", "name"), new RuntimeException("failure 1"))));
+
+        assertThat(ResultMatchers.failureCountIs(equalTo(3)).matches(resultWithOneFailure), is(false));
+        assertThat(ResultMatchers.failureCountIs(equalTo(1)).matches(resultWithOneFailure), is(true));
+    }
+
+    @Test
+    public void failureCountIsTakingMatcherShouldHaveGoodDescription() {
+        Matcher<Integer> matcherTestStub = new BaseMatcher<Integer>() {
+            public void describeTo(org.hamcrest.Description description) {
+                description.appendText("STUBBED DESCRIPTION");
+            }
+
+            public boolean matches(Object item) {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+        assertThat(ResultMatchers.failureCountIs(matcherTestStub).toString(),
+                is("has a number of failures matching STUBBED DESCRIPTION"));
     }
 }


### PR DESCRIPTION
This allows clients to assert that the failure count is greaterThan, lessThan, etc.