### PR TITLE
Update TemporaryFolder.newFolder(String) to support passing in paths

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -167,16 +167,27 @@ public class TemporaryFolder extends ExternalResource {
     }
 
     /**
-     * Returns a new fresh folder with the given name under the temporary
+     * Returns a new fresh folder with the given path under the temporary
      * folder.
      */
     public File newFolder(String folder) throws IOException {
-        return newFolder(new String[]{folder});
+        if (new File(folder).isAbsolute()) {
+            throw new IOException("folder name must be a relative path");
+        }
+        File file = new File(getRoot(), folder);
+        if (!file.mkdirs()) {
+            throw new IOException(
+                    "a folder with the name \'" + folder + "\' already exists");
+        }
+        return file;
     }
 
     /**
      * Returns a new fresh folder with the given name(s) under the temporary
-     * folder.
+     * folder. For example, if you pass in the strings {@code "parent"} and {@code "child"}
+     * then a directory named {@code "parent"} will be created under the temporary folder
+     * and a directory named {@code "child"} will be created under the newly-created
+     * {@code "parent"} directory.
      */
     public File newFolder(String... folderNames) throws IOException {
         File file = getRoot();

--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -84,12 +84,32 @@ public class TemporaryFolderUsageTest {
     }
     
     @Test
-    public void newFolderWithGivenFolderThrowsIOExceptionIfFolderNameConsistsOfMultiplePathComponents()
+    public void newFolderWithPathStartingWithFileSeparatorThrowsIOException()
             throws IOException {
         tempFolder.create();
         thrown.expect(IOException.class);
-        thrown.expectMessage("name cannot consist of multiple path components");
+        thrown.expectMessage("folder name must be a relative path");
+        tempFolder.newFolder(File.separator + "temp1");
+    }
+    
+    @Test
+    public void newFolderWithPathContainingFileSeparaterCreatesDirectories()
+            throws IOException {
+        tempFolder.create();
+        tempFolder.newFolder("temp1" + File.separator + "temp2");
+        File temp1 = new File(tempFolder.getRoot(), "temp1");
+        assertFileIsDirectory(temp1);
+        assertFileIsDirectory(new File(temp1, "temp2"));
+    }
+ 
+    @Test
+    public void newFolderWithPathContainingForwardSlashCreatesDirectories()
+            throws IOException {
+        tempFolder.create();
         tempFolder.newFolder("temp1/temp2");
+        File temp1 = new File(tempFolder.getRoot(), "temp1");
+        assertFileIsDirectory(temp1);
+        assertFileIsDirectory(new File(temp1, "temp2"));
     }
     
     @Test
@@ -114,7 +134,7 @@ public class TemporaryFolderUsageTest {
     @Test
     public void createInitializesRootFolder() throws IOException {
         tempFolder.create();
-        assertFileExists(tempFolder.getRoot());
+        assertFileIsDirectory(tempFolder.getRoot());
     }
 
     @Test
@@ -155,7 +175,7 @@ public class TemporaryFolderUsageTest {
         tempFolder.create();
 
         File f = tempFolder.newFolder();
-        assertFileExists(f);
+        assertFileIsDirectory(f);
         assertFileCreatedUnderRootFolder("Random folder", f);
     }
 
@@ -164,7 +184,7 @@ public class TemporaryFolderUsageTest {
         tempFolder.create();
 
         File f = tempFolder.newFolder("top", "middle", "bottom");
-        assertFileExists(f);
+        assertFileIsDirectory(f);
         assertParentFolderForFileIs(f, new File(tempFolder.getRoot(),
                 "top/middle"));
         assertParentFolderForFileIs(f.getParentFile(),
@@ -200,8 +220,20 @@ public class TemporaryFolderUsageTest {
                 file.exists(), is(exists));
     }
 
+    private void checkFileIsDirectory(String msg, File file, boolean isDirectory) {
+        assertThat("File is null", file, is(notNullValue()));
+        assertThat("File '" + file.getAbsolutePath() + "' " + msg,
+                file.isDirectory(), is(isDirectory));
+    }
+
     private void assertFileExists(File file) {
         checkFileExists("does not exist", file, true);
+        checkFileIsDirectory("is a directory", file, false);
+    }
+
+    private void assertFileIsDirectory(File file) {
+        checkFileExists("does not exist", file, true);
+        checkFileIsDirectory("is not a directory", file, true);
     }
 
     private void assertFileCreatedUnderRootFolder(String msg, File f) {


### PR DESCRIPTION
that include path separator characters. The overload of newFolder() that
supports passing in multiple strings still does not allow path separators.