### PR TITLE
Remove unnecessary modifiers "public" for TestRunListener interface

### DIFF
--- a/src/main/java/junit/runner/TestRunListener.java
+++ b/src/main/java/junit/runner/TestRunListener.java
@@ -8,18 +8,18 @@ package junit.runner;
  */
 public interface TestRunListener {
     /* test status constants*/
-    public static final int STATUS_ERROR = 1;
-    public static final int STATUS_FAILURE = 2;
+    int STATUS_ERROR = 1;
+    int STATUS_FAILURE = 2;
 
-    public void testRunStarted(String testSuiteName, int testCount);
+    void testRunStarted(String testSuiteName, int testCount);
 
-    public void testRunEnded(long elapsedTime);
+    void testRunEnded(long elapsedTime);
 
-    public void testRunStopped(long elapsedTime);
+    void testRunStopped(long elapsedTime);
 
-    public void testStarted(String testName);
+    void testStarted(String testName);
 
-    public void testEnded(String testName);
+    void testEnded(String testName);
 
-    public void testFailed(int status, String testName, String trace);
+    void testFailed(int status, String testName, String trace);
 }


### PR DESCRIPTION
Remove unnecessary modifiers "public" for TestRunListener interface because all abstract, default, and static methods in an interface are implicitly public, so you can omit the public modifier.

Here is specified: [Java Doc About Interface Definition](http://docs.oracle.com/javase/tutorial/java/IandI/interfaceDef.html)