### PR TITLE
Classes annotated with @RunWith(Suite.class) do not need to be public.

### DIFF
--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -30,6 +30,8 @@ import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
+import org.junit.validator.PublicClassValidator;
+import org.junit.validator.TestClassValidator;
 
 /**
  * Implements the JUnit 4 standard test case class model, as defined by the
@@ -56,6 +58,7 @@ import org.junit.runners.model.Statement;
  * @since 4.5
  */
 public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
+    private static TestClassValidator PUBLIC_CLASS_VALIDATOR = new PublicClassValidator();
 
     private final ConcurrentMap<FrameworkMethod, Description> methodDescriptions = new ConcurrentHashMap<FrameworkMethod, Description>();
 
@@ -133,11 +136,18 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
     protected void collectInitializationErrors(List<Throwable> errors) {
         super.collectInitializationErrors(errors);
 
+        validatePublicConstructor(errors);
         validateNoNonStaticInnerClass(errors);
         validateConstructor(errors);
         validateInstanceMethods(errors);
         validateFields(errors);
         validateMethods(errors);
+    }
+
+    private void validatePublicConstructor(List<Throwable> errors) {
+        if (getTestClass().getJavaClass() != null) {
+            errors.addAll(PUBLIC_CLASS_VALIDATOR.validateTestClass(getTestClass()));
+        }
     }
 
     protected void validateNoNonStaticInnerClass(List<Throwable> errors) {

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -40,7 +40,6 @@ import org.junit.runners.model.RunnerScheduler;
 import org.junit.runners.model.Statement;
 import org.junit.runners.model.TestClass;
 import org.junit.validator.AnnotationsValidator;
-import org.junit.validator.PublicClassValidator;
 import org.junit.validator.TestClassValidator;
 
 /**
@@ -58,8 +57,8 @@ import org.junit.validator.TestClassValidator;
  */
 public abstract class ParentRunner<T> extends Runner implements Filterable,
         Sortable {
-    private static final List<TestClassValidator> VALIDATORS = Arrays.asList(
-            new AnnotationsValidator(), new PublicClassValidator());
+    private static final List<TestClassValidator> VALIDATORS = Arrays.<TestClassValidator>asList(
+            new AnnotationsValidator());
 
     private final Object childrenLock = new Object();
     private final TestClass testClass;

--- a/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
@@ -1,7 +1,6 @@
 package org.junit.tests.running.classes;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -137,6 +136,9 @@ public class ParentRunnerTest {
     static class NonPublicTestClass {
         public NonPublicTestClass() {
         }
+
+        @Test
+        public void alwaysPasses() {}
     }
 
     @Test

--- a/src/test/java/org/junit/tests/running/classes/SuiteTest.java
+++ b/src/test/java/org/junit/tests/running/classes/SuiteTest.java
@@ -1,5 +1,6 @@
 package org.junit.tests.running.classes;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -41,6 +42,18 @@ public class SuiteTest {
     public static class All {
     }
 
+    @RunWith(Suite.class)
+    @SuiteClasses(TestA.class)
+    static class NonPublicSuite {
+    }
+
+    @RunWith(Suite.class)
+    @SuiteClasses(TestA.class)
+    static class NonPublicSuiteWithBeforeClass {
+        @BeforeClass
+        public static void doesNothing() {}
+    }
+
     public static class InheritsAll extends All {
     }
 
@@ -64,6 +77,19 @@ public class SuiteTest {
     public void suiteTestCountIsCorrect() throws Exception {
         Runner runner = Request.aClass(All.class).getRunner();
         assertEquals(2, runner.testCount());
+    }
+
+    @Test
+    public void suiteClassDoesNotNeedToBePublic() {
+        JUnitCore core = new JUnitCore();
+        Result result = core.run(NonPublicSuite.class);
+        assertEquals(1, result.getRunCount());
+        assertEquals(0, result.getFailureCount());
+    }
+
+    @Test
+    public void nonPublicSuiteClassWithBeforeClassFailsWithoutRunningTests() {
+        assertThat(testResult(NonPublicSuiteWithBeforeClass.class), hasSingleFailureContaining("can not access"));
     }
 
     @Test


### PR DESCRIPTION
This fixes a regression in JUnit 4.12.