### PR TITLE
Runner to detect default test methods on interfaces (mixin support)

### DIFF
--- a/src/main/java/org/junit/experimental/runners/Mixin.java
+++ b/src/main/java/org/junit/experimental/runners/Mixin.java
@@ -2,7 +2,6 @@ package org.junit.experimental.runners;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/org/junit/experimental/runners/Mixin.java
+++ b/src/main/java/org/junit/experimental/runners/Mixin.java
@@ -1,0 +1,94 @@
+package org.junit.experimental.runners;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.JUnit4;
+import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.TestClass;
+
+/**
+ * Support tests declared on interfaces where they are defined as {@code Method#isDefaultMethod default} methods for
+ * Java 8 and above, as well as those otherwise on the {@link JUnit4 default runner}.
+ *
+ * On earlier JVMs it will not behave any differently to the default runner.
+ *
+ * @author Ollie Robertshaw
+ * @see JUnit4
+ * @since 4.13
+ */
+public class Mixin extends BlockJUnit4ClassRunner {
+
+    public Mixin(final Class<?> klass) throws InitializationError {
+        super(klass);
+    }
+
+    @Override
+    protected final TestClass createTestClass(final Class<?> testClass) {
+        return new MixinDetectingTestClass(testClass);
+    }
+
+    protected static final class MixinDetectingTestClass extends TestClass {
+
+        private static final Method isDefaultInterface;
+
+        static {
+            Method method;
+            try {
+                method = Method.class.getDeclaredMethod("isDefault");
+            } catch (final Throwable t) {
+                method = null;
+            }
+            isDefaultInterface = method;
+        }
+
+        MixinDetectingTestClass(final Class<?> clazz) {
+            super(clazz);
+        }
+
+        @Override
+        protected void scanAnnotatedMembers(
+                final Map<Class<? extends Annotation>, List<FrameworkMethod>> methodsForAnnotations,
+                final Map<Class<? extends Annotation>, List<FrameworkField>> fieldsForAnnotations) {
+            super.scanAnnotatedMembers(methodsForAnnotations, fieldsForAnnotations);
+            if (isDefaultInterface == null) {
+                return;
+            }
+            for (final Class<?> interfaceClass : getInterfaces(this.getJavaClass())) {
+                for (final Method method : interfaceClass.getDeclaredMethods()) {
+                    try {
+                        if (Boolean.TRUE.equals(isDefaultInterface.invoke(method))) {
+                            addToAnnotationLists(new FrameworkMethod(method), methodsForAnnotations);
+                        }
+                    } catch (final Exception ex) {
+                        //Ignore
+                    }
+                }
+            }
+        }
+
+        private static Set<Class<?>> getInterfaces(final Class<?> clazz) {
+            final Set<Class<?>> interfaces = new HashSet<Class<?>>();
+            getInterfaces(clazz, interfaces);
+            return interfaces;
+        }
+
+        private static void getInterfaces(final Class<?> clazz, final Set<Class<?>> interfaces) {
+            for (final Class<?> interfaceClass : clazz.getInterfaces()) {
+                if (interfaces.add(interfaceClass)) {
+                    getInterfaces(interfaceClass, interfaces);
+                }
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
I'd like to be able to mixin tests defined as default methods on interfaces. 

This PR adds a new Mixin runner that supports default methods on Java 8+, and operates the same as BlockJUnit4ClassRunner on on Java 7-.

My feeling is that this behaviour should be moved into BlockJUnit4ClassRunner at some point, but for now it's kept as a separate experimental runner.