### PR TITLE
Ignore bridge methods when scanning for annotated methods.

### DIFF
--- a/src/main/java/org/junit/runners/model/FrameworkField.java
+++ b/src/main/java/org/junit/runners/model/FrameworkField.java
@@ -41,6 +41,11 @@ public class FrameworkField extends FrameworkMember<FrameworkField> {
     }
 
     @Override
+    boolean isBridgeMethod() {
+        return false;
+    }
+
+    @Override
     protected int getModifiers() {
         return field.getModifiers();
     }

--- a/src/main/java/org/junit/runners/model/FrameworkMember.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMember.java
@@ -12,14 +12,28 @@ public abstract class FrameworkMember<T extends FrameworkMember<T>> implements
         Annotatable {
     abstract boolean isShadowedBy(T otherMember);
 
-    boolean isShadowedBy(List<T> members) {
-        for (T each : members) {
-            if (isShadowedBy(each)) {
-                return true;
+    T handlePossibleBridgeMethod(List<T> members) {
+        for (int i = members.size() - 1; i >=0; i--) {
+            T otherMember = members.get(i);
+            if (isShadowedBy(otherMember)) {
+                if (otherMember.isBridgeMethod()) {
+                    /*
+                     *  We need to return the previously-encountered bridge method
+                     *  because JUnit won't be able to call the parent method,
+                     *  because the parent class isn't public.
+                     */
+                    members.remove(i);
+                    return otherMember;
+                }
+                // We found a shadowed member that isn't a bridge method. Ignore it.
+                return null;
             }
         }
-        return false;
+        // No shadow or bridge method found. The caller should add *this* member.
+        return (T) this;
     }
+
+    abstract boolean isBridgeMethod();
 
     protected abstract int getModifiers();
 

--- a/src/main/java/org/junit/runners/model/FrameworkMethod.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMethod.java
@@ -149,6 +149,11 @@ public class FrameworkMethod extends FrameworkMember<FrameworkMethod> {
     }
 
     @Override
+    boolean isBridgeMethod() {
+        return method.isBridge();
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (!FrameworkMethod.class.isInstance(obj)) {
             return false;

--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -84,13 +84,14 @@ public class TestClass implements Annotatable {
         for (Annotation each : member.getAnnotations()) {
             Class<? extends Annotation> type = each.annotationType();
             List<T> members = getAnnotatedMembers(map, type, true);
-            if (member.isShadowedBy(members)) {
+            T memberToAdd = member.handlePossibleBridgeMethod(members);
+            if (memberToAdd == null) {
                 return;
             }
             if (runsTopToBottom(type)) {
-                members.add(0, member);
+                members.add(0, memberToAdd);
             } else {
-                members.add(member);
+                members.add(memberToAdd);
             }
         }
     }


### PR DESCRIPTION
This is one possible fix for #1411
The other possible fix is #1412