### PR TITLE
Wrap assumption violations in ErrorCollector

### DIFF
--- a/src/main/java/org/junit/experimental/results/PrintableResult.java
+++ b/src/main/java/org/junit/experimental/results/PrintableResult.java
@@ -54,6 +54,15 @@ public class PrintableResult {
         return result.getFailures().size();
     }
 
+    /**
+     * Returns the failures in this result.
+     *
+     * @since 4.13
+     */
+    public List<Failure> failures() {
+        return result.getFailures();
+    }
+
     @Override
     public String toString() {
         ByteArrayOutputStream stream = new ByteArrayOutputStream();

--- a/src/main/java/org/junit/experimental/results/ResultMatchers.java
+++ b/src/main/java/org/junit/experimental/results/ResultMatchers.java
@@ -4,6 +4,7 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.runner.notification.Failure;
 
 /**
  * Matchers on a PrintableResult, to enable JUnit self-tests.
@@ -62,11 +63,31 @@ public class ResultMatchers {
     }
 
     /**
+     * Matches if the result has exactly one failure matching the given matcher.
+     *
+     * @since 4.13
+     */
+    public static Matcher<PrintableResult> hasSingleFailureMatching(final Matcher<Throwable> matcher) {
+        return new TypeSafeMatcher<PrintableResult>() {
+            @Override
+            public boolean matchesSafely(PrintableResult item) {
+                return item.failureCount() == 1 && matcher.matches(item.failures().get(0).getException());
+            }
+
+            public void describeTo(Description description) {
+                description.appendText("has failure with exception matching ");
+                matcher.describeTo(description);
+            }
+        };
+    }
+
+    /**
      * Matches if the result has one or more failures, and at least one of them
      * contains {@code string}
      */
     public static Matcher<PrintableResult> hasFailureContaining(final String string) {
         return new TypeSafeMatcher<PrintableResult>() {
+            @Override
             public boolean matchesSafely(PrintableResult item) {
                 return item.failureCount() > 0 && item.toString().contains(string);
             }

--- a/src/main/java/org/junit/rules/ErrorCollector.java
+++ b/src/main/java/org/junit/rules/ErrorCollector.java
@@ -46,6 +46,9 @@ public class ErrorCollector extends Verifier {
      * Adds a Throwable to the table.  Execution continues, but the test will fail at the end.
      */
     public void addError(Throwable error) {
+        if (error == null) {
+            throw new NullPointerException("Error cannot be null");
+        }
         if (error instanceof AssumptionViolatedException) {
             AssertionError e = new AssertionError(error.getMessage());
             e.initCause(error);


### PR DESCRIPTION
addError() and checkSucceeds() now wrap assumption violations.