### PR TITLE
Fix regression with TemporaryFolder introduced by #1304

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -224,10 +224,10 @@ public class TemporaryFolder extends ExternalResource {
             // Use createTempFile to get a suitable folder name.
             String suffix = ".tmp";
             File tmpFile = File.createTempFile(TMP_PREFIX, suffix, parentFolder);
-            String tmpName = tmpFile.getName();
-            // Discard suffix of tmpName.
+            String tmpName = tmpFile.toString();
+            // Discard .tmp suffix of tmpName.
             String folderName = tmpName.substring(0, tmpName.length() - suffix.length());
-            createdFolder = new File(parentFolder, folderName);
+            createdFolder = new File(folderName);
             if (createdFolder.mkdir()) {
                 tmpFile.delete();
                 return createdFolder;

--- a/src/test/java/org/junit/rules/TempFolderRuleTest.java
+++ b/src/test/java/org/junit/rules/TempFolderRuleTest.java
@@ -31,6 +31,13 @@ public class TempFolderRuleTest {
             createdFiles[0] = folder.newFile("myfile.txt");
             assertTrue(createdFiles[0].exists());
         }
+
+        @Test
+        public void testTempFolderLocation() throws IOException {
+            File folderRoot = folder.getRoot();
+            String tmpRoot = System.getProperty("java.io.tmpdir");
+            assertTrue(folderRoot.toString().startsWith(tmpRoot));
+        }
     }
 
     @Test


### PR DESCRIPTION
Looks like #1304 caused a regression where the location of the temporary folder created no longer ends up in the standard temporary directory. See issue #1309.

I added a test that checks the location of the created folder relative to the system property "java.io.tmpdir".