### PR TITLE
Delete assertThrows()

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -968,21 +968,6 @@ public class Assert {
 
     /**
      * Asserts that {@code runnable} throws an exception of type {@code expectedThrowable} when
-     * executed. If it does not throw an exception, an {@link AssertionError} is thrown. If it
-     * throws the wrong type of exception, an {@code AssertionError} is thrown describing the
-     * mismatch; the exception that was actually thrown can be obtained by calling {@link
-     * AssertionError#getCause}.
-     *
-     * @param expectedThrowable the expected type of the exception
-     * @param runnable       a function that is expected to throw an exception when executed
-     * @since 4.13
-     */
-    public static void assertThrows(Class<? extends Throwable> expectedThrowable, ThrowingRunnable runnable) {
-        expectThrows(expectedThrowable, runnable);
-    }
-
-    /**
-     * Asserts that {@code runnable} throws an exception of type {@code expectedThrowable} when
      * executed. If it does, the exception object is returned. If it does not throw an exception, an
      * {@link AssertionError} is thrown. If it throws the wrong type of exception, an {@code
      * AssertionError} is thrown describing the mismatch; the exception that was actually thrown can
@@ -993,7 +978,7 @@ public class Assert {
      * @return the exception thrown by {@code runnable}
      * @since 4.13
      */
-    public static <T extends Throwable> T expectThrows(Class<T> expectedThrowable, ThrowingRunnable runnable) {
+    public static <T extends Throwable> T assertThrows(Class<T> expectedThrowable, ThrowingRunnable runnable) {
         try {
             runnable.run();
         } catch (Throwable actualThrown) {

--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -967,7 +967,7 @@ public class Assert {
     }
 
     /**
-     * Asserts that {@code runnable} throws an exception of type {@code expectedThrowable} when
+     * Checks that {@code runnable} throws an exception of type {@code expectedThrowable} when
      * executed. If it does, the exception object is returned. If it does not throw an exception, an
      * {@link AssertionError} is thrown. If it throws the wrong type of exception, an {@code
      * AssertionError} is thrown describing the mismatch; the exception that was actually thrown can
@@ -978,7 +978,7 @@ public class Assert {
      * @return the exception thrown by {@code runnable}
      * @since 4.13
      */
-    public static <T extends Throwable> T assertThrows(Class<T> expectedThrowable, ThrowingRunnable runnable) {
+    public static <T extends Throwable> T expectThrows(Class<T> expectedThrowable, ThrowingRunnable runnable) {
         try {
             runnable.run();
         } catch (Throwable actualThrown) {

--- a/src/main/java/org/junit/function/ThrowingRunnable.java
+++ b/src/main/java/org/junit/function/ThrowingRunnable.java
@@ -1,8 +1,8 @@
 package org.junit.function;
 
 /**
- * This interface facilitates the use of expectThrows from Java 8. It allows method references
- * to void methods (that declare checked exceptions) to be passed directly into expectThrows
+ * This interface facilitates the use of assertThrows from Java 8. It allows method references
+ * to void methods (that declare checked exceptions) to be passed directly into assertThrows
  * without wrapping. It is not meant to be implemented directly.
  *
  * @since 4.13

--- a/src/main/java/org/junit/function/ThrowingRunnable.java
+++ b/src/main/java/org/junit/function/ThrowingRunnable.java
@@ -1,8 +1,8 @@
 package org.junit.function;
 
 /**
- * This interface facilitates the use of assertThrows from Java 8. It allows method references
- * to void methods (that declare checked exceptions) to be passed directly into assertThrows
+ * This interface facilitates the use of {@code expectThrows} from Java 8. It allows method references
+ * to void methods (that declare checked exceptions) to be passed directly into {@code expectThrows}.
  * without wrapping. It is not meant to be implemented directly.
  *
  * @since 4.13

--- a/src/main/java/org/junit/rules/ErrorCollector.java
+++ b/src/main/java/org/junit/rules/ErrorCollector.java
@@ -1,7 +1,7 @@
 package org.junit.rules;
 
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.expectThrows;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -117,7 +117,7 @@ public class ErrorCollector extends Verifier {
      */
     public void checkThrows(Class<? extends Throwable> expectedThrowable, ThrowingRunnable runnable) {
         try {
-            assertThrows(expectedThrowable, runnable);
+            expectThrows(expectedThrowable, runnable);
         } catch (AssertionError e) {
             addError(e);
         }

--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -18,10 +18,7 @@ import org.junit.runners.model.Statement;
  * {@link org.junit.Assert#assertThrows(java.lang.Class, org.junit.function.ThrowingRunnable)
  * Assert.assertThrows}
  * is often a better choice since it allows you to express exactly where you
- * expect the exception to be thrown. Use
- * {@link org.junit.Assert#expectThrows(java.lang.Class,
- * org.junit.function.ThrowingRunnable) expectThrows}
- * if you need to assert something about the thrown exception.
+ * expect the exception to be thrown.
  *
  * <h3>Usage</h3>
  *

--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -15,8 +15,8 @@ import org.junit.runners.model.Statement;
 /**
  * The {@code ExpectedException} rule allows you to verify that your code
  * throws a specific exception. Note that, starting with Java 8,
- * {@link org.junit.Assert#assertThrows(java.lang.Class, org.junit.function.ThrowingRunnable)
- * Assert.assertThrows}
+ * {@link org.junit.Assert#expectThrows(java.lang.Class, org.junit.function.ThrowingRunnable)
+ * Assert.expectThrows}
  * is often a better choice since it allows you to express exactly where you
  * expect the exception to be thrown.
  *

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -10,8 +10,8 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.expectThrows;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -797,14 +797,14 @@ public class AssertionTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void assertThrowsRequiresAnExceptionToBeThrown() {
-        assertThrows(Throwable.class, nonThrowingRunnable());
+    public void expectThrowsRequiresAnExceptionToBeThrown() {
+        expectThrows(Throwable.class, nonThrowingRunnable());
     }
 
     @Test
-    public void assertThrowsIncludesAnInformativeDefaultMessage() {
+    public void expectThrowsIncludesAnInformativeDefaultMessage() {
         try {
-            assertThrows(Throwable.class, nonThrowingRunnable());
+            expectThrows(Throwable.class, nonThrowingRunnable());
         } catch (AssertionError ex) {
             assertEquals("expected java.lang.Throwable to be thrown, but nothing was thrown", ex.getMessage());
             return;
@@ -813,27 +813,27 @@ public class AssertionTest {
     }
 
     @Test
-    public void assertThrowsReturnsTheSameObjectThrown() {
+    public void expectThrowsReturnsTheSameObjectThrown() {
         NullPointerException npe = new NullPointerException();
 
-        Throwable throwable = assertThrows(Throwable.class, throwingRunnable(npe));
+        Throwable throwable = expectThrows(Throwable.class, throwingRunnable(npe));
 
         assertSame(npe, throwable);
     }
 
     @Test(expected = AssertionError.class)
-    public void assertThrowsDetectsTypeMismatchesViaExplicitTypeHint() {
+    public void expectThrowsDetectsTypeMismatchesViaExplicitTypeHint() {
         NullPointerException npe = new NullPointerException();
 
-        assertThrows(IOException.class, throwingRunnable(npe));
+        expectThrows(IOException.class, throwingRunnable(npe));
     }
 
     @Test
-    public void assertThrowsWrapsAndPropagatesUnexpectedExceptions() {
+    public void expectThrowsWrapsAndPropagatesUnexpectedExceptions() {
         NullPointerException npe = new NullPointerException("inner-message");
 
         try {
-            assertThrows(IOException.class, throwingRunnable(npe));
+            expectThrows(IOException.class, throwingRunnable(npe));
         } catch (AssertionError ex) {
             assertSame(npe, ex.getCause());
             assertEquals("inner-message", ex.getCause().getMessage());
@@ -843,11 +843,11 @@ public class AssertionTest {
     }
 
     @Test
-    public void assertThrowsSuppliesACoherentErrorMessageUponTypeMismatch() {
+    public void expectThrowsSuppliesACoherentErrorMessageUponTypeMismatch() {
         NullPointerException npe = new NullPointerException();
 
         try {
-            assertThrows(IOException.class, throwingRunnable(npe));
+            expectThrows(IOException.class, throwingRunnable(npe));
         } catch (AssertionError error) {
             assertEquals("unexpected exception type thrown; expected:<java.io.IOException> but was:<java.lang.NullPointerException>",
                     error.getMessage());
@@ -858,11 +858,11 @@ public class AssertionTest {
     }
 
     @Test
-    public void assertThrowsUsesCanonicalNameUponTypeMismatch() {
+    public void expectThrowsUsesCanonicalNameUponTypeMismatch() {
         NullPointerException npe = new NullPointerException();
 
         try {
-            assertThrows(NestedException.class, throwingRunnable(npe));
+            expectThrows(NestedException.class, throwingRunnable(npe));
         } catch (AssertionError error) {
             assertEquals(
                     "unexpected exception type thrown; expected:<org.junit.tests.assertion.AssertionTest.NestedException>"
@@ -875,12 +875,12 @@ public class AssertionTest {
     }
 
     @Test
-    public void assertThrowsUsesNameUponTypeMismatchWithAnonymousClass() {
+    public void expectThrowsUsesNameUponTypeMismatchWithAnonymousClass() {
         NullPointerException npe = new NullPointerException() {
         };
 
         try {
-            assertThrows(IOException.class, throwingRunnable(npe));
+            expectThrows(IOException.class, throwingRunnable(npe));
         } catch (AssertionError error) {
             assertEquals(
                     "unexpected exception type thrown; expected:<java.io.IOException>"
@@ -893,9 +893,9 @@ public class AssertionTest {
     }
 
     @Test
-    public void assertThrowsUsesCanonicalNameWhenRequiredExceptionNotThrown() {
+    public void expectThrowsUsesCanonicalNameWhenRequiredExceptionNotThrown() {
         try {
-            assertThrows(NestedException.class, nonThrowingRunnable());
+            expectThrows(NestedException.class, nonThrowingRunnable());
         } catch (AssertionError error) {
             assertEquals(
                     "expected org.junit.tests.assertion.AssertionTest.NestedException to be thrown,"

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -10,8 +10,8 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.expectThrows;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -797,14 +797,14 @@ public class AssertionTest {
     }
 
     @Test(expected = AssertionError.class)
-    public void expectThrowsRequiresAnExceptionToBeThrown() {
-        expectThrows(Throwable.class, nonThrowingRunnable());
+    public void assertThrowsRequiresAnExceptionToBeThrown() {
+        assertThrows(Throwable.class, nonThrowingRunnable());
     }
 
     @Test
-    public void expectThrowsIncludesAnInformativeDefaultMessage() {
+    public void assertThrowsIncludesAnInformativeDefaultMessage() {
         try {
-            expectThrows(Throwable.class, nonThrowingRunnable());
+            assertThrows(Throwable.class, nonThrowingRunnable());
         } catch (AssertionError ex) {
             assertEquals("expected java.lang.Throwable to be thrown, but nothing was thrown", ex.getMessage());
             return;
@@ -813,27 +813,27 @@ public class AssertionTest {
     }
 
     @Test
-    public void expectThrowsReturnsTheSameObjectThrown() {
+    public void assertThrowsReturnsTheSameObjectThrown() {
         NullPointerException npe = new NullPointerException();
 
-        Throwable throwable = expectThrows(Throwable.class, throwingRunnable(npe));
+        Throwable throwable = assertThrows(Throwable.class, throwingRunnable(npe));
 
         assertSame(npe, throwable);
     }
 
     @Test(expected = AssertionError.class)
-    public void expectThrowsDetectsTypeMismatchesViaExplicitTypeHint() {
+    public void assertThrowsDetectsTypeMismatchesViaExplicitTypeHint() {
         NullPointerException npe = new NullPointerException();
 
-        expectThrows(IOException.class, throwingRunnable(npe));
+        assertThrows(IOException.class, throwingRunnable(npe));
     }
 
     @Test
-    public void expectThrowsWrapsAndPropagatesUnexpectedExceptions() {
+    public void assertThrowsWrapsAndPropagatesUnexpectedExceptions() {
         NullPointerException npe = new NullPointerException("inner-message");
 
         try {
-            expectThrows(IOException.class, throwingRunnable(npe));
+            assertThrows(IOException.class, throwingRunnable(npe));
         } catch (AssertionError ex) {
             assertSame(npe, ex.getCause());
             assertEquals("inner-message", ex.getCause().getMessage());
@@ -843,11 +843,11 @@ public class AssertionTest {
     }
 
     @Test
-    public void expectThrowsSuppliesACoherentErrorMessageUponTypeMismatch() {
+    public void assertThrowsSuppliesACoherentErrorMessageUponTypeMismatch() {
         NullPointerException npe = new NullPointerException();
 
         try {
-            expectThrows(IOException.class, throwingRunnable(npe));
+            assertThrows(IOException.class, throwingRunnable(npe));
         } catch (AssertionError error) {
             assertEquals("unexpected exception type thrown; expected:<java.io.IOException> but was:<java.lang.NullPointerException>",
                     error.getMessage());
@@ -858,11 +858,11 @@ public class AssertionTest {
     }
 
     @Test
-    public void expectThrowsUsesCanonicalNameUponTypeMismatch() {
+    public void assertThrowsUsesCanonicalNameUponTypeMismatch() {
         NullPointerException npe = new NullPointerException();
 
         try {
-            expectThrows(NestedException.class, throwingRunnable(npe));
+            assertThrows(NestedException.class, throwingRunnable(npe));
         } catch (AssertionError error) {
             assertEquals(
                     "unexpected exception type thrown; expected:<org.junit.tests.assertion.AssertionTest.NestedException>"
@@ -875,12 +875,12 @@ public class AssertionTest {
     }
 
     @Test
-    public void expectThrowsUsesNameUponTypeMismatchWithAnonymousClass() {
+    public void assertThrowsUsesNameUponTypeMismatchWithAnonymousClass() {
         NullPointerException npe = new NullPointerException() {
         };
 
         try {
-            expectThrows(IOException.class, throwingRunnable(npe));
+            assertThrows(IOException.class, throwingRunnable(npe));
         } catch (AssertionError error) {
             assertEquals(
                     "unexpected exception type thrown; expected:<java.io.IOException>"
@@ -893,9 +893,9 @@ public class AssertionTest {
     }
 
     @Test
-    public void expectThrowsUsesCanonicalNameWhenRequiredExceptionNotThrown() {
+    public void assertThrowsUsesCanonicalNameWhenRequiredExceptionNotThrown() {
         try {
-            expectThrows(NestedException.class, nonThrowingRunnable());
+            assertThrows(NestedException.class, nonThrowingRunnable());
         } catch (AssertionError error) {
             assertEquals(
                     "expected org.junit.tests.assertion.AssertionTest.NestedException to be thrown,"


### PR DESCRIPTION
Delete expectThrows(). Change assertThrows() to return the caught exception.

JUnit 5 decided to make the same change in the Assertions class, so this
change makes the JUnit4 API consistent.