### PR TITLE
Update a sample in Javadoc for Timeout

### DIFF
--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
  * public static class HasGlobalLongTimeout {
  *
  *  &#064;Rule
- *  public Timeout globalTimeout = Timeout.millis(20);
+ *  public Timeout globalTimeout = Timeout.millis(20, TimeUnit.MILLISECONDS);
  *
  *  &#064;Test
  *  public void run1() throws InterruptedException {


### PR DESCRIPTION
This PR simply replaces the deprecated method in a sample in Javadoc for `Timeout`.