### PR TITLE
Change javadoc reference of ThrowingRunnable on ExpectedException

### DIFF
--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -15,12 +15,12 @@ import org.junit.runners.model.Statement;
 /**
  * The {@code ExpectedException} rule allows you to verify that your code
  * throws a specific exception. Note that, starting with Java 8,
- * {@link org.junit.Assert#assertThrows(java.lang.Class, org.junit.Assert.ThrowingRunnable)
+ * {@link org.junit.Assert#assertThrows(java.lang.Class, org.junit.function.ThrowingRunnable)
  * Assert.assertThrows}
  * is often a better choice since it allows you to express exactly where you
  * expect the exception to be thrown. Use
  * {@link org.junit.Assert#expectThrows(java.lang.Class,
- * org.junit.Assert.ThrowingRunnable) expectThrows}
+ * org.junit.function.ThrowingRunnable) expectThrows}
  * if you need to assert something about the thrown exception.
  *
  * <h3>Usage</h3>


### PR DESCRIPTION
##### Description of change
- Change reference of javadoc from `org.junit.Assert.ThrowingRunnable` to `org.junit.function.ThrowingRunnable` on `ExpectedException`

##### Checklist
- [x] Run `mvn verify`
- [x] All tests are passing
- [x] Generated JavaDoc with working links
