### PR TITLE
Fix StackTrace printing when multiple exceptions occur (#1238)

### DIFF
--- a/src/main/java/org/junit/runners/model/MultipleFailureException.java
+++ b/src/main/java/org/junit/runners/model/MultipleFailureException.java
@@ -1,5 +1,7 @@
 package org.junit.runners.model;
 
+import java.io.PrintStream;
+import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -39,6 +41,27 @@ public class MultipleFailureException extends Exception {
         return sb.toString();
     }
 
+    @Override
+    public void printStackTrace() {
+        for (Throwable e: fErrors) {
+            e.printStackTrace();
+        }
+    }
+    
+    @Override
+    public void printStackTrace(PrintStream s) {
+        for (Throwable e: fErrors) {
+            e.printStackTrace(s);
+        }
+    }
+    
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        for (Throwable e: fErrors) {
+            e.printStackTrace(s);
+        }
+    }
+    
     /**
      * Asserts that a list of throwables is empty. If it isn't empty,
      * will throw {@link MultipleFailureException} (if there are


### PR DESCRIPTION
I fixed the way MultipleFailureException prints the stacktraces. Now, when multiple exceptions are found, the stacktrace for each exception is printed