### PR TITLE
RuleChain#around should not allow null args

### DIFF
--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -77,8 +77,12 @@ public class RuleChain implements TestRule {
      *
      * @param enclosedRule the rule to enclose.
      * @return a new {@code RuleChain}.
+     * @throws IllegalArgumentException if {@code enclosedRule} is null
      */
     public RuleChain around(TestRule enclosedRule) {
+        if (enclosedRule == null) {
+            throw new IllegalArgumentException("The enclosed rule should not be null");
+        }
         List<TestRule> rulesOfNewChain = new ArrayList<TestRule>();
         rulesOfNewChain.add(enclosedRule);
         rulesOfNewChain.addAll(rulesStartingWithInnerMost);

--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -77,11 +77,11 @@ public class RuleChain implements TestRule {
      *
      * @param enclosedRule the rule to enclose.
      * @return a new {@code RuleChain}.
-     * @throws IllegalArgumentException if {@code enclosedRule} is null
+     * @throws NullPointerException if the argument {@code enclosedRule} is null
      */
     public RuleChain around(TestRule enclosedRule) {
         if (enclosedRule == null) {
-            throw new IllegalArgumentException("The enclosed rule should not be null");
+            throw new NullPointerException("The enclosed rule should not be null");
         }
         List<TestRule> rulesOfNewChain = new ArrayList<TestRule>();
         rulesOfNewChain.add(enclosedRule);

--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -75,13 +75,13 @@ public class RuleChain implements TestRule {
      * Create a new {@code RuleChain}, which encloses the given {@link TestRule} with
      * the rules of the current {@code RuleChain}.
      *
-     * @param enclosedRule the rule to enclose.
+     * @param enclosedRule the rule to enclose; must not be {@code null}.
      * @return a new {@code RuleChain}.
-     * @throws NullPointerException if the argument {@code enclosedRule} is null
+     * @throws NullPointerException if the argument {@code enclosedRule} is {@code null}
      */
     public RuleChain around(TestRule enclosedRule) {
         if (enclosedRule == null) {
-            throw new NullPointerException("The enclosed rule should not be null");
+            throw new NullPointerException("The enclosed rule must not be null");
         }
         List<TestRule> rulesOfNewChain = new ArrayList<TestRule>();
         rulesOfNewChain.add(enclosedRule);

--- a/src/test/java/org/junit/rules/RuleChainTest.java
+++ b/src/test/java/org/junit/rules/RuleChainTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.internal.Throwables;
 import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
@@ -89,15 +90,7 @@ public class RuleChainTest {
         Result result = JUnitCore.runClasses(RuleChainWithNullRules.class);
 
         assertThat(result.getFailures().size(), equalTo(1));
-        String stacktrace = stacktraceToString(result.getFailures().get(0).getException());
+        String stacktrace = Throwables.getStacktrace(result.getFailures().get(0).getException());
         assertThat(stacktrace, containsString("\tat org.junit.rules.RuleChainTest$RuleChainWithNullRules.<init>(RuleChainTest.java:"));
-    }
-
-    // TODO delete as soon as #1312 is merged
-    private static String stacktraceToString(Throwable e) {
-        StringWriter sw = new StringWriter();
-        PrintWriter pw = new PrintWriter(sw);
-        e.printStackTrace(pw);
-        return sw.toString();
     }
 }

--- a/src/test/java/org/junit/rules/RuleChainTest.java
+++ b/src/test/java/org/junit/rules/RuleChainTest.java
@@ -72,7 +72,7 @@ public class RuleChainTest {
             chain.around(null);
             fail("around() should not allow null rules");
         } catch (NullPointerException e) {
-            assertThat(e.getMessage(), equalTo("The enclosed rule should not be null"));
+            assertThat(e.getMessage(), equalTo("The enclosed rule must not be null"));
         }
     }
 

--- a/src/test/java/org/junit/rules/RuleChainTest.java
+++ b/src/test/java/org/junit/rules/RuleChainTest.java
@@ -1,17 +1,25 @@
 package org.junit.rules;
 
 import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.rules.RuleChain.outerRule;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
 
 public class RuleChainTest {
     private static final List<String> LOG = new ArrayList<String>();
@@ -54,5 +62,42 @@ public class RuleChainTest {
                 "finished inner rule", "finished middle rule",
                 "finished outer rule");
         assertEquals(expectedLog, LOG);
+    }
+
+    @Test
+    public void aroundShouldNotAllowNullRules() {
+        RuleChain chain = RuleChain.emptyRuleChain();
+        try {
+            chain.around(null);
+            fail("around() should not allow null rules");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    public static class RuleChainWithNullRules {
+        @Rule
+        public final RuleChain chain = outerRule(new LoggingRule("outer rule"))
+                .around(null);
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void whenRuleChainHasNullRuleTheStacktraceShouldPointToIt() {
+        Result result = JUnitCore.runClasses(RuleChainWithNullRules.class);
+
+        assertThat(result.getFailures().size(), equalTo(1));
+        String stacktrace = stacktraceToString(result.getFailures().get(0).getException());
+        assertThat(stacktrace, containsString("\tat org.junit.rules.RuleChainTest$RuleChainWithNullRules.<init>(RuleChainTest.java:"));
+    }
+
+    // TODO delete as soon as #1312 is merged
+    private static String stacktraceToString(Throwable e) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        e.printStackTrace(pw);
+        return sw.toString();
     }
 }

--- a/src/test/java/org/junit/rules/RuleChainTest.java
+++ b/src/test/java/org/junit/rules/RuleChainTest.java
@@ -70,8 +70,8 @@ public class RuleChainTest {
         try {
             chain.around(null);
             fail("around() should not allow null rules");
-        } catch (IllegalArgumentException e) {
-            // expected
+        } catch (NullPointerException e) {
+            assertThat(e.getMessage(), equalTo("The enclosed rule should not be null"));
         }
     }
 


### PR DESCRIPTION
By throwing IllegalArgEx from around(),
we allow for better feedback to the final user,
as the stacktrace will point to the exact line where the null rule is declared.

Previously the stacktrace would have been something like this:

```
java.lang.NullPointerException
	at org.junit.rules.RunRules.applyAll(RunRules.java:26)
	at org.junit.rules.RunRules.<init>(RunRules.java:15)
	at org.junit.rules.RuleChain.apply(RuleChain.java:96)
	at org.junit.rules.RunRules.applyAll(RunRules.java:26)
	at org.junit.rules.RunRules.<init>(RunRules.java:15)
	at org.junit.runners.BlockJUnit4ClassRunner.withTestRules(BlockJUnit4ClassRunner.java:424)
	at org.junit.runners.BlockJUnit4ClassRunner.withRules(BlockJUnit4ClassRunner.java:378)
	at org.junit.runners.BlockJUnit4ClassRunner.methodBlock(BlockJUnit4ClassRunner.java:299)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:83)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:58)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
```

As you can see, it was pretty hard to figure out that the null pointer was one of the rules in the chain.

Whereas with this change it is:

```
java.lang.IllegalArgumentException: The enclosed rule should not be null

	at org.junit.rules.RuleChain.around(RuleChain.java:84)
	at org.junit.rules.RuleChainTest$RuleChainWithNullRules.<init>(RuleChainTest.java:81)  <-----
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:228)
	at org.junit.runners.BlockJUnit4ClassRunner.createTest(BlockJUnit4ClassRunner.java:238)
```

where `at org.junit.rules.RuleChainTest$RuleChainWithNullRules.<init>(RuleChainTest.java:81)` points at the line where the null rule is appended.

Follows the sample test class used above:

    public class RuleChainWithNullRules {
        @Rule
        public final RuleChain chain = outerRule(new LoggingRule("outer rule"))
                .around(null);

        @Test
        public void example() {}
    }
