### PR TITLE
Fixed failing tests when running build on Windows.

### DIFF
--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -20,7 +20,6 @@ import org.junit.Test;
  */
 public class TemporaryFolderUsageTest {
 
-    public static final String ROOT_PATH = File.listRoots()[0].getAbsolutePath();
     private TemporaryFolder tempFolder;
 
     @Rule
@@ -90,6 +89,7 @@ public class TemporaryFolderUsageTest {
         tempFolder.create();
         thrown.expect(IOException.class);
         thrown.expectMessage("folder name must be a relative path");
+        String ROOT_PATH = File.listRoots()[0].getAbsolutePath();
         tempFolder.newFolder(ROOT_PATH + "temp1");
     }
     

--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
  */
 public class TemporaryFolderUsageTest {
 
+    public static final String ROOT_PATH = File.listRoots()[0].getAbsolutePath();
     private TemporaryFolder tempFolder;
 
     @Rule
@@ -89,7 +90,7 @@ public class TemporaryFolderUsageTest {
         tempFolder.create();
         thrown.expect(IOException.class);
         thrown.expectMessage("folder name must be a relative path");
-        tempFolder.newFolder(File.separator + "temp1");
+        tempFolder.newFolder(ROOT_PATH + "temp1");
     }
     
     @Test

--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -86,12 +86,14 @@ public class TemporaryFolderUsageTest {
     @Test
     public void newFolderWithPathStartingWithFileSeparatorThrowsIOException()
             throws IOException {
-        File[] roots = File.listRoots();
-        if (roots == null || roots.length == 0) {
-            return;
+        File fileAtRoot;
+        File[] roots = File.listRoots();  
+        if (roots != null && roots.length > 0) {
+            fileAtRoot = new File(roots[0], "temp1");
+        } else {
+            fileAtRoot = new File(File.separator + "temp1");
         }
         tempFolder.create();
-        File fileAtRoot = new File(roots[0], "temp1");
         thrown.expect(IOException.class);
         thrown.expectMessage("folder name must be a relative path");
         tempFolder.newFolder(fileAtRoot.getAbsolutePath());

--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -86,11 +86,15 @@ public class TemporaryFolderUsageTest {
     @Test
     public void newFolderWithPathStartingWithFileSeparatorThrowsIOException()
             throws IOException {
+        File[] roots = File.listRoots();
+        if (roots == null || roots.length == 0) {
+            return;
+        }
         tempFolder.create();
+        File fileAtRoot = new File(roots[0], "temp1");
         thrown.expect(IOException.class);
         thrown.expectMessage("folder name must be a relative path");
-        String ROOT_PATH = File.listRoots()[0].getAbsolutePath();
-        tempFolder.newFolder(ROOT_PATH + "temp1");
+        tempFolder.newFolder(fileAtRoot.getAbsolutePath());
     }
     
     @Test

--- a/src/test/java/org/junit/tests/assertion/MultipleFailureExceptionTest.java
+++ b/src/test/java/org/junit/tests/assertion/MultipleFailureExceptionTest.java
@@ -27,6 +27,9 @@ import org.junit.runners.model.MultipleFailureException;
  */
 public class MultipleFailureExceptionTest {
 
+    public static final String LINE_SEPARATOR = System.getProperty("line.separator");
+
+
     @Test
     public void assertEmptyDoesNotThrowForEmptyList() throws Exception {
         MultipleFailureException.assertEmpty(Collections.<Throwable>emptyList());
@@ -67,8 +70,8 @@ public class MultipleFailureExceptionTest {
             fail();
         } catch (MultipleFailureException expected) {
             assertThat(expected.getFailures(), equalTo(errors));
-            assertTrue(expected.getMessage().startsWith("There were 2 errors:\n"));
-            assertTrue(expected.getMessage().contains("ExpectedException(basil)\n"));
+            assertTrue(expected.getMessage().startsWith("There were 2 errors:" + LINE_SEPARATOR));
+            assertTrue(expected.getMessage().contains("ExpectedException(basil)" + LINE_SEPARATOR));
             assertTrue(expected.getMessage().contains("RuntimeException(garlic)"));
         }
     }
@@ -96,7 +99,7 @@ public class MultipleFailureExceptionTest {
             fail();
         } catch (MultipleFailureException expected) {
             assertThat(expected.getFailures().size(), equalTo(2));
-            assertTrue(expected.getMessage().startsWith("There were 2 errors:\n"));
+            assertTrue(expected.getMessage().startsWith("There were 2 errors:" + LINE_SEPARATOR));
             assertTrue(expected.getMessage().contains("TestCouldNotBeSkippedException(Test could not be skipped"));
             assertTrue(expected.getMessage().contains("RuntimeException(garlic)"));
             Throwable first = expected.getFailures().get(0);


### PR DESCRIPTION
Note that File.separator is not sufficient to build an absolute path on windows.
String.format with "%n" (used in MultipleFailureException.getMessage()) produces a platform dependent line separator, i.e. not necessarily "/n";