### PR TITLE
Update MultipleFailureException.assertEmpty() to wrap assumption failures

### DIFF
--- a/src/main/java/org/junit/TestCouldNotBeSkippedException.java
+++ b/src/main/java/org/junit/TestCouldNotBeSkippedException.java
@@ -1,0 +1,19 @@
+package org.junit;
+
+/**
+ * Indicates that a test that indicated that it should be skipped could not be skipped.
+ * This can be thrown if a test uses the methods in {@link Assume} to indicate that
+ * it should be skipped, but before processing of the test was completed, other failures
+ * occured.
+ *
+ * @see org.junit.Assume
+ * @since 4.13
+ */
+public class TestCouldNotBeSkippedException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /** Creates an instance using the given assumption failure. */
+    public TestCouldNotBeSkippedException(org.junit.internal.AssumptionViolatedException cause) {
+        super("Test could not be skipped due to other failures", cause);
+    }
+}

--- a/src/main/java/org/junit/runners/model/MultipleFailureException.java
+++ b/src/main/java/org/junit/runners/model/MultipleFailureException.java
@@ -6,6 +6,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.TestCouldNotBeSkippedException;
+import org.junit.internal.AssumptionViolatedException;
 import org.junit.internal.Throwables;
 
 /**
@@ -28,7 +30,13 @@ public class MultipleFailureException extends Exception {
             throw new IllegalArgumentException(
                     "List of Throwables must not be empty");
         }
-        this.fErrors = new ArrayList<Throwable>(errors);
+        this.fErrors = new ArrayList<Throwable>(errors.size());
+        for (Throwable error : errors) {
+            if (error instanceof AssumptionViolatedException) {
+                error = new TestCouldNotBeSkippedException((AssumptionViolatedException) error);
+            }
+            fErrors.add(error);
+        }
     }
 
     public List<Throwable> getFailures() {


### PR DESCRIPTION
if there are multiple exceptions.

This makes failures during the handling of assumption failures easier
to understand.
