### PR TITLE
Retry TemporaryFolder.newFolder's call to mkdir if unsuccessful

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -44,6 +44,9 @@ public class TemporaryFolder extends ExternalResource {
     private final boolean assureDeletion;
     private File folder;
 
+    private static final int TEMP_DIR_ATTEMPTS = 10000;
+    private static final String TMP_PREFIX = "junit";
+
     /**
      * Create a temporary folder which uses system default temporary-file 
      * directory to create temporary resources.
@@ -160,7 +163,7 @@ public class TemporaryFolder extends ExternalResource {
      * Returns a new fresh file with a random name under the temporary folder.
      */
     public File newFile() throws IOException {
-        return File.createTempFile("junit", null, getRoot());
+        return File.createTempFile(TMP_PREFIX, null, getRoot());
     }
 
     /**
@@ -216,10 +219,24 @@ public class TemporaryFolder extends ExternalResource {
     }
 
     private File createTemporaryFolderIn(File parentFolder) throws IOException {
-        File createdFolder = File.createTempFile("junit", "", parentFolder);
-        createdFolder.delete();
-        createdFolder.mkdir();
-        return createdFolder;
+        File createdFolder = null;
+        for (int i = 0; i < TEMP_DIR_ATTEMPTS; ++i) {
+            // Use createTempFile to get a suitable folder name.
+            String suffix = ".tmp";
+            File tmpFile = File.createTempFile(TMP_PREFIX, suffix, parentFolder);
+            String tmpName = tmpFile.getName();
+            // Discard suffix of tmpName.
+            String folderName = tmpName.substring(0, tmpName.length() - suffix.length());
+            createdFolder = new File(parentFolder, folderName);
+            if (createdFolder.mkdir()) {
+                tmpFile.delete();
+                return createdFolder;
+            }
+            tmpFile.delete();
+        }
+        throw new IOException("Unable to create temporary directory in: "
+            + parentFolder.toString() + ". Tried " + TEMP_DIR_ATTEMPTS + " times. "
+            + "Last attempted to create: " + createdFolder.toString());
     }
 
     /**


### PR DESCRIPTION
If java.io.File.mkdir returns false, then a new directory has not been created, causing problems when running tests in parallel (see issue #1223).