### PR TITLE
Throw AssumptionViolatedException when single null is passed to Assum…

### DIFF
--- a/src/main/java/org/junit/Assume.java
+++ b/src/main/java/org/junit/Assume.java
@@ -79,6 +79,7 @@ public class Assume {
      * If called with one or more null elements in <code>objects</code>, the test will halt and be ignored.
      */
     public static void assumeNotNull(Object... objects) {
+        assumeThat(objects, notNullValue());
         assumeThat(asList(objects), everyItem(notNullValue()));
     }
 

--- a/src/main/java/org/junit/Assume.java
+++ b/src/main/java/org/junit/Assume.java
@@ -76,7 +76,8 @@ public class Assume {
     }
 
     /**
-     * If called with one or more null elements in <code>objects</code>, the test will halt and be ignored.
+     * If called with a {@code null} array or one or more {@code null} elements in {@code objects},
+     * the test will halt and be ignored.
      */
     public static void assumeNotNull(Object... objects) {
         assumeThat(objects, notNullValue());

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -111,6 +111,16 @@ public class AssumptionTest {
     }
 
     @Test
+    public void assumeNotNullSingleNullThrowsException() {
+        try {
+            assumeNotNull(null);
+            fail("should throw AssumptionViolatedException");
+        } catch (AssumptionViolatedException e) {
+            // expected
+        }
+    }
+
+    @Test
     public void assumeNotNullPasses() {
         Object[] objects = {1, 2};
         assumeNotNull(objects);

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -113,7 +113,7 @@ public class AssumptionTest {
     @Test
     public void assumeNotNullSingleNullThrowsException() {
         try {
-            assumeNotNull(null);
+            assumeNotNull((Object[]) null);
             fail("should throw AssumptionViolatedException");
         } catch (AssumptionViolatedException e) {
             // expected


### PR DESCRIPTION
…e.assumeNotNull(Object... objects) method

Previous implementation threw NullPointerException when single null argument was passed:
java.lang.NullPointerException
at java.util.Objects.requireNonNull(Objects.java:203)
at java.util.Arrays$ArrayList.<init>(Arrays.java:3813)
at java.util.Arrays.asList(Arrays.java:3800)