### PR TITLE
Remove unnecessary boxing on ListTest

### DIFF
--- a/src/main/java/junit/runner/BaseTestRunner.java
+++ b/src/main/java/junit/runner/BaseTestRunner.java
@@ -297,7 +297,7 @@ public abstract class BaseTestRunner implements TestListener {
     }
 
     protected static boolean showStackRaw() {
-        return !getPreference("filterstack").equals("true") || fgFilterStack == false;
+        return !getPreference("filterstack").equals("true") || !fgFilterStack;
     }
 
     static boolean filterLine(String line) {

--- a/src/main/java/junit/runner/BaseTestRunner.java
+++ b/src/main/java/junit/runner/BaseTestRunner.java
@@ -297,7 +297,7 @@ public abstract class BaseTestRunner implements TestListener {
     }
 
     protected static boolean showStackRaw() {
-        return !getPreference("filterstack").equals("true") || !fgFilterStack;
+        return !getPreference("filterstack").equals("true") || fgFilterStack == false;
     }
 
     static boolean filterLine(String line) {

--- a/src/test/java/junit/samples/ListTest.java
+++ b/src/test/java/junit/samples/ListTest.java
@@ -34,7 +34,7 @@ public class ListTest extends TestCase {
     public void testCapacity() {
         int size = fFull.size();
         for (int i = 0; i < 100; i++) {
-            fFull.add(new Integer(i));
+            fFull.add(i);
         }
         assertTrue(fFull.size() == 100 + size);
     }


### PR DESCRIPTION
Remove unnecessary boxing on ListTest because Java creates an Integer object from `i` and adds to the object `fFull`

Reference:
[`Autoboxing and Unboxing`](https://docs.oracle.com/javase/tutorial/java/data/autoboxing.html)