### PR TITLE
Change generics on ExpectedException.expectCause().

### DIFF
--- a/src/main/java/org/junit/internal/matchers/ThrowableCauseMatcher.java
+++ b/src/main/java/org/junit/internal/matchers/ThrowableCauseMatcher.java
@@ -16,9 +16,9 @@ import org.hamcrest.TypeSafeMatcher;
 public class ThrowableCauseMatcher<T extends Throwable> extends
         TypeSafeMatcher<T> {
 
-    private final Matcher<? extends Throwable> causeMatcher;
+    private final Matcher<?> causeMatcher;
 
-    public ThrowableCauseMatcher(Matcher<? extends Throwable> causeMatcher) {
+    public ThrowableCauseMatcher(Matcher<?> causeMatcher) {
         this.causeMatcher = causeMatcher;
     }
 
@@ -46,7 +46,7 @@ public class ThrowableCauseMatcher<T extends Throwable> extends
      * @param <T> type of the outer exception
      */
     @Factory
-    public static <T extends Throwable> Matcher<T> hasCause(final Matcher<? extends Throwable> matcher) {
+    public static <T extends Throwable> Matcher<T> hasCause(final Matcher<?> matcher) {
         return new ThrowableCauseMatcher<T>(matcher);
     }
 }

--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -240,7 +240,7 @@ public class ExpectedException implements TestRule {
      * @deprecated use {@code org.hamcrest.junit.ExpectedException.expectCause()}
      */
     @Deprecated
-    public ExpectedException expectCause(Matcher<? extends Throwable> expectedCause) {
+    public ExpectedException expectCause(Matcher<?> expectedCause) {
         expect(hasCause(expectedCause));
         return this;
     }


### PR DESCRIPTION
The previous generics (Matcher<? extends Throwable>) would not allow
you do use matchers on Object, like notNullValue().

Fixes #1073