### PR TITLE
allow RuleChain construction by annotation: @Rule(priority=42)

### DIFF
--- a/src/main/java/org/junit/Rule.java
+++ b/src/main/java/org/junit/Rule.java
@@ -68,5 +68,12 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.FIELD, ElementType.METHOD})
 public @interface Rule {
+   /**
+    * Optionally specify <code>priority</code> for your TestRule.
+    * TestRules with non-negative priority will be autochained accordingly.
+    * Highest priority will be the most outer Rule.
+    * See also {@link org.junit.rules.RuleChain RuleChains} for more details.
+    */
+   int priority() default -1;
 
 }

--- a/src/main/java/org/junit/rules/SortRules.java
+++ b/src/main/java/org/junit/rules/SortRules.java
@@ -1,0 +1,86 @@
+package org.junit.rules;
+
+import static org.junit.rules.RuleChain.emptyRuleChain;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/*
+ * Stores a list of TestRule-priorities-pairs
+ * and can return a lists of all TestRules
+ * as well as a list containing the autoconstructed RuleChain.
+ */
+public class SortRules {
+    private final List<RulePriorityPair> rules = new ArrayList<RulePriorityPair>();
+
+    /*
+     * Adds a TestRulePriorityPair into the List.
+     * @param rule: the TestRule to be added to SortRules
+     * @param priority: the annotated priority of the TestRule
+     */
+    public void add(TestRule rule, int priority) {
+        rules.add(new RulePriorityPair(rule,priority));
+    }
+
+    /*
+     * Returns the a list of all the stored TestRules in insertion order.
+     * @return A list of TestRules in the order of their insertion.
+     */
+    public List<TestRule> listWithAllRules() {
+        List<TestRule> result = new ArrayList<TestRule>(rules.size());
+        for (RulePriorityPair rule : rules) {
+            result.add(rule.testRule);
+        }
+        return result;
+    }
+
+    /*
+     * Construct a list of all TestRules with negative priorities
+     * plus a autoconstructed RuleChain containing all TestRules with non-negative priorities.
+     * The TestRules of the RuleChain are sorted in such a way
+     * that the TestRule with the highest priority becomes the most outer TestRule.
+     */
+    public List<TestRule> listWithAutoconstructedRuleChain() {
+        List<TestRule> sortedRules = new ArrayList<TestRule>();
+        Integer[] index = new Integer[rules.size()];
+        for( int i = 0 ; i < index.length; i++ ) {
+            index[i] = i;
+        }
+        Arrays.sort(index, new Comparator<Integer>() {
+            public int compare(Integer i1, Integer i2) {
+                return rules.get(i1).compareTo(rules.get(i2));
+            }
+        });
+        RuleChain chain = emptyRuleChain();
+        for( int i: index) {
+            if (rules.get(i).priority >= 0) {
+                chain = chain.around(rules.get(i).testRule);
+            } else {
+                sortedRules.add(rules.get(i).testRule);
+            }
+        }
+        if (!chain.equals(emptyRuleChain())) {
+            sortedRules.add(chain);
+        }
+        return sortedRules;
+    }
+
+    private class RulePriorityPair implements Comparable<RulePriorityPair>{
+        private final TestRule testRule;
+        private final int      priority;
+
+        private RulePriorityPair(TestRule testRule, int priority) {
+            this.testRule = testRule;
+            this.priority = priority;
+        }
+
+        public int compareTo(RulePriorityPair o) {
+            if (this.priority < 0 && o.priority < 0) {
+                return 0;
+            }
+            return o.priority - this.priority;
+        }
+    }
+}

--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -227,42 +227,64 @@ public class TestClass implements Annotatable {
             Class<? extends Annotation> annotationClass, Class<T> valueClass) {
         List<T> results = new ArrayList<T>();
         for (FrameworkField each : getAnnotatedFields(annotationClass)) {
-            try {
-                Object fieldValue = each.get(test);
-                if (valueClass.isInstance(fieldValue)) {
-                    results.add(valueClass.cast(fieldValue));
-                }
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(
-                        "How did getFields return a field we couldn't access?", e);
-            }
+            T result = castField(test, each, annotationClass,valueClass);
+            if (result != null) results.add(result);
         }
         return results;
+    }
+
+    /*
+     * Returns an object of type T that is defined by a FrameworkField and an annotation
+     */
+    public <T> T castField(Object test, FrameworkField field,
+            Class<? extends Annotation> annotationClass, Class<T> valueClass) {
+        T result = null;
+        try {
+            Object fieldValue = field.get(test);
+            if (valueClass.isInstance(fieldValue)) {
+                result = valueClass.cast(fieldValue);
+            }
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(
+                    "How did getFields return a field we couldn't access?", e);
+        }
+        return result;
     }
 
     public <T> List<T> getAnnotatedMethodValues(Object test,
             Class<? extends Annotation> annotationClass, Class<T> valueClass) {
         List<T> results = new ArrayList<T>();
         for (FrameworkMethod each : getAnnotatedMethods(annotationClass)) {
-            try {
-                /*
-                 * A method annotated with @Rule may return a @TestRule or a @MethodRule,
-                 * we cannot call the method to check whether the return type matches our
-                 * expectation i.e. subclass of valueClass. If we do that then the method 
-                 * will be invoked twice and we do not want to do that. So we first check
-                 * whether return type matches our expectation and only then call the method
-                 * to fetch the MethodRule
-                 */
-                if (valueClass.isAssignableFrom(each.getReturnType())) {
-                    Object fieldValue = each.invokeExplosively(test);
-                    results.add(valueClass.cast(fieldValue));
-                }
-            } catch (Throwable e) {
-                throw new RuntimeException(
-                        "Exception in " + each.getName(), e);
-            }
+            T result = castMethod(test, each, annotationClass, valueClass);
+            if (result != null) results.add(result);
         }
         return results;
+    }
+
+    /*
+     * Returns an object of type T that is defined by a FrameworkMethod and an annotation.
+     */
+    public <T> T castMethod(Object test, FrameworkMethod method,
+            Class<? extends Annotation> annotationClass, Class<T> valueClass) {
+        T result = null;
+        try {
+            /*
+             * A method annotated with @Rule may return a @TestRule or a @MethodRule,
+             * we cannot call the method to check whether the return type matches our
+             * expectation i.e. subclass of valueClass. If we do that then the method
+             * will be invoked twice and we do not want to do that. So we first check
+             * whether return type matches our expectation and only then call the method
+             * to fetch the MethodRule
+             */
+            if (valueClass.isAssignableFrom(method.getReturnType())) {
+                Object fieldValue = method.invokeExplosively(test);
+                result = valueClass.cast(fieldValue);
+            }
+        } catch (Throwable e) {
+            throw new RuntimeException(
+                    "Exception in " + method.getName(), e);
+        }
+        return result;
     }
 
     public boolean isPublic() {

--- a/src/test/java/org/junit/rules/AllRulesTests.java
+++ b/src/test/java/org/junit/rules/AllRulesTests.java
@@ -15,6 +15,7 @@ import org.junit.runners.Suite.SuiteClasses;
         NameRulesTest.class,
         RuleChainTest.class,
         RuleMemberValidatorTest.class,
+        SortRulesTest.class,
         StopwatchTest.class,
         TempFolderRuleTest.class,
         TemporaryFolderRuleAssuredDeletionTest.class,

--- a/src/test/java/org/junit/rules/BlockJUnit4ClassRunnerOverrideTest.java
+++ b/src/test/java/org/junit/rules/BlockJUnit4ClassRunnerOverrideTest.java
@@ -68,14 +68,13 @@ public class BlockJUnit4ClassRunnerOverrideTest {
         }
 
         @Override
-        protected List<TestRule> getTestRules(final Object test) {
-            final LinkedList<TestRule> methodRules = new LinkedList<TestRule>(
-                    super.getTestRules(test));
+        protected SortRules getTestRules(final Object test) {
+            final SortRules methodRules = super.getTestRules(test);
             methodRules.add(new TestRule() {
                 public Statement apply(Statement base, Description description) {
                     return new FlipBitRule().apply(base, null, test);
                 }
-            });
+            },-1);
             return methodRules;
         }
     }

--- a/src/test/java/org/junit/rules/SortRulesTest.java
+++ b/src/test/java/org/junit/rules/SortRulesTest.java
@@ -1,0 +1,133 @@
+package org.junit.rules;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+import static org.junit.experimental.results.PrintableResult.testResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.junit.Rule;
+
+public class SortRulesTest {
+
+    private static final List<String> LOG = new ArrayList<String>();
+
+    @After
+    public void tearDown() {
+        LOG.clear();
+    }
+
+    private static class LoggingRule extends TestWatcher {
+        private final String label;
+
+        public LoggingRule(String label) {
+            this.label = label;
+        }
+
+        @Override
+        protected void starting(Description description) {
+            LOG.add("starting " + label);
+        }
+
+        @Override
+        protected void finished(Description description) {
+            LOG.add("finished " + label);
+        }
+    }
+
+    public static class IdentityRule implements TestRule {
+        public Statement apply(final Statement base, final Description description) {
+          return base;
+        }
+      }
+
+    @Test
+    public final void testSortListWithoutPriorities() {
+        SortRules testObject = new SortRules();
+        testObject.add(new IdentityRule(), -1);
+        List<TestRule> result = testObject.listWithAutoconstructedRuleChain();
+        //only the IdentityRule is inserted and not an empty RuleChain.
+        assertEquals(result.size(),1);
+        assertTrue(result.get(0) instanceof IdentityRule);
+    }
+
+    @Test
+    public final void testSortList() {
+        SortRules testObject = new SortRules();
+        testObject.add(new LoggingRule(""), 0);
+        testObject.add(new LoggingRule(""), 0);
+        testObject.add(new IdentityRule(), -2);
+        testObject.add(new IdentityRule(), -1);
+        List<TestRule> result = testObject.listWithAutoconstructedRuleChain();
+        //all LoggingRules are cained into a RuleChain
+        assertEquals(result.size(),3);
+        assertTrue(result.get(0) instanceof IdentityRule);
+        assertTrue(result.get(1) instanceof IdentityRule);
+        assertTrue(result.get(2) instanceof RuleChain);
+    }
+
+    public static class SortRulesIntoRuleChain {
+        @Rule(priority = 2)
+        public final TestRule rule2 = new LoggingRule("rule2");
+
+        @Rule(priority = 1)
+        public final TestRule rule1 = new LoggingRule("rule1");
+
+        @Rule
+        public final TestRule rule = new LoggingRule("withoutPriority");
+
+        @Rule(priority = 0)
+        public final TestRule rule0 = new LoggingRule("rule0");
+
+        @Rule(priority = 3)
+        public final TestRule rule3 = new LoggingRule("rule3");
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void testSortRulesIntoRuleChain() {
+        testResult(SortRulesIntoRuleChain.class);
+        List<String> expectedLog = asList(
+                "starting rule3","starting rule2", "starting rule1",
+                "starting rule0","starting withoutPriority",
+                "finished withoutPriority","finished rule0",
+                "finished rule1", "finished rule2","finished rule3"
+        );
+        assertEquals(expectedLog, LOG);
+    }
+
+    public static class SortRulesWithIdenticalPriorities {
+        @Rule(priority = 1)
+        public final TestRule rule11 = new LoggingRule("rule1");
+
+        @Rule(priority = 0)
+        public final TestRule rule0 = new LoggingRule("rule0");
+
+        @Rule(priority = 2)
+        public final TestRule rule2 = new LoggingRule("rule2");
+
+        @Rule(priority = 1)
+        public final TestRule rule12 = new LoggingRule("rule1");
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void testSortRulesWithIdenticalPriorities() {
+        testResult(SortRulesWithIdenticalPriorities.class);
+        List<String> expectedLog = asList("starting rule2",
+                "starting rule1", "starting rule1", "starting rule0",
+                "finished rule0", "finished rule1", "finished rule1",
+                "finished rule2");
+        assertEquals(expectedLog, LOG);
+    }
+}


### PR DESCRIPTION
This PR addresses #1221. 
This Feature is very similar to #1418 for Issue #1045

I extended the `@Rule` interface with an optional parameter for autoconstructing a `RuleChain` out of the annotated `TestRules`.
The parameter represents a priority and the order of the `RuleChain` will be accordingly.
Highest priority becomes most outer `TestRule` in `RuleChain`.
Negative priorities will be ignored and not put into the `RuleChain`.

For the implementation I introduced a new class `SortRules` in the rule package.
This class takes care of the actual sorting and `RuleChain`-construction.
Also a minor refactoring was necessary for the implementation.

In addition I added Tests to check the functionality of the implementation.

Please let me know what you think about this Implementation and if it is any useful for the project.

This Issue was part of a project in university. Two other classmates worked on JUnit as well.
You can check their PR at #1418 and #xxxx.