### PR TITLE
Prevent following symbolic links when deleting temporary directories.

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -262,8 +262,13 @@ public class TemporaryFolder extends ExternalResource {
         
         return recursiveDelete(folder);
     }
-    
+
     private boolean recursiveDelete(File file) {
+        // Try deleting file before assuming file is a directory
+        // to prevent following symbolic links.
+        if (file.delete()) {
+            return true;
+        }
         boolean result = true;
         File[] files = file.listFiles();
         if (files != null) {


### PR DESCRIPTION
Following symbolic links when removing files can lead to the removal of files outside the directory structure rooted in the temporary folder, and it can lead to unbounded recursion if a symbolic link points to a directory where the link is directly reachable from.

Preventing following symbolic links is pretty easy with JDK5 and later, but writing a test is ugly because there is no java interface to create symbolic links until NIO2 in JDK7. So I'll hold off with a test unless a reviewer insists.