### PR TITLE
Add TestFixture

### DIFF
--- a/src/main/java/junit/framework/TestCase.java
+++ b/src/main/java/junit/framework/TestCase.java
@@ -6,6 +6,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.fixtures.ClassWrapper;
 import org.junit.fixtures.FixtureManager;
 import org.junit.fixtures.InstanceMethod;
 import org.junit.fixtures.TearDown;
@@ -143,7 +144,8 @@ public abstract class TestCase extends Assert implements Test {
     private FixtureManager getOrCreateFixtureManager() {
         if (fixtureManager == null) {
             Method testMethod = getTestMethod(); // Can throw AssertionFailedError
-            fixtureManager = FixtureManager.forTestMethod(new InstanceMethod(testMethod, this));
+            fixtureManager = FixtureManager.forTestMethod(
+                    new InstanceMethod(new ClassWrapper(getClass()), testMethod, this));
         }
         return fixtureManager;
     }

--- a/src/main/java/org/junit/fixtures/AbstractTestFixture.java
+++ b/src/main/java/org/junit/fixtures/AbstractTestFixture.java
@@ -1,0 +1,50 @@
+package org.junit.fixtures;
+
+/**
+ * Base class for simple test fixtures.
+ */
+public abstract class AbstractTestFixture implements TestFixture {
+
+    public final void initialize(FixtureContext context) throws Exception {
+        beforeTest();
+        context.addTearDown(new TearDown() {
+            public void tearDown() throws Exception {
+                afterTest();
+            }
+        });
+        context.addTestPostcondition(new TestPostcondition() {
+            public void verify() throws Exception {
+                AbstractTestFixture.this.verify();
+            }
+        });
+    }
+ 
+    /**
+     * Override to set up your test fixture before the test starts.
+     *
+     * @throws Exception if setup fails (which will disable {@link #afterTest()})
+     */
+    protected void beforeTest() throws Exception {
+    }
+ 
+    /**
+     * Verifies any postconditions on the test fixture. Only called if the test
+     * passes, and if no previous postcondition fails (which means it is not
+     * called if {@link #beforeTest()} throws an exception).
+     *
+     * @throws Exception if verification fails (which will cause the test method to fail)
+     */
+    protected void verify() throws Exception {
+    }
+    
+    /**
+     * Override to tear down your test fixture after the test run completes.
+     * This will be called whether the test passes or fails, but will not
+     * be called unless {@link #beforeTest()} is called and doesn't throw
+     * an exception.
+     *
+     * @throws Exception if setup fails (which will cause the test method to fail)
+     */
+    protected void afterTest() throws Exception {
+    }
+}

--- a/src/main/java/org/junit/fixtures/ClassFixture.java
+++ b/src/main/java/org/junit/fixtures/ClassFixture.java
@@ -1,0 +1,76 @@
+package org.junit.fixtures;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates static fields that reference test fixtures or methods that return them. A field must be public,
+ * static and implement {@link org.junit.rules.TestFixture}. A method must be public static, and return
+ * a subtype of {@link org.junit.rules.TestRule}. Fields and methods of this type are called Class Fixtures.
+ *
+ * <p>Class fixtures will be initialized before all the test methods in a the class or fixture
+ * where the fixture is installed, , and will have their teardowns and postconditions called after
+ * all the test method.s The fixture initiation occurs before any {@link org.junit.BeforeClass}
+ * methods are called, and the postconditions and teardowns are called after all 
+ * {@link org.junit.AfterClass} methods.
+ * 
+ * If there are multiple members annotated with {@link TestFixture} in a class, they will be
+ * applied in an order that depends on your JVM's implementation of the reflection API, which is
+ * undefined, in general. However, fixtures defined by fields will always be applied before fixtures
+ * defined by methods.
+ *
+ * <p> For example, here is a test suite that connects to a server once before
+ * all the test classes run, and disconnects after they are finished:
+ * <pre>
+ * &#064;RunWith(Suite.class)
+ * &#064;SuiteClasses({A.class, B.class, C.class})
+ * public class UsesServer {
+ *     public static final Server myServer = new Server();
+ *
+ *     &#064;ClassFixture
+ *     public static AbstractTestFixture runServer = new AbstractTestFixture() {
+ *       &#064;Override
+ *       protected void beforeTest() throws Exception {
+ *          myServer.connect();
+ *      }
+ *
+ *      &#064;Override
+ *      protected void afterTest() throws Exception {
+ *          myServer.disconnect();
+ *      }
+ *   };
+ * }
+ * </pre>
+ * <p>
+ * and the same using a method
+ * <pre>
+ * &#064;RunWith(Suite.class)
+ * &#064;SuiteClasses({A.class, B.class, C.class})
+ * public class UsesServer {
+ *     public static final Server myServer = new Server();
+ *
+ *     &#064;ClassFixture
+ *     public static TestFixture runServer() {
+ *         return new AbstractTestFixture() {
+ *             &#064;Override
+ *             protected void beforeTest() throws Exception {
+ *                 myServer.connect();
+ *             }
+ *
+ *             &#064;Override
+ *             protected void afterTest() throws Exception {
+ *                 myServer.disconnect();
+ *             }
+ *         };
+ *     }
+ * }
+ * </pre>
+ *
+ * @since 4.13
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface ClassFixture {
+}

--- a/src/main/java/org/junit/fixtures/ClassFixture.java
+++ b/src/main/java/org/junit/fixtures/ClassFixture.java
@@ -7,7 +7,7 @@ import java.lang.annotation.Target;
 
 /**
  * Annotates static fields that reference test fixtures or methods that return them. A field must be public,
- * static and implement {@link org.junit.rules.TestFixture}. A method must be public static, and return
+ * static and implement {@link org.junit.fixtures.TestFixture}. A method must be public static, and return
  * a subtype of {@link org.junit.rules.TestRule}. Fields and methods of this type are called Class Fixtures.
  *
  * <p>Class fixtures will be initialized before all the test methods in a the class or fixture

--- a/src/main/java/org/junit/fixtures/ClassWrapper.java
+++ b/src/main/java/org/junit/fixtures/ClassWrapper.java
@@ -4,44 +4,28 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class InstanceMethod {
+public class ClassWrapper {
     private final ReentrantLock lock = new ReentrantLock();
-    private final ClassWrapper javaClass;
-    private final Method method;
-    private final Object object;
+    private final Class<?> wrappedClass;
     private volatile List<Annotation> annotations;
 
-    public InstanceMethod(ClassWrapper javaClass, Method method, Object object) {
-        this.javaClass = javaClass;
-        this.method = method;
-        this.object = object;
-    }
-
-    public Object getObject() {
-        return object;
+    public ClassWrapper(Class<?> classToWrap) {
+        wrappedClass = classToWrap;
     }
 
     /**
-     * Gets the underlying Java method.
+     * Returns the underlying Java class.
      */
-    public Method getMethod() {
-        return method;
+    public Class<?> getJavaClass() {
+        return wrappedClass;
     }
 
     /**
-     * Gets a {@link ClassWrapper} for the class of the underlying Java method.
-     */
-    public ClassWrapper getJavaClass() {
-        return javaClass;
-    }
-
-    /**
-     * Gets the annotations on the underlying Java method.
+     * Gets the annotations on the underlying Java class.
      */
     public List<Annotation> getAnnotations() {
         if (annotations == null) {
@@ -50,7 +34,7 @@ public class InstanceMethod {
                 if (annotations == null) {
                     annotations = unmodifiableList(
                             new ArrayList<Annotation>(
-                                    asList(method.getAnnotations())));
+                                    asList(wrappedClass.getAnnotations())));
                 }
             } finally { 
                 lock.unlock();

--- a/src/main/java/org/junit/fixtures/ClassWrapper.java
+++ b/src/main/java/org/junit/fixtures/ClassWrapper.java
@@ -1,6 +1,7 @@
 package org.junit.fixtures;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
 import java.lang.annotation.Annotation;
@@ -14,7 +15,12 @@ public class ClassWrapper {
     private volatile List<Annotation> annotations;
 
     public ClassWrapper(Class<?> classToWrap) {
-        wrappedClass = classToWrap;
+        wrappedClass = checkNotNull(classToWrap);
+    }
+
+    public ClassWrapper(Class<?> classToWrap, List<Annotation> classAnnotations) {
+        wrappedClass = checkNotNull(classToWrap);
+        annotations = makeImmutable(checkNotNull(classAnnotations));
     }
 
     /**
@@ -32,14 +38,27 @@ public class ClassWrapper {
             lock.lock();
             try {
                 if (annotations == null) {
-                    annotations = unmodifiableList(
-                            new ArrayList<Annotation>(
-                                    asList(wrappedClass.getAnnotations())));
+                    if (wrappedClass == null) {
+                        annotations = emptyList();
+                    } else {
+                        annotations = makeImmutable(asList(wrappedClass.getAnnotations()));
+                    }
                 }
             } finally { 
                 lock.unlock();
             }
         }
         return annotations;
+    }
+
+    private static <T> List<T> makeImmutable(List<T> list) {
+        return unmodifiableList(new ArrayList<T>(list));
+    }
+
+    private static <T> T checkNotNull(T t) {
+        if (t == null) {
+            throw new NullPointerException();
+        }
+        return t;
     }
 }

--- a/src/main/java/org/junit/fixtures/Fixture.java
+++ b/src/main/java/org/junit/fixtures/Fixture.java
@@ -1,0 +1,58 @@
+package org.junit.fixtures;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * AnnotaWtes fields that reference test fixtures or methods that return a test fixture. A field must be
+ * public, non-static and a subtype of {@link TestFixture}. A method must be public and must return a subtype
+ * of {@link TestFixture}. Fields and methods of this type are called Method Fixtures.
+ * 
+ * <p>Method fixtures will be initialized before each test method in the class, and will
+ * have their teardowns and postconditions called after each test method. The fixture
+ * initiation occurs before any {@link org.junit.Before} methods are called, and the
+ * postconditions and teardowns are called after all {@link org.junit.After} methods.
+ * 
+ * <p>For example, here is a test class that creates a temporary directory before
+ * each test method, and deletes it after each:
+ * <pre>
+ * public static class HasTempDirectory {
+ *     &#064;Fixture
+ *     public final TemporaryDirectory tmpDir = new TemporaryDirectory();
+ *
+ *     &#064;Test
+ *     public void testUsingTempFolder() throws IOException {
+ *         File createdFile = tmpDir.newFile(&quot;myfile.txt&quot;);
+ *         File createdDir = tmpDir.newDirectory(&quot;subDir&quot;);
+ *         // ...
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * And the same using a method.
+ * <pre>
+ * public static class HasTempDirectory {
+ *     private final TemporaryDirectory tmpDir = new TemporaryDirectory();
+ *
+ *     &#064;Fixture
+ *     public TemporaryFolder createTmpDitr() {
+ *         return tmpDir;
+ *     }
+ *
+ *     &#064;Test
+ *     public void testUsingTempDirectory() throws IOException {
+ *         File createdFile = tmpDir.newFile(&quot;myfile.txt&quot;);
+ *         File createdDir = tmpDir.newDirectory(&quot;subDir&quot;);
+ *         // ...
+ *     }
+ * }
+ * </pre>
+ *
+ * @since 4.13
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface Fixture  {
+}

--- a/src/main/java/org/junit/fixtures/FixtureContext.java
+++ b/src/main/java/org/junit/fixtures/FixtureContext.java
@@ -26,5 +26,5 @@ public abstract class FixtureContext {
     /**
      * Gets the class that this fixture is modifying.
      */
-    public abstract Class<?> getTestClass();
+    public abstract ClassWrapper getTestClass();
 }

--- a/src/main/java/org/junit/fixtures/FixtureContext.java
+++ b/src/main/java/org/junit/fixtures/FixtureContext.java
@@ -1,0 +1,19 @@
+package org.junit.fixtures;
+
+/**
+ * Provides methods to register {@link TearDown} and {@link TestPostcondition} instances.
+ */
+public abstract class FixtureContext {
+
+    /**
+     * Adds a {@link TearDown} to run after the test completes.
+     */
+    abstract public void addTearDown(TearDown tearDown);
+ 
+    /**
+     * Adds a {@link TestPostcondition} to run after a successful test run. The 
+     * post-condition will run before any {@link TearDown} instances, but
+     * may not run at all if an easier post-condidtion fails.
+     */
+    public abstract void addTestPostcondition(TestPostcondition postcondition);
+}

--- a/src/main/java/org/junit/fixtures/FixtureContext.java
+++ b/src/main/java/org/junit/fixtures/FixtureContext.java
@@ -16,4 +16,15 @@ public abstract class FixtureContext {
      * may not run at all if an easier post-condidtion fails.
      */
     public abstract void addTestPostcondition(TestPostcondition postcondition);
+
+    /**
+     * Gets the method that this fixture is modifying, or {@code null} if this
+     * fixture is a class fixture.
+     */
+    public abstract InstanceMethod getInstanceMethod();
+
+    /**
+     * Gets the class that this fixture is modifying.
+     */
+    public abstract Class<?> getTestClass();
 }

--- a/src/main/java/org/junit/fixtures/FixtureManager.java
+++ b/src/main/java/org/junit/fixtures/FixtureManager.java
@@ -32,7 +32,7 @@ public class FixtureManager  {
      * @throws Exception exception thrown during {@code TestFixture#initialize(FixtureContext)}
      */
     public final void initializeFixture(TestFixture testFixture) throws Exception {
-        state.checkCanInitializeFixture();
+        state.checkCanModifyFixture();
         FixtureContextFacade context = new FixtureContextFacade();
         try {
             context.initialize(testFixture);
@@ -50,12 +50,12 @@ public class FixtureManager  {
     /**
      * Resets this fixture to its initial state.
      */
-    public void reset() {
+    public final void reset() {
         state = State.HEALTHY;
         tearDowns.clear();
         testPostconditions.clear();
     }
- 
+
     /**
      * Adds a {@link TearDown} to run after the test completes.
      */
@@ -63,10 +63,10 @@ public class FixtureManager  {
         if (tearDown == null) {
             throw new NullPointerException();
         }
-        state.checkCanInitializeFixture();
+        state.checkCanModifyFixture();
         tearDowns.add(tearDown);
     } 
-
+ 
     /**
      * Handle a suppressed exceptions that occurred while running  tear downs.
      * Subclasses can override this to do additional work (for example, in JDK 7
@@ -110,8 +110,12 @@ public class FixtureManager  {
         }
     }
 
-
-    private FixtureManager(InstanceMethod testMethod, Class<?> testClass) {
+    /**
+     * Constructs an instance.
+     *
+     * @param testMethod test method, or {@code null} if this is a class fixture.
+     */
+    protected FixtureManager(InstanceMethod testMethod, Class<?> testClass) {
         this.testMethod = testMethod;
         this.testClass = testClass;
     }
@@ -163,7 +167,7 @@ public class FixtureManager  {
     private enum State {
         HEALTHY {
             @Override
-            void checkCanInitializeFixture() {
+            void checkCanModifyFixture() {
             }
 
             @Override
@@ -177,7 +181,7 @@ public class FixtureManager  {
             }
         }, READY_FOR_TEARDOWN {
             @Override
-            void checkCanInitializeFixture() {
+            void checkCanModifyFixture() {
                 throw new IllegalStateException();
             }
 
@@ -192,7 +196,7 @@ public class FixtureManager  {
             }
         }, RUNNING_TEAR_DOWNS {
             @Override
-            void checkCanInitializeFixture() {
+            void checkCanModifyFixture() {
                 throw new IllegalStateException();
             }
 
@@ -207,7 +211,7 @@ public class FixtureManager  {
             }
         }, COMPLETED {
             @Override
-            void checkCanInitializeFixture() {
+            void checkCanModifyFixture() {
                 throw new IllegalStateException();
             }
 
@@ -222,7 +226,7 @@ public class FixtureManager  {
             }
         };
 
-        abstract void checkCanInitializeFixture();
+        abstract void checkCanModifyFixture();
         abstract State startRunPostConditions();
         abstract State startRunTearDowns();
     }

--- a/src/main/java/org/junit/fixtures/FixtureManager.java
+++ b/src/main/java/org/junit/fixtures/FixtureManager.java
@@ -1,0 +1,194 @@
+package org.junit.fixtures;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Stack;
+
+import org.junit.internal.Throwables;
+
+/**
+ * Manages the interaction of a {@link TestFixture}
+ */
+public class FixtureManager  {
+    private final Stack<TearDown> tearDowns = new Stack<TearDown>();
+    private final List<TestPostcondition> testPostconditions = new ArrayList<TestPostcondition>();
+    private State state = State.HEALTHY;
+
+    /**
+     * Initializes a fixture, registering any tear downs or postconditions registered by
+     * the fixture initialization. If {@link TestFixture#initialize(FixtureContext)} throws
+     * an exception, then all registered tear downs will be executed.
+     *
+     * @throws Exception exception thrown during {@code TestFixture#initialize(FixtureContext)}
+     */
+    public final void initializeFixture(TestFixture testFixture) throws Exception {
+        state.checkCanInitializeFixture();
+        FixtureContextFacade context = new FixtureContextFacade();
+        try {
+            context.initialize(testFixture);
+        } catch (Throwable e) {
+            List<Throwable> suppressedErrors = new ArrayList<Throwable>();
+            runAllTearDowns(suppressedErrors);
+            
+            for (Throwable suppressedError : suppressedErrors) {
+                handleSuppressedError(e, suppressedError);
+            }
+            Throwables.rethrowAsException(e);
+        }
+    }
+ 
+    /**
+     * Adds a {@link TearDown} to run after the test completes.
+     */
+    public final void addTearDown(TearDown tearDown) {
+        if (tearDown == null) {
+            throw new NullPointerException();
+        }
+        state.checkCanInitializeFixture();
+        tearDowns.add(tearDown);
+    } 
+
+    /**
+     * Handle a suppressed exceptions that occurred while running  tear downs.
+     * Subclasses can override this to do additional work (for example, in JDK 7
+     * or higher, you could register the exceptions as suppressed exceptions).
+     *
+     * @param originalException exception that triggered the tear downs
+     * @param suppressedErrors suppressed errors encountered during tear-down.
+     */
+    protected void handleSuppressedError(Throwable originalException, Throwable suppressedError) {
+    }
+
+    /**
+     * Runs all of the {@link TearDown} instances managed by this class.
+     * 
+     * @param errors filled in with a list of all errors encountered while running the tear downs.
+     */
+    public final void runAllTearDowns(List<Throwable> errors) {
+        state = state.startRunTearDowns();
+
+        while (!tearDowns.isEmpty()) {
+            try {
+                tearDowns.pop().tearDown();
+            } catch (Throwable e) {
+                errors.add(e);
+            }
+        }
+        state = State.COMPLETED;
+    }
+ 
+    /**
+     * Removes and runs all of the {@link TearDown} instances managed by this class.
+     * 
+     * @param errors filled in with a list of all errors encountered while running the tear downs.
+     * @throws Throwable exception thrown from first failing postcondition
+     */
+    public final void runAllPostconditions() throws Throwable {
+        state = state.startRunPostConditions();
+
+        for (TestPostcondition postcondition : testPostconditions) {
+            postcondition.verify();
+        }
+    }
+
+    private class FixtureContextFacade extends FixtureContext {
+        private boolean initialized = false;
+        
+        public void initialize(TestFixture testFixture) throws Throwable {
+            if (initialized) {
+                throw new IllegalStateException("Already initialized");
+            }
+            try {
+                testFixture.initialize(this);
+            } finally {
+                initialized = true;
+            }
+        }
+
+        @Override
+        public void addTearDown(TearDown tearDown) {
+            checkUnitialized();
+            tearDowns.add(tearDown);
+        }
+
+        @Override
+        public void addTestPostcondition(TestPostcondition postcondition) {
+            checkUnitialized();
+            testPostconditions.add(postcondition);
+        }
+
+        private void checkUnitialized() {
+            if (!initialized) {
+                throw new IllegalStateException(
+                        "Cannot modify context after initialize()");
+            }
+        }
+    }
+     
+    private enum State {
+        HEALTHY {
+            @Override
+            void checkCanInitializeFixture() {
+            }
+
+            @Override
+            State startRunPostConditions() {
+                return READY_FOR_TEARDOWN;
+            }
+
+            @Override
+            State startRunTearDowns() {
+                return RUNNING_TEAR_DOWNS;
+            }
+        }, READY_FOR_TEARDOWN {
+            @Override
+            void checkCanInitializeFixture() {
+                throw new IllegalStateException();
+            }
+
+            @Override
+            State startRunPostConditions() {
+                throw new IllegalStateException();
+            }
+
+            @Override
+            State startRunTearDowns() {
+                return RUNNING_TEAR_DOWNS;
+            }
+        }, RUNNING_TEAR_DOWNS {
+            @Override
+            void checkCanInitializeFixture() {
+                throw new IllegalStateException();
+            }
+
+            @Override
+            State startRunPostConditions() {
+                throw new IllegalStateException();
+            }
+
+            @Override
+            State startRunTearDowns() {
+                throw new IllegalStateException();
+            }
+        }, COMPLETED {
+            @Override
+            void checkCanInitializeFixture() {
+                throw new IllegalStateException();
+            }
+
+            @Override
+            State startRunPostConditions() {
+               throw new IllegalStateException();
+            }
+
+            @Override
+            State startRunTearDowns() {
+                throw new IllegalStateException();
+            }
+        };
+
+        abstract void checkCanInitializeFixture();
+        abstract State startRunPostConditions();
+        abstract State startRunTearDowns();
+    }   
+}

--- a/src/main/java/org/junit/fixtures/InstanceMethod.java
+++ b/src/main/java/org/junit/fixtures/InstanceMethod.java
@@ -1,0 +1,20 @@
+package org.junit.fixtures;
+
+import java.lang.reflect.Method;
+
+public class InstanceMethod {
+    private final Method method;
+    private final Object object;
+    
+    public InstanceMethod(Method method, Object object) {
+        this.method = method;
+        this.object = object;
+    }
+    public Object getObject() {
+        return object;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+}

--- a/src/main/java/org/junit/fixtures/InstanceMethod.java
+++ b/src/main/java/org/junit/fixtures/InstanceMethod.java
@@ -17,9 +17,17 @@ public class InstanceMethod {
     private volatile List<Annotation> annotations;
 
     public InstanceMethod(ClassWrapper javaClass, Method method, Object object) {
-        this.javaClass = javaClass;
-        this.method = method;
-        this.object = object;
+        this.javaClass = checkNotNull(javaClass);
+        this.method = checkNotNull(method);
+        this.object = checkNotNull(object);
+    }
+
+    public InstanceMethod(
+            ClassWrapper javaClass, Method method, Object object, List<Annotation> methodAnnotations) {
+        this.javaClass = checkNotNull(javaClass);
+        this.method = checkNotNull(method);
+        this.object = checkNotNull(object);
+        this.annotations = makeImmutable(checkNotNull(methodAnnotations));
     }
 
     public Object getObject() {
@@ -48,14 +56,23 @@ public class InstanceMethod {
             lock.lock();
             try {
                 if (annotations == null) {
-                    annotations = unmodifiableList(
-                            new ArrayList<Annotation>(
-                                    asList(method.getAnnotations())));
+                    annotations = makeImmutable(asList(method.getAnnotations()));
                 }
             } finally { 
                 lock.unlock();
             }
         }
         return annotations;
+    }
+
+    private static <T> List<T> makeImmutable(List<T> list) {
+        return unmodifiableList(new ArrayList<T>(list));
+    }
+
+    private static <T> T checkNotNull(T t) {
+        if (t == null) {
+            throw new NullPointerException();
+        }
+        return t;
     }
 }

--- a/src/main/java/org/junit/fixtures/SimpleTestFixture.java
+++ b/src/main/java/org/junit/fixtures/SimpleTestFixture.java
@@ -3,7 +3,7 @@ package org.junit.fixtures;
 /**
  * Base class for simple test fixtures.
  */
-public abstract class AbstractTestFixture implements TestFixture {
+public abstract class SimpleTestFixture implements TestFixture {
 
     public final void initialize(FixtureContext context) throws Exception {
         beforeTest();
@@ -14,7 +14,7 @@ public abstract class AbstractTestFixture implements TestFixture {
         });
         context.addTestPostcondition(new TestPostcondition() {
             public void verify() throws Exception {
-                AbstractTestFixture.this.verify();
+                SimpleTestFixture.this.verify();
             }
         });
     }

--- a/src/main/java/org/junit/fixtures/TearDown.java
+++ b/src/main/java/org/junit/fixtures/TearDown.java
@@ -1,6 +1,15 @@
 package org.junit.fixtures;
 
+/**
+ * Indicates objects that that can perform tear-down activities.
+ */
 public interface TearDown {
 
+    /**
+     * Performs a tear-down operation. If this method throws
+     * an exception, then the containing test will fail.
+     *
+     * @throws Exception if the tear down fails
+     */
     void tearDown() throws Exception;
 }

--- a/src/main/java/org/junit/fixtures/TearDown.java
+++ b/src/main/java/org/junit/fixtures/TearDown.java
@@ -1,0 +1,6 @@
+package org.junit.fixtures;
+
+public interface TearDown {
+
+    void tearDown() throws Exception;
+}

--- a/src/main/java/org/junit/fixtures/TemporaryDirectory.java
+++ b/src/main/java/org/junit/fixtures/TemporaryDirectory.java
@@ -1,0 +1,275 @@
+package org.junit.fixtures;
+
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Allows creation of files and directories that should be deleted when the test method
+ * finishes (whether it passes or fails).
+ * By default no exception will be thrown in case the deletion fails.
+ *
+ * <p>Example of usage:
+ * <pre>
+ * public static class HasTempDirectory {
+ *  &#064;Rule
+ *  public TemporaryDirectory tmpDir = new TemporaryDirectory();
+ *
+ *  &#064;Test
+ *  public void testUsingTempDirectory() throws IOException {
+ *      File createdFile = tmpDir.newFile(&quot;myfile.txt&quot;);
+ *      File createdDirectory = tmpDir.newDirectory(&quot;subdirectory&quot;);
+ *      // ...
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>The TemporaryDirectory fixture supports assured deletion mode, which
+ * will fail the test in case deletion fails with {@link AssertionError}.
+ *
+ * <p>Creating TemporaryDirectory with assured deletion:
+ * <pre>
+ *  &#064;Rule
+ *  public TemporaryDirectory tmpDir = TemporaryDirectory.builder().assureDeletion().build();
+ * </pre>
+ *
+ * @since 4.13
+ */
+public class TemporaryDirectory implements TestFixture {
+    private final File parentDirectory;
+    private final boolean assureDeletion;
+    private File directory;
+
+    /**
+     * Create a temporary directory which uses system default temporary-file 
+     * directory to create temporary resources.
+     */
+    public TemporaryDirectory() {
+        this.parentDirectory = null;
+        this.assureDeletion = false;
+    }
+
+    /**
+     * Create a temporary directory which uses the specified directory to create
+     * temporary resources.
+     *
+     * @param parentDirectory directory where temporary resources will be created.
+     */
+    public TemporaryDirectory(File parentDirectory) {
+        if (parentDirectory == null) {
+            throw new NullPointerException("parentDirectory cannot be null");
+        }
+        this.parentDirectory = parentDirectory;
+        this.assureDeletion = false;
+    }
+
+    /**
+     * Create a {@link TemporaryDirectory} initialized with
+     * values from a builder.
+     */
+    protected TemporaryDirectory(Builder builder) {
+        this.parentDirectory = builder.parentDirectory;
+        this.assureDeletion = builder.assureDeletion;
+    }
+
+    /**
+     * Returns a new builder for building an instance of {@link TemporaryDirectory}.
+     *
+     * @since 4.13
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds an instance of {@link TemporaryDirectory}.
+     * 
+     * @since 4.13
+     */
+    public static class Builder {
+        private File parentDirectory;
+        private boolean assureDeletion;
+
+        protected Builder() {}
+
+        /**
+         * Specifies which directory to use for creating temporary resources.
+         * If this is not called then system default temporary-file directory is
+         * used.
+         *
+         * @return this
+         */
+        public Builder parentDirectory(File parentDirectory) {
+            if (parentDirectory == null) {
+                throw new NullPointerException("parentDirectory cannot be null");
+            }
+            this.parentDirectory = parentDirectory;
+            return this;
+        }
+
+        /**
+         * Setting this flag assures that no resources are left undeleted. Failure
+         * to fulfill the assurance results in failure of tests with an
+         * {@link IllegalStateException}.
+         *
+         * @return this
+         */
+        public Builder assureDeletion() {
+            this.assureDeletion = true;
+            return this;
+        }
+
+        /**
+         * Builds a {@link TemporaryDirectory} instance using the values in this builder.
+         */
+        public TemporaryDirectory build() {
+            return new TemporaryDirectory(this);
+        }
+    }
+
+    public void initialize(FixtureContext context) throws Exception {
+        create();
+        context.addTearDown(new TearDown() {
+            public void tearDown() throws Exception {
+                delete();
+            }
+        });
+        
+    }
+
+    /**
+     * for testing purposes only. Do not use.
+     */
+    private void create() throws IOException {
+       directory = createTemporaryDirectoryIn(parentDirectory);
+    }
+
+
+    /**
+     * Returns a new fresh file with the given name under the temporary directory.
+     */
+    public File newFile(String fileName) throws IOException {
+        File file = new File(getRoot(), fileName);
+        if (!file.createNewFile()) {
+            throw new IOException(
+                    "a file with the name \'" + fileName + "\' already exists in the test directory");
+        }
+        return file;
+    }
+
+    /**
+     * Returns a new fresh file with a random name under the temporary directory.
+     */
+    public File newFile() throws IOException {
+        return File.createTempFile("junit", null, getRoot());
+    }
+
+    /**
+     * Returns a new fresh d with the given name(s) under the temporary
+     * directory.
+     */
+    public File newDirectory(String topDirectoryName, String... subDirectoryNames) throws IOException {
+        List<String> directoryNames = new ArrayList<String>(subDirectoryNames.length + 1);
+        directoryNames.add(topDirectoryName);
+        directoryNames.addAll(Arrays.asList(subDirectoryNames));
+        File file = getRoot();
+        for (int i = 0; i < directoryNames.size(); i++) {
+            String directoryName = directoryNames.get(i);
+            validateDirectoryName(directoryName);
+            file = new File(file, directoryName);
+            if (!file.mkdir() && isLastElementInList(i, directoryNames)) {
+                throw new IOException(
+                        "a directory with the name \'" + directoryName + "\' already exists");
+            }
+        }
+        return file;
+    }
+    
+    /**
+     * Validates if multiple path components were used while creating a directory.
+     * 
+     * @param directoryName
+     *            Name of the directory being created
+     */
+    private void validateDirectoryName(String directoryName) throws IOException {
+        File tempFile = new File(directoryName);
+        if (tempFile.getParent() != null) {
+            String errorMsg = "Directory name cannot consist of multiple path components separated by a file separator."
+                    + " Please use newDirectory('MyParentDir','MySubDir') to create hierarchies of directories";
+            throw new IOException(errorMsg);
+        }
+    }
+
+    private boolean isLastElementInList(int index, List<String> list) {
+        return index == list.size() - 1;
+    }
+
+    /**
+     * Returns a new fresh directory with a random name under the temporary directory.
+     */
+    public File newDirectory() throws IOException {
+        return createTemporaryDirectoryIn(getRoot());
+    }
+
+    private File createTemporaryDirectoryIn(File parentDirectory) throws IOException {
+        File createdDirectory = File.createTempFile("junit", "", parentDirectory);
+        createdDirectory.delete();
+        createdDirectory.mkdir();
+        return createdDirectory;
+    }
+
+    /**
+     * @return the location of this temporary directory.
+     */
+    public File getRoot() {
+        if (directory == null) {
+            throw new IllegalStateException(
+                    "the temporary directory has not yet been created");
+        }
+        return directory;
+    }
+
+    /**
+     * Delete all files and directories under the temporary directory.
+     *
+     * @throws IllegalStateException if unable to clean up resources
+     * and deletion of resources is assured.
+     */
+    private void delete() {
+        if (!tryDelete()) {
+            if (assureDeletion) {
+                fail("Unable to clean up temporary directory " + directory);
+            }
+        }
+    }
+
+    /**
+     * Tries to delete all files and directories under the temporary directory and
+     * returns whether deletion was successful or not.
+     *
+     * @return {@code true} if all resources are deleted successfully,
+     *         {@code false} otherwise.
+     */
+    protected boolean tryDelete() {
+        if (directory == null) {
+            return true;
+        }
+        
+        return recursiveDelete(directory);
+    }
+    
+    private boolean recursiveDelete(File file) {
+        boolean result = true;
+        File[] files = file.listFiles();
+        if (files != null) {
+            for (File each : files) {
+                result = result && recursiveDelete(each);
+            }
+        }
+        return result && file.delete();
+    }
+}

--- a/src/main/java/org/junit/fixtures/TestFixture.java
+++ b/src/main/java/org/junit/fixtures/TestFixture.java
@@ -7,14 +7,14 @@ import org.junit.rules.TestRule;
 /**
  * A test fixture adds behavior before and after a test method, or set of test methods.
  * It may perform necessary setup or cleanup for tests, or it may verify that some
- * condition holds true after a test (or set of tests) runs witout throwing an
+ * condition holds true after a test (or set of tests) runs without throwing an
  * exception.
  *
  * Test fixtures are a simpler replacement for {@link TestRule}, and can do everything
  * that could be done previously with methods annotated with {@link org.junit.Before},
  * {@link org.junit.After}, {@link org.junit.BeforeClass}, or {@link org.junit.AfterClass},
  * but they allow a single object to encapsulate these behaviors, and therefore are
- * reusable between classes and projects. They are also composeable.
+ * reusable between classes and projects. They are also composable.
  *
  * The default JUnit test runners for suites and individual test cases will install
  * {@code TestFixture} instances that are found via non-static methods and fields
@@ -31,12 +31,11 @@ import org.junit.rules.TestRule;
  * To see how test fixtures can be useful, see these provided fixturs.
  *
  * <ul>
- *   <li>{@link TemporaryDirectory}: create fresh files, and delete them after test runs</li>
+ *   <li>{@link TemporaryDirectory}: create fresh directories, and delete them after test runs</li>
  * </ul>
  *
  * @since 4.13
  */
-
 public interface TestFixture {
 
     /**

--- a/src/main/java/org/junit/fixtures/TestFixture.java
+++ b/src/main/java/org/junit/fixtures/TestFixture.java
@@ -26,7 +26,7 @@ import org.junit.rules.TestRule;
  *
  * Multiple test fixtures can be applied to a test or suite execution.
  *
- * To make writing test fixtures easier, you can use {@link AbstractTestFixture}.
+ * To make writing test fixtures easier, you can use {@link SimpleTestFixture}.
  *
  * To see how test fixtures can be useful, see these provided fixturs.
  *

--- a/src/main/java/org/junit/fixtures/TestFixture.java
+++ b/src/main/java/org/junit/fixtures/TestFixture.java
@@ -1,0 +1,46 @@
+package org.junit.fixtures;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+
+/**
+ * A test fixture adds behavior before and after a test method, or set of test methods.
+ * It may perform necessary setup or cleanup for tests, or it may verify that some
+ * condition holds true after a test (or set of tests) runs witout throwing an
+ * exception.
+ *
+ * Test fixtures are a simpler replacement for {@link TestRule}, and can do everything
+ * that could be done previously with methods annotated with {@link org.junit.Before},
+ * {@link org.junit.After}, {@link org.junit.BeforeClass}, or {@link org.junit.AfterClass},
+ * but they allow a single object to encapsulate these behaviors, and therefore are
+ * reusable between classes and projects. They are also composeable.
+ *
+ * The default JUnit test runners for suites and individual test cases will install
+ * {@code TestFixture} instances that are found via non-static methods and fields
+ * annotated with {@link org.junit.Rule} (in which case setup and tear-down is on a
+ * per-method level) as well as static methods and fields (in which case they work on a
+ * per-class or per-suite level). In all cases, the fields or methods should return
+ * an instance of {@link TestFixture}. See Javadoc for {@link Rule} and {@link ClassRule}
+ * for more information.
+ *
+ * Multiple test fixtures can be applied to a test or suite execution.
+ *
+ * To make writing test fixtures easier, you can use {@link AbstractTestFixture}.
+ *
+ * To see how test fixtures can be useful, see these provided fixturs.
+ *
+ * <ul>
+ *   <li>{@link TemporaryDirectory}: create fresh files, and delete them after test runs</li>
+ * </ul>
+ *
+ * @since 4.13
+ */
+
+public interface TestFixture {
+
+    /**
+     * Initializes the test fixture.
+     */
+    void initialize(FixtureContext context) throws Exception;
+}

--- a/src/main/java/org/junit/fixtures/TestPostcondition.java
+++ b/src/main/java/org/junit/fixtures/TestPostcondition.java
@@ -1,6 +1,15 @@
 package org.junit.fixtures;
 
+/**
+ * An assertion that is run after the test successfully completes.
+ */
 public interface TestPostcondition {
 
+    /**
+     * Runs assertions that should be run after the test successfully completes,
+     * but before the test status has been reported. If an assertion fails, this
+     * method can indicate it by throwing an exception (generally a subclass of
+     * {@link AssertionError} is used, but that is not required).
+     */
     void verify() throws Exception;
 }

--- a/src/main/java/org/junit/fixtures/TestPostcondition.java
+++ b/src/main/java/org/junit/fixtures/TestPostcondition.java
@@ -1,0 +1,6 @@
+package org.junit.fixtures;
+
+public interface TestPostcondition {
+
+    void verify() throws Exception;
+}

--- a/src/main/java/org/junit/internal/runners/rules/AnnotatedMemberValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/AnnotatedMemberValidator.java
@@ -1,0 +1,146 @@
+package org.junit.internal.runners.rules;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.runners.model.FrameworkMember;
+import org.junit.runners.model.TestClass;
+
+/**
+ * Base class for classe that validate fields and methods that are annotated with annotations
+ */
+abstract class AnnotatedMemberValidator {
+    private final Class<? extends Annotation> annotation;
+    private final boolean forMethods;
+    private final List<MemberValidator> validators;
+
+    AnnotatedMemberValidator(Builder<?> builder) {
+        if (builder.annotation == null) {
+            throw new IllegalStateException("Must call withAnnotation() before build()");
+        }
+        annotation = builder.annotation;
+        forMethods = builder.forMethods;
+        validators = new ArrayList<MemberValidator>(
+                builder.validators.size() + (builder.isClassAnnotation ? 3 : 2));
+        this.validators.add(MemberMustBePublic.INSTANCE);
+        this.validators.add(DeclaringClassMustBePublic.INSTANCE);
+        if (builder.isClassAnnotation) {
+            this.validators.add(MemberMustBeStatic.INSTANCE);
+        }
+        validators.addAll(builder.validators);
+    }
+
+    /**
+     * Validate the {@link org.junit.runners.model.TestClass} and adds reasons
+     * for rejecting the class to a list of errors.
+     *
+     * @param target the {@code TestClass} to validate.
+     * @param errors the list of errors.
+     */
+    public final void validate(TestClass target, List<Throwable> errors) {
+        List<? extends FrameworkMember<?>> members = forMethods ? target.getAnnotatedMethods(annotation)
+                : target.getAnnotatedFields(annotation);
+
+        for (FrameworkMember<?> each : members) {
+            validateMember(each, errors);
+        }
+    }
+
+    private void validateMember(FrameworkMember<?> member, List<Throwable> errors) {
+        for (MemberValidator strategy : validators) {
+            strategy.validate(member, annotation, errors);
+        }
+    }
+
+    protected static class Builder<B extends Builder<B>> {
+        private Class<? extends Annotation> annotation;
+        private boolean forMethods = false;
+        private boolean isClassAnnotation = false;
+        private final List<MemberValidator> validators = new ArrayList<MemberValidator>();
+
+        protected Builder() {
+        }
+        
+        B forClassAnnotation(Class<? extends Annotation> annotation) {
+            this.annotation = checkNotNull(annotation);
+            this.isClassAnnotation = true;
+            return selfRef();
+        }
+
+        B forTestAnnotation(Class<? extends Annotation> annotation) {
+            this.annotation = checkNotNull(annotation);
+            this.isClassAnnotation = false;
+            return selfRef();
+        }
+
+        B forMethods() {
+            forMethods = true;
+            return selfRef();
+        }
+
+        B withValidator(MemberValidator validator) {
+            validators.add(checkNotNull(validator));
+            return selfRef();
+        }
+
+        @SuppressWarnings("unchecked")
+        private B selfRef() {
+            return (B) this;
+        }
+
+        private <T> T checkNotNull(T t) {
+            if (t == null) {
+                throw new NullPointerException();
+            }
+            return t;
+        }
+    }
+
+    /**
+     * Requires the member's declaring class to be public
+     */
+    private static final class DeclaringClassMustBePublic implements MemberValidator {
+        public static final DeclaringClassMustBePublic INSTANCE = new DeclaringClassMustBePublic();
+
+        public void validate(FrameworkMember<?> member, Class<? extends Annotation> annotation, List<Throwable> errors) {
+            if (!isDeclaringClassPublic(member)) {
+                errors.add(new ValidationError(member, annotation,
+                        "must be declared in a public class."));
+            }
+        }
+
+        private boolean isDeclaringClassPublic(FrameworkMember<?> member) {
+            return Modifier.isPublic(member.getDeclaringClass().getModifiers());
+        }
+    }
+
+    /**
+     * Requires the member to be static
+     */
+    private static final class MemberMustBeStatic implements MemberValidator {
+        public static final MemberMustBeStatic INSTANCE = new MemberMustBeStatic();
+
+        public void validate(FrameworkMember<?> member, Class<? extends Annotation> annotation, List<Throwable> errors) {
+            if (!member.isStatic()) {
+                errors.add(new ValidationError(member, annotation,
+                        "must be static."));
+            }
+        }
+    }
+ 
+    /**
+     * Requires the member to be public
+     */
+    private static final class MemberMustBePublic implements MemberValidator {
+        public static final MemberMustBePublic INSTANCE = new MemberMustBePublic();
+
+        public void validate(FrameworkMember<?> member, Class<? extends Annotation> annotation, List<Throwable> errors) {
+            if (!member.isPublic()) {
+                errors.add(new ValidationError(member, annotation,
+                        "must be public."));
+            }
+        }
+    }
+}

--- a/src/main/java/org/junit/internal/runners/rules/AnnotatedMemberValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/AnnotatedMemberValidator.java
@@ -90,7 +90,7 @@ abstract class AnnotatedMemberValidator {
             return (B) this;
         }
 
-        private <T> T checkNotNull(T t) {
+        private static <T> T checkNotNull(T t) {
             if (t == null) {
                 throw new NullPointerException();
             }

--- a/src/main/java/org/junit/internal/runners/rules/FixtureMemberValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/FixtureMemberValidator.java
@@ -1,0 +1,100 @@
+package org.junit.internal.runners.rules;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import org.junit.fixtures.ClassFixture;
+import org.junit.fixtures.Fixture;
+import org.junit.fixtures.TestFixture;
+import org.junit.runners.model.FrameworkMember;
+
+/**
+ * Validates the fixture fields/methods of a {@link org.junit.runners.model.TestClass}.
+ * All reasons for rejecting the {@code TestClass} are written to a list of errors.
+ *
+ * <p>There are two slightly different validators. The {@link #FIXTURE_FIELD_VALIDATOR}
+ * validates fields with a {@link Fixture} annotation and the
+ * {@link #FIXTURE_METHDO_VALIDATOR} validates methods with a {@link Fixture} annotation.</p>
+ */
+public class FixtureMemberValidator extends AnnotatedMemberValidator {
+    /**
+     * Validates fields with a {@link ClassFixture} annotation.
+     */
+    public static final FixtureMemberValidator CLASS_FIXTURE_FIELD_VALIDATOR = classMemberValidatorBuilder()
+            .withValidator(new FieldMustBeAFixture())
+            .build();
+
+    /**
+     * Validates fields with a {@link Fixture} annotation.
+     */
+    public static final FixtureMemberValidator FIXTURE_FIELD_VALIDATOR = testMemberValidatorBuilder()
+            .withValidator(new FieldMustBeAFixture())
+            .build();
+  
+    /**
+     * Validates methods with a {@link ClassFixture} annotation.
+     */
+    public static final FixtureMemberValidator CLASS_FIXTURE_METHOD_VALIDATOR = classMemberValidatorBuilder()
+            .forMethods()
+            .withValidator(new MethodMustBeAFixture())
+            .build();
+
+    /**
+     * Validates methods with a {@link Fixture} annotation.
+     */
+    public static final FixtureMemberValidator FIXTURE_METHOD_VALIDATOR = classMemberValidatorBuilder()
+            .forMethods()
+            .withValidator(new MethodMustBeAFixture())
+            .build();
+
+
+    FixtureMemberValidator(Builder builder) {
+        super(builder);
+    }
+
+    private static class Builder extends AnnotatedMemberValidator.Builder<Builder> {
+
+        FixtureMemberValidator build() {
+            return new FixtureMemberValidator(this);
+        }
+    }
+    
+    private static Builder classMemberValidatorBuilder() {
+        return new Builder().forClassAnnotation(ClassFixture.class);
+    }
+
+    private static Builder testMemberValidatorBuilder() {
+        return new Builder().forTestAnnotation(Fixture.class);
+    }
+
+    private static boolean isTestFixture(FrameworkMember<?> member) {
+        return TestFixture.class.isAssignableFrom(member.getType());
+    }
+
+    /**
+     * Require the member to return an implementation of {@link org.junit.rules.TestFixture}
+     */
+    private static final class MethodMustBeAFixture implements MemberValidator {
+        public void validate(FrameworkMember<?> member,
+                Class<? extends Annotation> annotation, List<Throwable> errors) {
+            if (!isTestFixture(member)) {
+                errors.add(new ValidationError(member, annotation, 
+                        "must return an implementation of TestFixture."));
+            }
+        }
+    }
+    
+    /**
+     * Requires the member is a field implementing {@link org.junit.rules.TestFixture}
+     */
+    private static final class FieldMustBeAFixture implements MemberValidator {
+
+        public void validate(FrameworkMember<?> member,
+                Class<? extends Annotation> annotation, List<Throwable> errors) {
+            if (!isTestFixture(member)) {
+                errors.add(new ValidationError(member, annotation,
+                        "must implement TestFixture."));
+            }
+        }
+    }
+}

--- a/src/main/java/org/junit/internal/runners/rules/FixtureMemberValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/FixtureMemberValidator.java
@@ -3,6 +3,8 @@ package org.junit.internal.runners.rules;
 import java.lang.annotation.Annotation;
 import java.util.List;
 
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.fixtures.ClassFixture;
 import org.junit.fixtures.Fixture;
 import org.junit.fixtures.TestFixture;
@@ -12,9 +14,14 @@ import org.junit.runners.model.FrameworkMember;
  * Validates the fixture fields/methods of a {@link org.junit.runners.model.TestClass}.
  * All reasons for rejecting the {@code TestClass} are written to a list of errors.
  *
- * <p>There are two slightly different validators. The {@link #FIXTURE_FIELD_VALIDATOR}
- * validates fields with a {@link Fixture} annotation and the
- * {@link #FIXTURE_METHDO_VALIDATOR} validates methods with a {@link Fixture} annotation.</p>
+ * <p>There are four slightly different validators. The {@link #CLASS_FIXTURE_FIELD_VALIDATOR}
+ * validates fields with a {@link ClassFixture} annotation and the
+ * {@link #FIXTURE_FIELD_VALIDATOR} validates fields with a {@link Fixture} annotation.</p>
+ *
+ * <p>The {@link #CLASS_FIXTURE_METHOD_VALIDATOR}
+ * validates methods with a {@link ClassFixture} annotation and the
+ * {@link #FIXTURE_METHOD_VALIDATOR} validates methods with a {@link Fixture} annotation.</p>
+ 
  */
 public class FixtureMemberValidator extends AnnotatedMemberValidator {
     /**

--- a/src/main/java/org/junit/internal/runners/rules/FixtureMemberValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/FixtureMemberValidator.java
@@ -28,6 +28,7 @@ public class FixtureMemberValidator extends AnnotatedMemberValidator {
      * Validates fields with a {@link Fixture} annotation.
      */
     public static final FixtureMemberValidator FIXTURE_FIELD_VALIDATOR = testMemberValidatorBuilder()
+            .withValidator(new MemberMustBeNonStaticOrAlsoClassFixture())
             .withValidator(new FieldMustBeAFixture())
             .build();
   
@@ -44,6 +45,7 @@ public class FixtureMemberValidator extends AnnotatedMemberValidator {
      */
     public static final FixtureMemberValidator FIXTURE_METHOD_VALIDATOR = classMemberValidatorBuilder()
             .forMethods()
+            .withValidator(new MemberMustBeNonStaticOrAlsoClassFixture())
             .withValidator(new MethodMustBeAFixture())
             .build();
 
@@ -94,6 +96,20 @@ public class FixtureMemberValidator extends AnnotatedMemberValidator {
             if (!isTestFixture(member)) {
                 errors.add(new ValidationError(member, annotation,
                         "must implement TestFixture."));
+            }
+        }
+    }
+
+    /**
+     * Requires the validated member to be non-static, unless they are annotated with {@code @ClassFixture}.
+     */
+    private static final class MemberMustBeNonStaticOrAlsoClassFixture implements MemberValidator {
+        public void validate(FrameworkMember<?> member, Class<? extends Annotation> annotation, List<Throwable> errors) {
+            boolean isClassFixtureAnnotated = (member.getAnnotation(ClassFixture.class) != null);
+
+            if (member.isStatic() && !isClassFixtureAnnotated) {
+                String message = "must not be static or it must be annotated with @ClassFixture.";
+                errors.add(new ValidationError(member, annotation, message));
             }
         }
     }

--- a/src/main/java/org/junit/internal/runners/rules/MemberValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/MemberValidator.java
@@ -1,0 +1,21 @@
+package org.junit.internal.runners.rules;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+import org.junit.runners.model.FrameworkMember;
+
+/**
+ * Encapsulates a single piece of validation logic for a field or method.
+ *
+ * <p>See also {@link MemberValidators}.
+ */
+interface MemberValidator {
+    /**
+     * Examine the given member and add any violations of the strategy's validation logic to the given list of errors
+     * @param member The member (field or member) to examine
+     * @param annotation The type of rule annotation on the member
+     * @param errors The list of errors to add validation violations to
+     */
+    void validate(FrameworkMember<?> member, Class<? extends Annotation> annotation, List<Throwable> errors);
+}

--- a/src/main/java/org/junit/internal/runners/rules/MemberValidator.java
+++ b/src/main/java/org/junit/internal/runners/rules/MemberValidator.java
@@ -8,7 +8,7 @@ import org.junit.runners.model.FrameworkMember;
 /**
  * Encapsulates a single piece of validation logic for a field or method.
  *
- * <p>See also {@link MemberValidators}.
+ * <p>See also {@link AnnotatedMemberValidator}.
  */
 interface MemberValidator {
     /**

--- a/src/main/java/org/junit/internal/runners/rules/RunFixture.java
+++ b/src/main/java/org/junit/internal/runners/rules/RunFixture.java
@@ -1,0 +1,51 @@
+package org.junit.internal.runners.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.fixtures.FixtureManager;
+import org.junit.fixtures.TestFixture;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.MultipleFailureException;
+import org.junit.runners.model.Statement;
+
+/**
+ * Adapter that allows a {@link TestFixture} to be used as a rule.
+ */
+public class RunFixture implements TestRule {
+    private final TestFixture testFixture;
+
+    public RunFixture(TestFixture testFixture) {
+        this.testFixture = testFixture;
+    }
+
+    public Statement apply(Statement base, Description description) {
+        return new FixtureInstallingStatement(base);
+    }
+ 
+    private class FixtureInstallingStatement extends Statement  {
+        private final Statement baseStatement;
+
+        public FixtureInstallingStatement(Statement baseStatement) {
+            this.baseStatement = baseStatement;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            FixtureManager fixtureManager = new FixtureManager();
+            fixtureManager.initializeFixture(testFixture);
+
+            List<Throwable> errors = new ArrayList<Throwable>();
+            try {
+                baseStatement.evaluate();
+                fixtureManager.runAllPostconditions();
+            } catch (Throwable e) {
+                errors.add(e);
+            } finally {
+                fixtureManager.runAllTearDowns(errors);
+            }
+            MultipleFailureException.assertEmpty(errors);
+        }
+    }
+}

--- a/src/main/java/org/junit/internal/runners/rules/RunFixture.java
+++ b/src/main/java/org/junit/internal/runners/rules/RunFixture.java
@@ -4,36 +4,49 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.fixtures.FixtureManager;
+import org.junit.fixtures.InstanceMethod;
 import org.junit.fixtures.TestFixture;
+import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
+import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 /**
  * Adapter that allows a {@link TestFixture} to be used as a rule.
  */
-public class RunFixture implements TestRule {
+public class RunFixture implements TestRule, MethodRule {
     private final TestFixture testFixture;
 
     public RunFixture(TestFixture testFixture) {
         this.testFixture = testFixture;
     }
 
+    public Statement apply(Statement base, FrameworkMethod method, Object target) {
+        return new FixtureInstallingStatement(base, method, target);
+    }
+
     public Statement apply(Statement base, Description description) {
-        return new FixtureInstallingStatement(base);
+        return new FixtureInstallingStatement(base, description.getTestClass());
     }
  
     private class FixtureInstallingStatement extends Statement  {
         private final Statement baseStatement;
+        private final FixtureManager fixtureManager;
 
-        public FixtureInstallingStatement(Statement baseStatement) {
+        public FixtureInstallingStatement(Statement baseStatement, Class<?> testClass) {
             this.baseStatement = baseStatement;
+            fixtureManager = FixtureManager.forTestClass(testClass);
+        }
+
+        public FixtureInstallingStatement(Statement baseStatement, FrameworkMethod method, Object target) {
+            this.baseStatement = baseStatement;
+            fixtureManager = FixtureManager.forTestMethod(new InstanceMethod(method.getMethod(), target));
         }
 
         @Override
         public void evaluate() throws Throwable {
-            FixtureManager fixtureManager = new FixtureManager();
             fixtureManager.initializeFixture(testFixture);
 
             List<Throwable> errors = new ArrayList<Throwable>();

--- a/src/main/java/org/junit/internal/runners/rules/RunFixtures.java
+++ b/src/main/java/org/junit/internal/runners/rules/RunFixtures.java
@@ -14,13 +14,13 @@ import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 /**
- * Adapter that allows a {@link TestFixture} to be used as a rule.
+ * Adapter that allows {@link TestFixture} instances to be run a rule.
  */
-public class RunFixture implements TestRule, MethodRule {
-    private final TestFixture testFixture;
+public class RunFixtures implements TestRule, MethodRule {
+    private final List<TestFixture> testFixtures;
 
-    public RunFixture(TestFixture testFixture) {
-        this.testFixture = testFixture;
+    public RunFixtures(List<TestFixture> testFixtures) {
+        this.testFixtures = new ArrayList<TestFixture>(testFixtures);
     }
 
     public Statement apply(Statement base, FrameworkMethod method, Object target) {
@@ -47,7 +47,9 @@ public class RunFixture implements TestRule, MethodRule {
 
         @Override
         public void evaluate() throws Throwable {
-            fixtureManager.initializeFixture(testFixture);
+            for (TestFixture testFixture : testFixtures) {
+                fixtureManager.initializeFixture(testFixture);
+            }
 
             List<Throwable> errors = new ArrayList<Throwable>();
             try {

--- a/src/main/java/org/junit/internal/runners/rules/RunFixtures.java
+++ b/src/main/java/org/junit/internal/runners/rules/RunFixtures.java
@@ -3,6 +3,7 @@ package org.junit.internal.runners.rules;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.fixtures.ClassWrapper;
 import org.junit.fixtures.FixtureManager;
 import org.junit.fixtures.InstanceMethod;
 import org.junit.fixtures.TestFixture;
@@ -18,8 +19,10 @@ import org.junit.runners.model.Statement;
  */
 public class RunFixtures implements TestRule, MethodRule {
     private final List<TestFixture> testFixtures;
+    private final ClassWrapper testClass;
 
-    public RunFixtures(List<TestFixture> testFixtures) {
+    public RunFixtures(List<TestFixture> testFixtures, ClassWrapper testClass) {
+        this.testClass = testClass;
         this.testFixtures = new ArrayList<TestFixture>(testFixtures);
     }
 
@@ -28,21 +31,22 @@ public class RunFixtures implements TestRule, MethodRule {
     }
 
     public Statement apply(Statement base, Description description) {
-        return new FixtureInstallingStatement(base, description.getTestClass());
+        return new FixtureInstallingStatement(base);
     }
  
     private class FixtureInstallingStatement extends Statement  {
         private final Statement baseStatement;
         private final FixtureManager fixtureManager;
 
-        public FixtureInstallingStatement(Statement baseStatement, Class<?> testClass) {
+        public FixtureInstallingStatement(Statement baseStatement) {
             this.baseStatement = baseStatement;
             fixtureManager = FixtureManager.forTestClass(testClass);
         }
 
         public FixtureInstallingStatement(Statement baseStatement, FrameworkMethod method, Object target) {
             this.baseStatement = baseStatement;
-            fixtureManager = FixtureManager.forTestMethod(new InstanceMethod(method.getMethod(), target));
+            fixtureManager = FixtureManager.forTestMethod(
+                    new InstanceMethod(testClass, method.getMethod(), target));
         }
 
         @Override

--- a/src/main/java/org/junit/rules/ExternalResource.java
+++ b/src/main/java/org/junit/rules/ExternalResource.java
@@ -56,7 +56,7 @@ public abstract class ExternalResource implements TestRule {
     /**
      * Override to set up your specific external resource.
      *
-     * @throws Throwable if setup fails (which will disable {@code after}
+     * @throws Throwable if setup fails (which will disable {@code after})
      */
     protected void before() throws Throwable {
         // do nothing

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -16,6 +16,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.Test.None;
+import org.junit.fixtures.ClassWrapper;
 import org.junit.fixtures.Fixture;
 import org.junit.fixtures.TestFixture;
 import org.junit.internal.runners.model.ReflectiveCallable;
@@ -419,7 +420,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
                 target, Fixture.class, TestFixture.class);
         fixtures.addAll(testClass.getAnnotatedFieldValues(
                 target, Fixture.class, TestFixture.class));
-        rules.add(new RunFixtures(fixtures));
+        rules.add(new RunFixtures(fixtures, new ClassWrapper(testClass.getJavaClass())));
         
         return rules;
     }

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -1,5 +1,6 @@
 package org.junit.runners;
 
+import static java.util.Arrays.asList;
 import static org.junit.internal.runners.rules.FixtureMemberValidator.FIXTURE_FIELD_VALIDATOR;
 import static org.junit.internal.runners.rules.FixtureMemberValidator.FIXTURE_METHOD_VALIDATOR;
 import static org.junit.internal.runners.rules.RuleMemberValidator.RULE_METHOD_VALIDATOR;
@@ -420,7 +421,11 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
                 target, Fixture.class, TestFixture.class);
         fixtures.addAll(testClass.getAnnotatedFieldValues(
                 target, Fixture.class, TestFixture.class));
-        rules.add(new RunFixtures(fixtures, new ClassWrapper(testClass.getJavaClass())));
+        if (!fixtures.isEmpty()) {
+            ClassWrapper classWrapper = new ClassWrapper(
+                    testClass.getJavaClass(), asList(testClass.getAnnotations()));
+            rules.add(new RunFixtures(fixtures, classWrapper));
+        }
         
         return rules;
     }

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -5,8 +5,6 @@ import static org.junit.internal.runners.rules.FixtureMemberValidator.FIXTURE_ME
 import static org.junit.internal.runners.rules.RuleMemberValidator.RULE_METHOD_VALIDATOR;
 import static org.junit.internal.runners.rules.RuleMemberValidator.RULE_VALIDATOR;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -21,7 +19,7 @@ import org.junit.Test.None;
 import org.junit.fixtures.Fixture;
 import org.junit.fixtures.TestFixture;
 import org.junit.internal.runners.model.ReflectiveCallable;
-import org.junit.internal.runners.rules.RunFixture;
+import org.junit.internal.runners.rules.RunFixtures;
 import org.junit.internal.runners.statements.ExpectException;
 import org.junit.internal.runners.statements.Fail;
 import org.junit.internal.runners.statements.FailOnTimeout;
@@ -414,15 +412,14 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         TestClass testClass = getTestClass();
         List<MethodRule> rules = testClass.getAnnotatedMethodValues(target, 
                 Rule.class, MethodRule.class);
-        List<TestFixture> fixtures = testClass.getAnnotatedMethodValues(
-                target, Fixture.class, TestFixture.class);
-        rules.addAll(toMethodRules(fixtures));
-
         rules.addAll(testClass.getAnnotatedFieldValues(target,
                 Rule.class, MethodRule.class));
-        fixtures = testClass.getAnnotatedFieldValues(
+
+        List<TestFixture> fixtures = testClass.getAnnotatedMethodValues(
                 target, Fixture.class, TestFixture.class);
-        rules.addAll(toMethodRules(fixtures));
+        fixtures.addAll(testClass.getAnnotatedFieldValues(
+                target, Fixture.class, TestFixture.class));
+        rules.add(new RunFixtures(fixtures));
         
         return rules;
     }
@@ -453,14 +450,6 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         result.addAll(testClass.getAnnotatedFieldValues(
                 target, Rule.class, TestRule.class));
         return result;
-    }
-
-    static Collection<MethodRule> toMethodRules(List<TestFixture> fixtures) {
-        List<MethodRule> rules = new ArrayList<MethodRule>(fixtures.size());
-        for (TestFixture fixture : fixtures) {
-            rules.add(new RunFixture(fixture));
-        }
-        return rules;
     }
 
     private Class<? extends Throwable> getExpectedException(Test annotation) {

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -5,6 +5,8 @@ import static org.junit.internal.runners.rules.FixtureMemberValidator.FIXTURE_ME
 import static org.junit.internal.runners.rules.RuleMemberValidator.RULE_METHOD_VALIDATOR;
 import static org.junit.internal.runners.rules.RuleMemberValidator.RULE_VALIDATOR;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -19,6 +21,7 @@ import org.junit.Test.None;
 import org.junit.fixtures.Fixture;
 import org.junit.fixtures.TestFixture;
 import org.junit.internal.runners.model.ReflectiveCallable;
+import org.junit.internal.runners.rules.RunFixture;
 import org.junit.internal.runners.statements.ExpectException;
 import org.junit.internal.runners.statements.Fail;
 import org.junit.internal.runners.statements.FailOnTimeout;
@@ -408,12 +411,19 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
      *         test
      */
     protected List<MethodRule> rules(Object target) {
-        List<MethodRule> rules = getTestClass().getAnnotatedMethodValues(target, 
+        TestClass testClass = getTestClass();
+        List<MethodRule> rules = testClass.getAnnotatedMethodValues(target, 
                 Rule.class, MethodRule.class);
+        List<TestFixture> fixtures = testClass.getAnnotatedMethodValues(
+                target, Fixture.class, TestFixture.class);
+        rules.addAll(toMethodRules(fixtures));
 
-        rules.addAll(getTestClass().getAnnotatedFieldValues(target,
+        rules.addAll(testClass.getAnnotatedFieldValues(target,
                 Rule.class, MethodRule.class));
-
+        fixtures = testClass.getAnnotatedFieldValues(
+                target, Fixture.class, TestFixture.class);
+        rules.addAll(toMethodRules(fixtures));
+        
         return rules;
     }
 
@@ -438,20 +448,19 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
      */
     protected List<TestRule> getTestRules(Object target) {
         TestClass testClass = getTestClass();
-
         List<TestRule> result = testClass.getAnnotatedMethodValues(
                 target, Rule.class, TestRule.class);
         result.addAll(testClass.getAnnotatedFieldValues(
                 target, Rule.class, TestRule.class));
-
-        List<TestFixture> fixtures = testClass.getAnnotatedMethodValues(
-                target, Fixture.class, TestFixture.class);
-        result.addAll(toTestRules(fixtures));
-        fixtures = testClass.getAnnotatedFieldValues(
-                target, Fixture.class, TestFixture.class);
-        result.addAll(toTestRules(fixtures));
-
         return result;
+    }
+
+    static Collection<MethodRule> toMethodRules(List<TestFixture> fixtures) {
+        List<MethodRule> rules = new ArrayList<MethodRule>(fixtures.size());
+        for (TestFixture fixture : fixtures) {
+            rules.add(new RunFixture(fixture));
+        }
+        return rules;
     }
 
     private Class<? extends Throwable> getExpectedException(Test annotation) {

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -21,6 +21,7 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.fixtures.ClassFixture;
+import org.junit.fixtures.ClassWrapper;
 import org.junit.fixtures.TestFixture;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.internal.runners.model.EachTestNotifier;
@@ -265,7 +266,7 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
         List<TestFixture> fixtures = clazz.getAnnotatedMethodValues(
                 null, ClassFixture.class, TestFixture.class);
         fixtures.addAll(clazz.getAnnotatedFieldValues(null, ClassFixture.class, TestFixture.class));
-        result.add(new RunFixtures(fixtures));
+        result.add(new RunFixtures(fixtures, new ClassWrapper(clazz.getJavaClass())));
         
         return result;
     }

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -270,7 +270,7 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
         return result;
     }
 
-    static Collection<TestRule> toTestRules(List<TestFixture> fixtures) {
+    private static Collection<TestRule> toTestRules(List<TestFixture> fixtures) {
         List<TestRule> rules = new ArrayList<TestRule>(fixtures.size());
         for (TestFixture fixture : fixtures) {
             rules.add(new RunFixture(fixture));

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -24,7 +24,7 @@ import org.junit.fixtures.ClassFixture;
 import org.junit.fixtures.TestFixture;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.internal.runners.model.EachTestNotifier;
-import org.junit.internal.runners.rules.RunFixture;
+import org.junit.internal.runners.rules.RunFixtures;
 import org.junit.internal.runners.statements.RunAfters;
 import org.junit.internal.runners.statements.RunBefores;
 import org.junit.rules.RunRules;
@@ -260,22 +260,14 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
     protected List<TestRule> classRules() {
         TestClass clazz = getTestClass();
         List<TestRule> result = clazz.getAnnotatedMethodValues(null, ClassRule.class, TestRule.class);
+        result.addAll(clazz.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class));
+        
         List<TestFixture> fixtures = clazz.getAnnotatedMethodValues(
                 null, ClassFixture.class, TestFixture.class);
-        result.addAll(toTestRules(fixtures));
+        fixtures.addAll(clazz.getAnnotatedFieldValues(null, ClassFixture.class, TestFixture.class));
+        result.add(new RunFixtures(fixtures));
         
-        result.addAll(clazz.getAnnotatedFieldValues(null, ClassRule.class, TestRule.class));
-        fixtures = clazz.getAnnotatedFieldValues(null, ClassFixture.class, TestFixture.class);
-        result.addAll(toTestRules(fixtures));
         return result;
-    }
-
-    private static Collection<TestRule> toTestRules(List<TestFixture> fixtures) {
-        List<TestRule> rules = new ArrayList<TestRule>(fixtures.size());
-        for (TestFixture fixture : fixtures) {
-            rules.add(new RunFixture(fixture));
-        }
-        return rules;
     }
 
     /**

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -1,5 +1,6 @@
 package org.junit.runners;
 
+import static java.util.Arrays.asList;
 import static org.junit.internal.runners.rules.FixtureMemberValidator.CLASS_FIXTURE_FIELD_VALIDATOR;
 import static org.junit.internal.runners.rules.FixtureMemberValidator.CLASS_FIXTURE_METHOD_VALIDATOR;
 import static org.junit.internal.runners.rules.RuleMemberValidator.CLASS_RULE_METHOD_VALIDATOR;
@@ -266,7 +267,11 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
         List<TestFixture> fixtures = clazz.getAnnotatedMethodValues(
                 null, ClassFixture.class, TestFixture.class);
         fixtures.addAll(clazz.getAnnotatedFieldValues(null, ClassFixture.class, TestFixture.class));
-        result.add(new RunFixtures(fixtures, new ClassWrapper(clazz.getJavaClass())));
+        if (!fixtures.isEmpty()) {
+            ClassWrapper classWrapper = new ClassWrapper(
+                    testClass.getJavaClass(), asList(testClass.getAnnotations()));
+            result.add(new RunFixtures(fixtures, classWrapper));
+        }
         
         return result;
     }

--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -60,6 +60,11 @@ public class TestClass implements Annotatable {
         this.fieldsForAnnotations = makeDeeplyUnmodifiable(fieldsForAnnotations);
     }
 
+    @Override
+    public String toString() {
+        return clazz.toString();
+    }
+
     protected void scanAnnotatedMembers(Map<Class<? extends Annotation>, List<FrameworkMethod>> methodsForAnnotations, Map<Class<? extends Annotation>, List<FrameworkField>> fieldsForAnnotations) {
         for (Class<?> eachClass : getSuperClasses(clazz)) {
             for (Method eachMethod : MethodSorter.getDeclaredMethods(eachClass)) {

--- a/src/test/java/org/junit/fixtures/TemporaryDirectoryTest.java
+++ b/src/test/java/org/junit/fixtures/TemporaryDirectoryTest.java
@@ -138,7 +138,7 @@ public class TemporaryDirectoryTest {
     @Test
     public void recursiveDeleteDirectoryWithOneElement() throws Throwable {
         TemporaryDirectory tmpDir = new TemporaryDirectory();
-        FixtureManager fixtureManager = new FixtureManager();
+        FixtureManager fixtureManager = FixtureManager.forTestClass(getClass());
         fixtureManager.initializeFixture(tmpDir);
         File file = tmpDir.newFile("a");
         runAllTearDowns(fixtureManager);
@@ -149,7 +149,7 @@ public class TemporaryDirectoryTest {
     @Test
     public void recursiveDeleteDirectoryWithOneRandomElement() throws Throwable {
         TemporaryDirectory tmpDir = new TemporaryDirectory();
-        FixtureManager fixtureManager = new FixtureManager();
+        FixtureManager fixtureManager = FixtureManager.forTestClass(getClass());
         fixtureManager.initializeFixture(tmpDir);
         File file = tmpDir.newFile();
         runAllTearDowns(fixtureManager);
@@ -160,7 +160,7 @@ public class TemporaryDirectoryTest {
     @Test
     public void recursiveDeleteDirectoryWithZeroElements() throws Throwable {
         TemporaryDirectory tmpDir = new TemporaryDirectory();
-        FixtureManager fixtureManager = new FixtureManager();
+        FixtureManager fixtureManager = FixtureManager.forTestClass(getClass());
         fixtureManager.initializeFixture(tmpDir);
         runAllTearDowns(fixtureManager);
         assertFalse(tmpDir.getRoot().exists());

--- a/src/test/java/org/junit/fixtures/TemporaryDirectoryTest.java
+++ b/src/test/java/org/junit/fixtures/TemporaryDirectoryTest.java
@@ -1,0 +1,236 @@
+package org.junit.fixtures;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.experimental.results.PrintableResult.testResult;
+import static org.junit.experimental.results.ResultMatchers.failureCountIs;
+import static org.junit.experimental.results.ResultMatchers.isSuccessful;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runners.model.MultipleFailureException;
+
+/**
+ * Tests for {@link TemporaryDirectory}.
+ */
+public class TemporaryDirectoryTest {
+    private static File[] createdFiles = new File[20];
+
+    public static class HasTempDirectory {
+        @Fixture
+        public TemporaryDirectory tmpDir = new TemporaryDirectory();
+
+        @Test
+        public void testUsingTempDirectory() throws IOException {
+            createdFiles[0] = tmpDir.newFile("myfile.txt");
+            assertTrue(createdFiles[0].exists());
+        }
+    }
+
+    @Test
+    public void tempDirectoryIsDeleted() {
+        assertThat(testResult(HasTempDirectory.class), isSuccessful());
+        assertFalse(createdFiles[0].exists());
+    }
+
+    public static class CreatesSubDirectory {
+        @Fixture
+        public TemporaryDirectory tmpDir = new TemporaryDirectory();
+
+        @Test
+        public void testUsingTempDirectoryString() throws IOException {
+            String subDir = "subdir";
+            String filename = "a.txt";
+            // ensure that a single String works
+            createdFiles[0] = tmpDir.newDirectory(subDir);
+            new File(createdFiles[0], filename).createNewFile();
+
+            File expectedFile = new File(tmpDir.getRoot(), join(subDir, filename));
+
+            assertTrue(expectedFile.exists());
+        }
+
+        @Test
+        public void testUsingTempTreeDirectories() throws IOException {
+            String subDir = "subDir";
+            String anotherDir = "anotherDir";
+            String filename = "a.txt";
+
+            createdFiles[0] = tmpDir.newDirectory(subDir, anotherDir);
+            new File(createdFiles[0], filename).createNewFile();
+
+            File expectedFile = new File(tmpDir.getRoot(), join(subDir, anotherDir, filename));
+
+            assertTrue(expectedFile.exists());
+        }
+
+        private String join(String... dirNames) {
+            StringBuilder path = new StringBuilder();
+            for (String dirName : dirNames) {
+                path.append(File.separator).append(dirName);
+            }
+            return path.toString();
+        }
+    }
+
+    @Test
+    public void subDirectoryIsDeleted() {
+        assertThat(testResult(CreatesSubDirectory.class), isSuccessful());
+        assertFalse(createdFiles[0].exists());
+    }
+
+    public static class CreatesRandomSubDirectories {
+        @Fixture
+        public TemporaryDirectory tmpDir = new TemporaryDirectory();
+
+        @Test
+        public void testUsingRandomTempDirectories() throws IOException {
+            for (int i = 0; i < 20; i++) {
+                File newDir = tmpDir.newDirectory();
+                assertThat(Arrays.asList(createdFiles), not(hasItem(newDir)));
+                createdFiles[i] = newDir;
+                new File(newDir, "a.txt").createNewFile();
+                assertTrue(newDir.exists());
+            }
+        }
+    }
+
+    @Test
+    public void randomSubDirectoriesAreDeleted() {
+        assertThat(testResult(CreatesRandomSubDirectories.class), isSuccessful());
+        for (File f : createdFiles) {
+            assertFalse(f.exists());
+        }
+    }
+
+    public static class CreatesRandomFiles {
+        @Fixture
+        public TemporaryDirectory tmpDir = new TemporaryDirectory();
+
+        @Test
+        public void testUsingRandomTempFiles() throws IOException {
+            for (int i = 0; i < 20; i++) {
+                File newFile = tmpDir.newFile();
+                assertThat(Arrays.asList(createdFiles), not(hasItem(newFile)));
+                createdFiles[i] = newFile;
+                assertTrue(newFile.exists());
+            }
+        }
+    }
+
+    @Test
+    public void randomFilesAreDeleted() {
+        assertThat(testResult(CreatesRandomFiles.class), isSuccessful());
+        for (File f : createdFiles) {
+            assertFalse(f.exists());
+        }
+    }
+
+    @Test
+    public void recursiveDeleteDirectoryWithOneElement() throws Throwable {
+        TemporaryDirectory tmpDir = new TemporaryDirectory();
+        FixtureManager fixtureManager = new FixtureManager();
+        fixtureManager.initializeFixture(tmpDir);
+        File file = tmpDir.newFile("a");
+        runAllTearDowns(fixtureManager);
+        assertFalse(file.exists());
+        assertFalse(tmpDir.getRoot().exists());
+    }
+
+    @Test
+    public void recursiveDeleteDirectoryWithOneRandomElement() throws Throwable {
+        TemporaryDirectory tmpDir = new TemporaryDirectory();
+        FixtureManager fixtureManager = new FixtureManager();
+        fixtureManager.initializeFixture(tmpDir);
+        File file = tmpDir.newFile();
+        runAllTearDowns(fixtureManager);
+        assertFalse(file.exists());
+        assertFalse(tmpDir.getRoot().exists());
+    }
+
+    @Test
+    public void recursiveDeleteDirectoryWithZeroElements() throws Throwable {
+        TemporaryDirectory tmpDir = new TemporaryDirectory();
+        FixtureManager fixtureManager = new FixtureManager();
+        fixtureManager.initializeFixture(tmpDir);
+        runAllTearDowns(fixtureManager);
+        assertFalse(tmpDir.getRoot().exists());
+    }
+
+    public static class NameClashes {
+        @Fixture
+        public TemporaryDirectory tmpDir = new TemporaryDirectory();
+
+        @Test
+        public void fileWithFileClash() throws IOException {
+            tmpDir.newFile("something.txt");
+            tmpDir.newFile("something.txt");
+        }
+
+        @Test
+        public void fileWithDirectoryTest() throws IOException {
+            tmpDir.newDirectory("dummy");
+            tmpDir.newFile("dummy");
+        }
+    }
+
+    @Test
+    public void nameClashesResultInTestFailures() {
+        assertThat(testResult(NameClashes.class), failureCountIs(2));
+    }
+
+    private static final String GET_ROOT_DUMMY = "dummy-getRoot";
+
+    private static final String NEW_FILE_DUMMY = "dummy-newFile";
+
+    private static final String NEW_DIR_DUMMY = "dummy-newDir";
+
+    public static class IncorrectUsage {
+        public TemporaryDirectory tmpDir = new TemporaryDirectory();
+
+        @Test
+        public void testGetRoot() throws IOException {
+            new File(tmpDir.getRoot(), GET_ROOT_DUMMY).createNewFile();
+        }
+
+        @Test
+        public void testNewFile() throws IOException {
+            tmpDir.newFile(NEW_FILE_DUMMY);
+        }
+
+        @Test
+        public void testNewDirectory() throws IOException {
+            tmpDir.newDirectory(NEW_DIR_DUMMY);
+        }
+    }
+
+    @Test
+    public void incorrectUsageWithoutApplyingTheRuleShouldNotPolluteTheCurrentWorkingDirectory() {
+        assertThat(testResult(IncorrectUsage.class), failureCountIs(3));
+        assertFalse("getRoot should have failed early", new File(GET_ROOT_DUMMY).exists());
+        assertFalse("newFile should have failed early", new File(NEW_FILE_DUMMY).exists());
+        assertFalse("newDirectory should have failed early", new File(NEW_DIR_DUMMY).exists());
+    }
+
+    @After
+    public void cleanCurrentWorkingDirectory() {
+        new File(GET_ROOT_DUMMY).delete();
+        new File(NEW_FILE_DUMMY).delete();
+        new File(NEW_DIR_DUMMY).delete();
+    }
+
+    private static void runAllTearDowns(FixtureManager fixtureManager) throws Exception {
+        List<Throwable> errors = new ArrayList<Throwable>();
+        fixtureManager.runAllTearDowns(errors);
+        MultipleFailureException.assertEmpty(errors);
+    }
+}

--- a/src/test/java/org/junit/fixtures/TemporaryDirectoryTest.java
+++ b/src/test/java/org/junit/fixtures/TemporaryDirectoryTest.java
@@ -23,6 +23,7 @@ import org.junit.runners.model.MultipleFailureException;
  * Tests for {@link TemporaryDirectory}.
  */
 public class TemporaryDirectoryTest {
+    private static final ClassWrapper CLASS_WRAPPER = new ClassWrapper(TemporaryDirectoryTest.class);
     private static File[] createdFiles = new File[20];
 
     public static class HasTempDirectory {
@@ -138,7 +139,7 @@ public class TemporaryDirectoryTest {
     @Test
     public void recursiveDeleteDirectoryWithOneElement() throws Throwable {
         TemporaryDirectory tmpDir = new TemporaryDirectory();
-        FixtureManager fixtureManager = FixtureManager.forTestClass(getClass());
+        FixtureManager fixtureManager = FixtureManager.forTestClass(CLASS_WRAPPER);
         fixtureManager.initializeFixture(tmpDir);
         File file = tmpDir.newFile("a");
         runAllTearDowns(fixtureManager);
@@ -149,7 +150,7 @@ public class TemporaryDirectoryTest {
     @Test
     public void recursiveDeleteDirectoryWithOneRandomElement() throws Throwable {
         TemporaryDirectory tmpDir = new TemporaryDirectory();
-        FixtureManager fixtureManager = FixtureManager.forTestClass(getClass());
+        FixtureManager fixtureManager = FixtureManager.forTestClass(CLASS_WRAPPER);
         fixtureManager.initializeFixture(tmpDir);
         File file = tmpDir.newFile();
         runAllTearDowns(fixtureManager);
@@ -160,7 +161,7 @@ public class TemporaryDirectoryTest {
     @Test
     public void recursiveDeleteDirectoryWithZeroElements() throws Throwable {
         TemporaryDirectory tmpDir = new TemporaryDirectory();
-        FixtureManager fixtureManager = FixtureManager.forTestClass(getClass());
+        FixtureManager fixtureManager = FixtureManager.forTestClass(CLASS_WRAPPER);
         fixtureManager.initializeFixture(tmpDir);
         runAllTearDowns(fixtureManager);
         assertFalse(tmpDir.getRoot().exists());


### PR DESCRIPTION
This is a prototype of test fixtures, an extension point designed to replaced rules. The core class is a new `TestFixture` interface that can be implemented in users' tests or put in a common location to be shared  by multiple tests.

The `TestFixture` API was designed so that it could be supported by JUnit Vintage tests as well as JUnit Jupiter tests. In the first commit I show integration with Vintage tests. In the second commit, as a proof of concept, I updated `TestCase` to support `TestFixture` (I figured if JUnit Legacy tests could support them, anything could).

Although designed as a possible replacement for rules, test fixtures are in some ways less powerful, but in other ways more powerful. A fixture can cause code to be executed 1) before a test (or suite), 2) after a test (or suite) and/or 3) between the successful completion of the test (or suite) and any tear down calls (`@After`,etc) have been called. Unlike rules, however, they cannot be used to cause a failing test to pass, or to run a test multiple times.

Test fixtures are also easy to compose. Here is an example of a test fixture using another one:

```
public class TestWithWebDriver implements TestFixture {
  private final ServerStarter server = new ServerStarter(); // another fixture
  private final WebDriver webDriver;

  public void initialize(FixtureContext context) throws Exception {
    server.initialize(context); // start the server
    webDriver = new FirefoxDriver();
    driver.get("http://localhost+" + server.getPort()); // open the home page
  }
}
```

Here's an example how one might might run two fixtures in order:

```
private final TestFixture firstFixture = ...
private final TestFixture secondFixture = ...

@Fixture
public final TestFixture initializeInOrder = new TestFixture() {

  public void initialize(FixtureContext context) throws Exception {
    firstFixture.initialize(context);
    secondFixture.initialize(context);
  }
}
```

See the `TemporaryDirectory` class for an example fixture.

As it happens, test fixtures are also easier to test than rules are. Note that `TemporaryDirectory` does not have any methods that were added only for testing purposes, but the tests in `TemporaryDirectoryTest` have the same coverage.

Note that this change is missing many tests, and would likely require some framework. I just wanted to send this as a concrete proposal for a simple but powerful extension point that can be supported by multiple styles of JUnit tests.
