### PR TITLE
fix #1295

### DIFF
--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -13,12 +13,12 @@ import org.junit.runners.model.Statement;
  * {@link #around(TestRule)}:
  *
  * <pre>
- * public static class UseRuleChain {
+ * public class UseRuleChain {
  * 	&#064;Rule
  * 	public RuleChain chain= RuleChain
- * 	                       .outerRule(new LoggingRule("outer rule")
- * 	                       .around(new LoggingRule("middle rule")
- * 	                       .around(new LoggingRule("inner rule");
+ * 	                       .outerRule(new LoggingRule("outer rule"))
+ * 	                       .around(new LoggingRule("middle rule"))
+ * 	                       .around(new LoggingRule("inner rule"));
  *
  * 	&#064;Test
  * 	public void example() {
@@ -37,6 +37,22 @@ import org.junit.runners.model.Statement;
  * finished middle rule
  * finished outer rule
  * </pre>
+ * 
+ * {@code RuleChain} cannot be used to define the order of existing rules.</br>
+ * For example in the below snippet the LoggingRule <i>middle</i> would be executed 
+ * outside as well as inside the {@code RuleChain}:
+ * <pre>
+ * &#064;Rule
+ * public LoggingRule middle = new LoggingRule("middle rule");
+ * 
+ * &#064;Rule
+ * public RuleChain chain = RuleChain
+ *                          .outerRule(new LoggingRule("outer rule"))
+ *                          .around(middle)
+ *                          .around(new LoggingRule("inner rule"));
+ * </pre>
+ * <p>
+ * 
  *
  * @since 4.10
  */

--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -38,7 +38,7 @@ import org.junit.runners.model.Statement;
  * finished outer rule
  * </pre>
  * 
- * {@code RuleChain} cannot be used to define the order of existing rules.</br>
+ * {@code RuleChain} cannot be used to define the order of existing rules.
  * For example in the below snippet the LoggingRule <i>middle</i> would be executed 
  * outside as well as inside the {@code RuleChain}:
  * <pre>

--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -106,3 +106,4 @@ public class RuleChain implements TestRule {
         return new RunRules(base, rulesStartingWithInnerMost, description);
     }
 }
+

--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -51,8 +51,6 @@ import org.junit.runners.model.Statement;
  *                          .around(middle)
  *                          .around(new LoggingRule("inner rule"));
  * </pre>
- * <p>
- * 
  *
  * @since 4.10
  */


### PR DESCRIPTION
Removed error from `RuleChain` Javadoc and clarified how it works with existing rules:

- Removed `static` modifier
- Added missing closing parenthesis of method calls
- Added clarification

