### PR TITLE
Introduce class TestRuleAdapter / RuleChain support for MethodRule

### DIFF
--- a/src/main/java/org/junit/rules/TestRuleAdapter.java
+++ b/src/main/java/org/junit/rules/TestRuleAdapter.java
@@ -1,0 +1,75 @@
+package org.junit.rules;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+import java.lang.reflect.Method;
+
+/**
+ * A TestRuleAdapter allows to wrap {@link MethodRule} classes in
+ * {@link TestRule} classes in order to use them inside {@link RuleChain}.
+ * Assuming we have an existing method rule:
+ *
+ * <pre>
+ * class MyMethodRule implements MethodRule {
+ *     public Statement apply(final Statement base, FrameworkMethod method,
+ *                            Object target) {
+ *         return new Statement() {
+ *             &#064;Override
+ *             public void evaluate() throws Throwable {
+ *                 base.evaluate();
+ *             }
+ *         };
+ *     }
+ * }
+ * </pre>
+ *
+ * It can then be used in a {@link RuleChain} like this:
+ * <pre>
+ * class MyTest {
+ *     &#064;Rule
+ *     public final RuleChain chain = RuleChain
+ *             .outerRule(new TestRuleAdapter(new MyMethodRule(), this))
+ *             .around(new TestRuleAdapter(new MyMethodRule(), this));
+ *
+ *     ...
+ * }
+ * </pre>
+ *
+ * @since 4.12
+ */
+class TestRuleAdapter implements TestRule {
+    private final MethodRule rule;
+    private final Object testObject;
+
+    /**
+     * Creates a new instance wrapping the provided {@link MethodRule}.
+     *
+     * Needs an instance of the test class using this TestRuleAdapter or
+     * the surrounding {@link RuleChain} to be allow the wrapped
+     * {@link MethodRule} to interact with it.
+     *
+     * @param rule the MethodRule to wrap
+     * @param testObject instance of the test class
+     */
+    public TestRuleAdapter(MethodRule rule, Object testObject) {
+        this.rule = rule;
+        this.testObject = testObject;
+    }
+
+    public Statement apply(Statement base, Description description) {
+        try {
+            String methodName = description.getMethodName();
+            Method method = testObject.getClass().getDeclaredMethod(methodName);
+            return rule.apply(base, new FrameworkMethod(method), testObject);
+        } catch (final NoSuchMethodException e) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    throw e;
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/org/junit/rules/AllRulesTests.java
+++ b/src/test/java/org/junit/rules/AllRulesTests.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
         TemporaryFolderRuleAssuredDeletionTest.class,
         TemporaryFolderUsageTest.class,
         TestRuleTest.class,
+        TestRuleAdapterTest.class,
         TestWatcherTest.class,
         TestWatchmanTest.class,
         // todo TestWatchmanTest.class, - doesn't work and wasn't being run before.

--- a/src/test/java/org/junit/rules/TestRuleAdapterTest.java
+++ b/src/test/java/org/junit/rules/TestRuleAdapterTest.java
@@ -1,0 +1,59 @@
+package org.junit.rules;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.experimental.results.PrintableResult.testResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+public class TestRuleAdapterTest {
+    private static final List<String> LOG = new ArrayList<String>();
+
+    private static class LoggingRule implements MethodRule {
+        private String label;
+
+        LoggingRule(String label) {
+            this.label = label;
+        }
+
+        public Statement apply(final Statement base, FrameworkMethod method,
+                               Object target) {
+            return new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    LOG.add("ran " + label);
+                    base.evaluate();
+                };
+            };
+        }
+    };
+
+    public static class UseRuleChain {
+        @Rule
+        public final RuleChain chain = RuleChain
+                .outerRule(new LoggingRule("outer rule"), this)
+                .around(new LoggingRule("middle rule"), this)
+                .around(new TestRuleAdapter(new LoggingRule("inner rule"), this));
+
+        @Test
+        public void example() {
+            assertTrue(true);
+
+        }
+    }
+
+    @Test
+    public void executeRulesInCorrectOrder() throws Exception {
+        testResult(UseRuleChain.class);
+        List<String> expectedLog = asList("ran outer rule",
+                "ran middle rule", "ran inner rule");
+        assertEquals(expectedLog, LOG);
+    }
+}


### PR DESCRIPTION
Allows to wrap method rules in test rules so that they can be used
inside rule chains. Not every third party project ported their method
rules yet (or even wants to).

Add respective overrides for RuleChain.outerRule and RuleChain.around
to simplify usage.

Inspired by Johan Haleby's solution to PowerMock issue #396
