### PR TITLE
Set private the lists fEmpty, fFull and remove unnecessary boxing on ListTest

### DIFF
--- a/src/test/java/junit/samples/ListTest.java
+++ b/src/test/java/junit/samples/ListTest.java
@@ -11,8 +11,9 @@ import junit.framework.TestSuite;
  * A sample test case, testing {@link java.util.ArrayList}.
  */
 public class ListTest extends TestCase {
-    protected List<Integer> fEmpty;
-    protected List<Integer> fFull;
+    private List<Integer> fEmpty;
+
+    private List<Integer> fFull;
 
     public static void main(String[] args) {
         junit.textui.TestRunner.run(suite());
@@ -64,7 +65,7 @@ public class ListTest extends TestCase {
     }
 
     public void testRemoveElement() {
-        fFull.remove(new Integer(3));
+        fFull.remove(3);
         assertTrue(!fFull.contains(3));
     }
 }

--- a/src/test/java/junit/samples/ListTest.java
+++ b/src/test/java/junit/samples/ListTest.java
@@ -11,21 +11,18 @@ import junit.framework.TestSuite;
  * A sample test case, testing {@link java.util.ArrayList}.
  */
 public class ListTest extends TestCase {
-    private List<Integer> fEmpty;
+    private List<Integer> emptyList;
 
-    private List<Integer> fFull;
+    private List<Integer> fullList;
 
-    public static void main(String[] args) {
-        junit.textui.TestRunner.run(suite());
-    }
 
     @Override
     protected void setUp() {
-        fEmpty = new ArrayList<Integer>();
-        fFull = new ArrayList<Integer>();
-        fFull.add(1);
-        fFull.add(2);
-        fFull.add(3);
+        emptyList = new ArrayList<Integer>();
+        fullList = new ArrayList<Integer>();
+        fullList.add(1);
+        fullList.add(2);
+        fullList.add(3);
     }
 
     public static Test suite() {
@@ -33,24 +30,24 @@ public class ListTest extends TestCase {
     }
 
     public void testCapacity() {
-        int size = fFull.size();
+        int size = fullList.size();
         for (int i = 0; i < 100; i++) {
-            fFull.add(i);
+            fullList.add(i);
         }
-        assertTrue(fFull.size() == 100 + size);
+        assertTrue(fullList.size() == 100 + size);
     }
 
     public void testContains() {
-        assertTrue(fFull.contains(1));
-        assertTrue(!fEmpty.contains(1));
+        assertTrue(fullList.contains(1));
+        assertTrue(!emptyList.contains(1));
     }
 
     public void testElementAt() {
-        int i = fFull.get(0);
+        int i = fullList.get(0);
         assertTrue(i == 1);
 
         try {
-            fFull.get(fFull.size());
+            fullList.get(fullList.size());
         } catch (IndexOutOfBoundsException e) {
             return;
         }
@@ -58,14 +55,14 @@ public class ListTest extends TestCase {
     }
 
     public void testRemoveAll() {
-        fFull.removeAll(fFull);
-        fEmpty.removeAll(fEmpty);
-        assertTrue(fFull.isEmpty());
-        assertTrue(fEmpty.isEmpty());
+        fullList.removeAll(fullList);
+        emptyList.removeAll(emptyList);
+        assertTrue(fullList.isEmpty());
+        assertTrue(emptyList.isEmpty());
     }
 
     public void testRemoveElement() {
-        fFull.remove(3);
-        assertTrue(!fFull.contains(3));
+        fullList.remove(3);
+        assertTrue(!fullList.contains(3));
     }
 }

--- a/src/test/java/junit/samples/ListTest.java
+++ b/src/test/java/junit/samples/ListTest.java
@@ -12,7 +12,6 @@ import junit.framework.TestSuite;
  */
 public class ListTest extends TestCase {
     private List<Integer> emptyList;
-
     private List<Integer> fullList;
 
 
@@ -44,7 +43,7 @@ public class ListTest extends TestCase {
 
     public void testElementAt() {
         int i = fullList.get(0);
-        assertTrue(i == 1);
+        assertEquals(1,i);
 
         try {
             fullList.get(fullList.size());


### PR DESCRIPTION
##### Description of change
- Change from protected to private `fEmpty` and `fFull` lists, because there is no need to keep accessible from the package and subclass
- Remove unnecessary boxing on `fFull.remove()` because Java creates an Integer object from `i` and adds to the object `fFull`

##### Requested Changes
- Remove main method from ListTest.java
- Rename `fEmpty` to `emptyList`
- Rename `fFull` to `fullList`
- Remove extra blank line
- Change `assertTrue()` for `assertEquals()` on `testElementAt()` method

##### Checklist
- [x] Run `mvn verify`
- [x] All tests are passing

##### References:
[Controlling Access to Members of a Class](https://docs.oracle.com/javase/tutorial/java/javaOO/accesscontrol.html)
[Autoboxing and Unboxing](https://docs.oracle.com/javase/tutorial/java/data/autoboxing.html)