### PR TITLE
Optimize string format

### DIFF
--- a/src/main/java/org/junit/runners/model/MultipleFailureException.java
+++ b/src/main/java/org/junit/runners/model/MultipleFailureException.java
@@ -34,7 +34,7 @@ public class MultipleFailureException extends Exception {
         StringBuilder sb = new StringBuilder(
                 String.format("There were %d errors:", fErrors.size()));
         for (Throwable e : fErrors) {
-            sb.append(String.format("\n  %s(%s)", e.getClass().getName(), e.getMessage()));
+            sb.append(String.format("%n  %s(%s)", e.getClass().getName(), e.getMessage()));
         }
         return sb.toString();
     }

--- a/src/test/java/org/junit/tests/experimental/max/MaxStarterTest.java
+++ b/src/test/java/org/junit/tests/experimental/max/MaxStarterTest.java
@@ -248,8 +248,6 @@ public class MaxStarterTest {
         }
     }
 
-    String fMessage = null;
-
     @Test
     public void correctErrorFromMalformedTest() {
         Request request = Request.aClass(MalformedJUnit38TestMethod.class);


### PR DESCRIPTION
 In format strings, it is generally preferable better to use %n, which will produce the platform-specific line separator.