### PR TITLE
Fix ExternalResource: the test failure was lost..

### DIFF
--- a/src/main/java/org/junit/rules/ExternalResource.java
+++ b/src/main/java/org/junit/rules/ExternalResource.java
@@ -1,7 +1,6 @@
 package org.junit.rules;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.runner.Description;

--- a/src/main/java/org/junit/rules/ExternalResource.java
+++ b/src/main/java/org/junit/rules/ExternalResource.java
@@ -1,6 +1,11 @@
 package org.junit.rules;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.junit.runner.Description;
+import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 /**
@@ -44,11 +49,20 @@ public abstract class ExternalResource implements TestRule {
             @Override
             public void evaluate() throws Throwable {
                 before();
+
+                List<Throwable> errors = new ArrayList<Throwable>();
                 try {
                     base.evaluate();
+                } catch(Throwable t) {
+                    errors.add(t);
                 } finally {
-                    after();
+                    try {
+                        after();
+                    } catch(Throwable t) {
+                        errors.add(t);
+                    }
                 }
+                MultipleFailureException.assertEmpty(errors);
             }
         };
     }

--- a/src/test/java/org/junit/rules/ExternalResourceRuleTest.java
+++ b/src/test/java/org/junit/rules/ExternalResourceRuleTest.java
@@ -1,12 +1,19 @@
 package org.junit.rules;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.internal.runners.statements.Fail;
+import org.junit.runner.Description;
+import org.junit.runners.model.MultipleFailureException;
+import org.junit.runners.model.Statement;
 
 public class ExternalResourceRuleTest {
     private static String callSequence;
@@ -40,5 +47,29 @@ public class ExternalResourceRuleTest {
         callSequence = "";
         assertThat(testResult(UsesExternalResource.class), isSuccessful());
         assertEquals("before test after ", callSequence);
+    }
+
+    @Test
+    public void shouldThrowMultipleFailureExceptionWhenTestFailsAndClosingResourceFails() throws Throwable {
+        // given
+        ExternalResource resourceRule = new ExternalResource() {
+            @Override
+            protected void after() {
+                throw new RuntimeException("simulating resource tear down failure");
+            }
+        };
+        Statement failingTest = new Fail(new RuntimeException("simulated test failure"));
+        Description dummyDescription = Description.createTestDescription(
+                "dummy test class name", "dummy test name");
+
+        try {
+            resourceRule.apply(failingTest, dummyDescription).evaluate();
+            fail("ExternalResource should throw");
+        } catch (MultipleFailureException e) {
+            assertThat(e.getMessage(), allOf(
+                    containsString("simulated test failure"),
+                    containsString("simulating resource tear down failure")
+            ));
+        }
     }
 }


### PR DESCRIPTION
.. when the test failed *and* closing the resource failed:
only the exception coming from the after() method was propagated, as per semantics of the try-finally
(see http://docs.oracle.com/javase/specs/jls/se8/html/jls-14.html#jls-14.20.2).

Finally, the new behavior is compatible with `@After` method semantics (see class RunAfters).

Fixes #1334, point 1.