### PR TITLE
Introduce class TestRuleAdapter

### DIFF
--- a/src/main/java/org/junit/rules/TestRuleAdapter.java
+++ b/src/main/java/org/junit/rules/TestRuleAdapter.java
@@ -1,0 +1,73 @@
+package org.junit.rules;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+import java.lang.reflect.Method;
+
+/**
+ * A TestRuleAdapter allows to wrap {@link MethodRule} classes in
+ * {@link TestRule} classes in order to use them inside {@link RuleChain}.
+ * Assuming we have an existing method rule:
+ *
+ * <pre>
+ * class MyMethodRule implements MethodRule {
+ *     public Statement apply(final Statement base, FrameworkMethod method,
+ *                            Object target) {
+ *         return new Statement() {
+ *             &#064;Override
+ *             public void evaluate() throws Throwable {
+ *                 base.evaluate();
+ *             }
+ *         };
+ *     }
+ * }
+ * </pre>
+ *
+ * It can then be used in a {@link RuleChain} like this:
+ * <pre>
+ *     &#064;Rule
+ *     public final RuleChain chain = RuleChain
+ *             .outerRule(new TestRuleAdapter(new MyMethodRule()))
+ *             .around(new TestRuleAdapter(new MyMethodRule()));
+ * </pre>
+ *
+ * @since 4.12
+ */
+public class TestRuleAdapter implements TestRule {
+    private final MethodRule rule;
+
+    public TestRuleAdapter(MethodRule rule) {
+        this.rule = rule;
+    }
+
+    public Statement apply(Statement base, Description description) {
+        return rule.apply(base, createFrameworkMethod(description), getTestObject(description));
+    }
+
+    private FrameworkMethod createFrameworkMethod(Description description) {
+        try {
+            String methodName = description.getMethodName();
+            Class<?> c = getTestClass(description);
+            Method m = c.getDeclaredMethod(methodName);
+            return new FrameworkMethod(m);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Class<?> getTestClass(Description description) {
+        return description.getTestClass();
+    }
+
+    private Object getTestObject(Description description) {
+        try {
+            return getTestClass(description).newInstance();
+        } catch (InstantiationException e) {
+            throw new IllegalStateException(e);
+        } catch (IllegalAccessException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/org/junit/rules/TestRuleAdapterTest.java
+++ b/src/test/java/org/junit/rules/TestRuleAdapterTest.java
@@ -1,0 +1,71 @@
+package org.junit.rules;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.experimental.results.PrintableResult.testResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+public class TestRuleAdapterTest {
+    private static final List<String> LOG = new ArrayList<String>();
+
+    class MyMethodRule implements MethodRule {
+        public Statement apply(final Statement base,
+                               FrameworkMethod method,
+                               Object target) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    base.evaluate();
+                }
+            };
+        }
+    }
+
+    private static class LoggingRule implements MethodRule {
+        private String label;
+
+        LoggingRule(String label) {
+            this.label = label;
+        }
+
+        public Statement apply(final Statement base, FrameworkMethod method,
+                               Object target) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    LOG.add("ran " + label);
+                    base.evaluate();
+                };
+            };
+        }
+    };
+
+    public static class UseRuleChain {
+        @Rule
+        public final RuleChain chain = RuleChain
+                .outerRule(new TestRuleAdapter(new LoggingRule("outer rule")))
+                .around(new TestRuleAdapter(new LoggingRule("middle rule")))
+                .around(new TestRuleAdapter(new LoggingRule("inner rule")));
+
+        @Test
+        public void example() {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void executeRulesInCorrectOrder() throws Exception {
+        testResult(UseRuleChain.class);
+        List<String> expectedLog = asList("ran outer rule",
+                "ran middle rule", "ran inner rule");
+        assertEquals(expectedLog, LOG);
+    }
+}


### PR DESCRIPTION
Allows to wrap method rules in test rules so that they can be used
inside rule chains. Not every third party project ported their method
rules yet (or even wants to).

Inspired by Johan Haleby's solution to PowerMock issue #396