### PR TITLE
Allow RuleChain building by @Rule(around="rule")

### DIFF
--- a/src/main/java/org/junit/Rule.java
+++ b/src/main/java/org/junit/Rule.java
@@ -69,4 +69,10 @@ import java.lang.annotation.Target;
 @Target({ElementType.FIELD, ElementType.METHOD})
 public @interface Rule {
 
+    /**
+     * Optionally specify <code>around</code>, the name of a TestRule,
+     * to chain the annotated TestRule around the specified TestRule.
+     * See also {@link org.junit.rules.RuleChain RuleChains} for more details.
+     */
+    String around() default "";
 }

--- a/src/main/java/org/junit/rules/SortRules.java
+++ b/src/main/java/org/junit/rules/SortRules.java
@@ -1,0 +1,112 @@
+package org.junit.rules;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/*
+ * Stores TestRules with their names and annotated around parameters
+ * and can return them in the order specified by the around parameters.
+ */
+public class SortRules {
+    private final Map<String,SortRule> rules = new LinkedHashMap<String,SortRule>();
+
+    /*
+     * Adds a TestRule with its name and around parameter to SortRules.
+     * @param rule: the TestRule to be added to SortRules
+     * @param name: the name of the TestRule
+     * @param around: the annotated around parameter of the TestRule
+     */
+    public void add(TestRule rule, String name, String around) {
+        if (around.equals(name)) {
+            throw new RuntimeException("Rule '" + name + "' has itself as around value");
+        }
+        rules.put(name, new SortRule(rule, name, around));
+    }
+
+    /*
+     * Returns the stored rules in insertion order.
+     * @return A list of TestRules in the order of their insertion.
+     */
+    public List<TestRule> unsortedRules() {
+        List<TestRule> result = new ArrayList<TestRule>();
+        for (SortRule rule : rules.values()) result.add(rule.testRule);
+        return result;
+    }
+
+    /*
+     * Returns the stored TestRules in the order specified by their around parameters.
+     * All TestRules annotated with or referenced by an around parameter are
+     * returned inside one single RuleChain inside this list which ensures ordering.
+     */
+    public List<TestRule> sortedAndChainedRules() {
+        List<TestRule>       sortedRules = new ArrayList<TestRule>(rules.size());
+        Map<String,SortRule> rulesCopy   = new LinkedHashMap<String,SortRule>(rules);
+        Set<String>          removeMe    = new HashSet<String>();
+        List<String>         arounds     = new ArrayList<String>();
+        for (SortRule rule : rulesCopy.values()) arounds.add(rule.around);
+
+        for (SortRule rule : rulesCopy.values()) {
+            int pointers = Collections.frequency(arounds, rule.name);
+            if (pointers == 0 && rule.around.equals("")) {
+                sortedRules.add(rule.testRule);
+                removeMe.add(rule.name);
+            } else {
+                if (!rule.around.equals("") && !rulesCopy.containsKey(rule.around)) {
+                    throw new RuntimeException("The around value '"
+                                               + rule.around
+                                               + "' doesn't specify a given TestRule.");
+                }
+                rule.pointAtMe = pointers;
+            }
+        }
+        removeAll(rulesCopy,removeMe);
+
+        RuleChain ruleChain = RuleChain.emptyRuleChain();
+        while (!rulesCopy.isEmpty()) {
+            boolean containsCycle = true;
+            for (SortRule rule : rulesCopy.values()) {
+                if (rule.pointAtMe == 0) {
+                    containsCycle = false;
+                    ruleChain     = ruleChain.around(rule.testRule);
+                    rule.decrementPointAtMeOfMyAround(rulesCopy);
+                    removeMe.add(rule.name);
+                }
+            }
+            if (containsCycle) throw new RuntimeException("Rules are chained cyclic.");
+            removeAll(rulesCopy,removeMe);
+        }
+        sortedRules.add(ruleChain);
+
+        return sortedRules;
+    }
+
+    private void removeAll(Map<String,SortRule> rules, Set<String> removeMe) {
+        for (String name : removeMe) rules.remove(name);
+        removeMe.clear();
+    }
+
+    private class SortRule {
+        private final TestRule testRule;
+        private final String   name;
+        private final String   around;
+        private       int      pointAtMe;
+
+        private SortRule(TestRule testRule, String name, String around) {
+            this.testRule  = testRule;
+            this.name      = name;
+            this.around    = around;
+            this.pointAtMe = 0;
+        }
+
+        private void decrementPointAtMeOfMyAround(Map<String,SortRule> rules) {
+            if (!around.equals("") && rules.containsKey(around)) {
+                rules.get(around).pointAtMe -= 1;
+            }
+        }
+    }
+}

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -23,9 +23,11 @@ import org.junit.internal.runners.statements.RunAfters;
 import org.junit.internal.runners.statements.RunBefores;
 import org.junit.rules.MethodRule;
 import org.junit.rules.RunRules;
+import org.junit.rules.SortRules;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.FrameworkField;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.MultipleFailureException;
@@ -372,10 +374,10 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 
     private Statement withRules(FrameworkMethod method, Object target,
             Statement statement) {
-        List<TestRule> testRules = getTestRules(target);
+        SortRules testRules = getTestRules(target);
         Statement result = statement;
-        result = withMethodRules(method, testRules, target, result);
-        result = withTestRules(method, testRules, result);
+        result = withMethodRules(method, testRules.unsortedRules(), target, result);
+        result = withTestRules(method, testRules.sortedAndChainedRules(), result);
 
         return result;
     }
@@ -425,16 +427,30 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
     }
 
     /**
+     * Returns a SortRules object containing all TestRules of the target.
+     * Additionally to the rules, their names and around parameters are stored.
+     *
      * @param target the test case instance
-     * @return a list of TestRules that should be applied when executing this
-     *         test
+     * @return a SortRules object containing all TestRules of the target
      */
-    protected List<TestRule> getTestRules(Object target) {
-        List<TestRule> result = getTestClass().getAnnotatedMethodValues(target,
-                Rule.class, TestRule.class);
+    protected SortRules getTestRules(Object target) {
+        List<FrameworkMethod>  methods = getTestClass().getAnnotatedMethods(Rule.class);
+        List<FrameworkField>   fields  = getTestClass().getAnnotatedFields(Rule.class);
+        SortRules          result  = new SortRules();
 
-        result.addAll(getTestClass().getAnnotatedFieldValues(target,
-                Rule.class, TestRule.class));
+        for (FrameworkMethod method : methods) {
+            TestRule rule = getTestClass().castMethod(target, method, Rule.class, TestRule.class);
+            if (rule != null) {
+                result.add(rule, method.getName(), method.getAnnotation(Rule.class).around());
+            }
+        }
+
+        for (FrameworkField field : fields) {
+            TestRule rule = getTestClass().castField(target, field, Rule.class, TestRule.class);
+            if (rule != null) {
+                result.add(rule, field.getName(), field.getAnnotation(Rule.class).around());
+            }
+        }
 
         return result;
     }

--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -227,42 +227,66 @@ public class TestClass implements Annotatable {
             Class<? extends Annotation> annotationClass, Class<T> valueClass) {
         List<T> results = new ArrayList<T>();
         for (FrameworkField each : getAnnotatedFields(annotationClass)) {
-            try {
-                Object fieldValue = each.get(test);
-                if (valueClass.isInstance(fieldValue)) {
-                    results.add(valueClass.cast(fieldValue));
-                }
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(
-                        "How did getFields return a field we couldn't access?", e);
-            }
+            T result = castField(test, each, annotationClass, valueClass);
+            if (result != null) results.add(result);
         }
         return results;
+    }
+
+    /*
+     * Returns an object of type T that is defined by a FrameworkField
+     * and an annotation.
+     */
+    public <T> T castField(Object test, FrameworkField field,
+            Class<? extends Annotation> annotationClass, Class<T> valueClass) {
+        T result = null;
+        try {
+            Object fieldValue = field.get(test);
+            if (valueClass.isInstance(fieldValue)) {
+                result = valueClass.cast(fieldValue);
+            }
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(
+                    "How did getFields return a field we couldn't access?", e);
+        }
+        return result;
     }
 
     public <T> List<T> getAnnotatedMethodValues(Object test,
             Class<? extends Annotation> annotationClass, Class<T> valueClass) {
         List<T> results = new ArrayList<T>();
         for (FrameworkMethod each : getAnnotatedMethods(annotationClass)) {
-            try {
-                /*
-                 * A method annotated with @Rule may return a @TestRule or a @MethodRule,
-                 * we cannot call the method to check whether the return type matches our
-                 * expectation i.e. subclass of valueClass. If we do that then the method 
-                 * will be invoked twice and we do not want to do that. So we first check
-                 * whether return type matches our expectation and only then call the method
-                 * to fetch the MethodRule
-                 */
-                if (valueClass.isAssignableFrom(each.getReturnType())) {
-                    Object fieldValue = each.invokeExplosively(test);
-                    results.add(valueClass.cast(fieldValue));
-                }
-            } catch (Throwable e) {
-                throw new RuntimeException(
-                        "Exception in " + each.getName(), e);
-            }
+            T result = castMethod(test, each, annotationClass, valueClass);
+            if (result != null) results.add(result);
         }
         return results;
+    }
+
+    /*
+     * Returns an object of type T that is defined by a FrameworkMethod
+     * and an annotation.
+     */
+    public <T> T castMethod(Object test, FrameworkMethod method,
+            Class<? extends Annotation> annotationClass, Class<T> valueClass) {
+        T result = null;
+        try {
+            /*
+             * A method annotated with @Rule may return a @TestRule or a @MethodRule,
+             * we cannot call the method to check whether the return type matches our
+             * expectation i.e. subclass of valueClass. If we do that then the method
+             * will be invoked twice and we do not want to do that. So we first check
+             * whether return type matches our expectation and only then call the method
+             * to fetch the MethodRule
+             */
+            if (valueClass.isAssignableFrom(method.getReturnType())) {
+                Object fieldValue = method.invokeExplosively(test);
+                result = valueClass.cast(fieldValue);
+            }
+        } catch (Throwable e) {
+            throw new RuntimeException(
+                    "Exception in " + method.getName(), e);
+        }
+        return result;
     }
 
     public boolean isPublic() {

--- a/src/test/java/org/junit/rules/AllRulesTests.java
+++ b/src/test/java/org/junit/rules/AllRulesTests.java
@@ -15,6 +15,7 @@ import org.junit.runners.Suite.SuiteClasses;
         NameRulesTest.class,
         RuleChainTest.class,
         RuleMemberValidatorTest.class,
+        SortRulesTest.class,
         StopwatchTest.class,
         TempFolderRuleTest.class,
         TemporaryFolderRuleAssuredDeletionTest.class,

--- a/src/test/java/org/junit/rules/BlockJUnit4ClassRunnerOverrideTest.java
+++ b/src/test/java/org/junit/rules/BlockJUnit4ClassRunnerOverrideTest.java
@@ -68,14 +68,13 @@ public class BlockJUnit4ClassRunnerOverrideTest {
         }
 
         @Override
-        protected List<TestRule> getTestRules(final Object test) {
-            final LinkedList<TestRule> methodRules = new LinkedList<TestRule>(
-                    super.getTestRules(test));
+        protected SortRules getTestRules(final Object test) {
+            final SortRules methodRules = super.getTestRules(test);
             methodRules.add(new TestRule() {
                 public Statement apply(Statement base, Description description) {
                     return new FlipBitRule().apply(base, null, test);
                 }
-            });
+            },"flipBit","");
             return methodRules;
         }
     }

--- a/src/test/java/org/junit/rules/SortRulesTest.java
+++ b/src/test/java/org/junit/rules/SortRulesTest.java
@@ -1,0 +1,383 @@
+package org.junit.rules;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+import static org.junit.experimental.results.PrintableResult.testResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+public class SortRulesTest {
+    private static final List<String> LOG = new ArrayList<String>();
+
+    private static class LoggingRule extends TestWatcher {
+        private final String label;
+
+        public LoggingRule(String label) {
+            this.label = label;
+        }
+
+        @Override
+        protected void starting(Description description) {
+            LOG.add("starting " + label);
+        }
+
+        @Override
+        protected void finished(Description description) {
+            LOG.add("finished " + label);
+        }
+    }
+
+    @After
+    public void tearDown() {
+        LOG.clear();
+    }
+
+    private String getExceptionMessage(Result result) {
+        return result.getFailures().get(0).getException().getMessage();
+    }
+
+    public static class RuleHasNonExistentAroundValue {
+        @Rule(around="foo")
+        public final TestRule rule = RuleChain.emptyRuleChain();
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void throwExceptionWhenRuleHasNonExistentAroundValue() {
+        Result result = new JUnitCore().run(RuleHasNonExistentAroundValue.class);
+
+        assertThat(result.getFailures().size(), equalTo(1));
+        assertThat(getExceptionMessage(result),
+                   equalTo("The around value 'foo' doesn't specify a given TestRule."));
+    }
+
+    public static class RuleHasSelfAsAroundValue {
+        @Rule(around="test")
+        public final TestRule test = RuleChain.emptyRuleChain();
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void throwExceptionWhenRuleHasSelfAsAroundValue() {
+        Result result = new JUnitCore().run(RuleHasSelfAsAroundValue.class);
+
+        assertThat(result.getFailures().size(), equalTo(1));
+        assertThat(getExceptionMessage(result),
+                   equalTo("Rule 'test' has itself as around value"));
+    }
+
+    public static class RulesAreChainedCyclic {
+        //Cycle
+        @Rule(around="ruleB")
+        public final TestRule ruleA = RuleChain.emptyRuleChain();
+
+        @Rule(around="ruleC")
+        public final TestRule ruleB = RuleChain.emptyRuleChain();
+
+        @Rule(around="ruleD")
+        public final TestRule ruleC = RuleChain.emptyRuleChain();
+
+        @Rule(around="ruleE")
+        public final TestRule ruleD = RuleChain.emptyRuleChain();
+
+        @Rule(around="ruleA")
+        public final TestRule ruleE = RuleChain.emptyRuleChain();
+
+        //RuleChain pointing to member of cycle
+        @Rule(around="ruleY")
+        public final TestRule ruleZ = RuleChain.emptyRuleChain();
+
+        @Rule(around="ruleX")
+        public final TestRule ruleY = RuleChain.emptyRuleChain();
+
+        @Rule(around="rulePointingToCycle")
+        public final TestRule ruleX = RuleChain.emptyRuleChain();
+
+        @Rule(around="ruleC")
+        public final TestRule rulePointingToCycle = RuleChain.emptyRuleChain();
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void throwExceptionWhenRulesAreChainedCyclic() {
+        Result result = new JUnitCore().run(RulesAreChainedCyclic.class);
+
+        assertThat(result.getFailures().size(), equalTo(1));
+        assertThat(getExceptionMessage(result),
+                   equalTo("Rules are chained cyclic."));
+    }
+
+    public static class ExampleMethodRule implements MethodRule {
+
+        public Statement apply(Statement base, FrameworkMethod method,
+                Object target) {
+            return base;
+        }
+    }
+
+    public static class RuleAnnotatedToBeChainedAroundMethodRule {
+        @Rule
+        public final MethodRule methodRule = new ExampleMethodRule();
+
+        @Rule(around="methodRule")
+        public final TestRule rule = RuleChain.emptyRuleChain();
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void throwExceptionWhenRuleIsToBeChainedAroundMethodRule() {
+        Result result = new JUnitCore().run(RuleAnnotatedToBeChainedAroundMethodRule.class);
+
+        assertThat(result.getFailures().size(), equalTo(1));
+        assertThat(getExceptionMessage(result),
+                   equalTo("The around value 'methodRule' doesn't specify a given TestRule."));
+    }
+
+    public static class UseSingleRuleChainConstructedByAnnotation {
+        @Rule(around="outerRule")
+        public final TestRule outerOuterRule = new LoggingRule("outerOuter rule");
+
+        @Rule(around="middleRule")
+        public final TestRule outerRule = new LoggingRule("outer rule");
+
+        @Rule(around="innerRule")
+        public final TestRule middleRule = new LoggingRule("middle rule");
+
+        @Rule(around="innerInnerRule")
+        public final TestRule innerRule = new LoggingRule("inner rule");
+
+        @Rule
+        public final TestRule innerInnerRule = new LoggingRule("innerInner rule");
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void executeRulesChainedByAnnotationInCorrectOrder() {
+        testResult(UseSingleRuleChainConstructedByAnnotation.class);
+        List<String> expectedLog = asList("starting outerOuter rule", "starting outer rule",
+                "starting middle rule", "starting inner rule", "starting innerInner rule",
+                "finished innerInner rule", "finished inner rule", "finished middle rule",
+                "finished outer rule", "finished outerOuter rule");
+        assertEquals(expectedLog, LOG);
+    }
+
+    public static class UseSingleRuleChainConstructedByAnnotationAmbiguously {
+        @Rule(around="middleRule123")
+        public final TestRule outerRule1 = new LoggingRule("outer rule");
+
+        @Rule(around="middleRule123")
+        public final TestRule outerRule2 = new LoggingRule("outer rule");
+
+        @Rule(around="middleRule123")
+        public final TestRule outerRule3 = new LoggingRule("outer rule");
+
+        @Rule(around="innerRule123")
+        public final TestRule middleRule123 = new LoggingRule("middle rule");
+
+        @Rule
+        public final TestRule innerRule123 = new LoggingRule("inner rule");
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void executeRulesChainedByAnnotationAmbiguouslyInCorrectOrder() {
+        testResult(UseSingleRuleChainConstructedByAnnotationAmbiguously.class);
+        List<String> expectedLog = asList("starting outer rule",
+                "starting outer rule", "starting outer rule", "starting middle rule",
+                "starting inner rule", "finished inner rule", "finished middle rule",
+                "finished outer rule", "finished outer rule", "finished outer rule");
+        assertTrue(LOG.equals(expectedLog));
+    }
+
+    public static class UseTwoIndependentRuleChainsConstructedByAnnotation {
+        @Rule(around="middleRuleA")
+        public final TestRule outerRuleA = new LoggingRule("outer rule A");
+
+        @Rule(around="innerRuleA")
+        public final TestRule middleRuleA = new LoggingRule("middle rule A");
+
+        @Rule
+        public final TestRule innerRuleA = new LoggingRule("inner rule A");
+
+        @Rule(around="middleRuleB")
+        public final TestRule outerRuleB = new LoggingRule("outer rule B");
+
+        @Rule(around="innerRuleB")
+        public final TestRule middleRuleB = new LoggingRule("middle rule B");
+
+        @Rule
+        public final TestRule innerRuleB = new LoggingRule("inner rule B");
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void executeRulesChainedByAnnotationInIndependentRuleChains() {
+        testResult(UseTwoIndependentRuleChainsConstructedByAnnotation.class);
+        String startingOuterA  = "starting outer rule A";
+        String startingMiddleA = "starting middle rule A";
+        String startingInnerA  = "starting inner rule A";
+        String finishedInnerA  = "finished inner rule A";
+        String finishedMiddleA = "finished middle rule A";
+        String finishedOuterA  = "finished outer rule A";
+        String startingOuterB  = "starting outer rule B";
+        String startingMiddleB = "starting middle rule B";
+        String startingInnerB  = "starting inner rule B";
+        String finishedInnerB  = "finished inner rule B";
+        String finishedMiddleB = "finished middle rule B";
+        String finishedOuterB  = "finished outer rule B";
+
+        assertEquals(12,LOG.size());
+        assertTrue(LOG.indexOf(startingOuterA) < LOG.indexOf(startingMiddleA));
+        assertTrue(LOG.indexOf(startingMiddleA) < LOG.indexOf(startingInnerA));
+        assertTrue(LOG.indexOf(finishedInnerA) < LOG.indexOf(finishedMiddleA));
+        assertTrue(LOG.indexOf(finishedMiddleA) < LOG.indexOf(finishedOuterA));
+        assertTrue(LOG.indexOf(startingOuterB) < LOG.indexOf(startingMiddleB));
+        assertTrue(LOG.indexOf(startingMiddleB) < LOG.indexOf(startingInnerB));
+        assertTrue(LOG.indexOf(finishedInnerB) < LOG.indexOf(finishedMiddleB));
+        assertTrue(LOG.indexOf(finishedMiddleB) < LOG.indexOf(finishedOuterB));
+    }
+
+    public static class UseAllValidRuleChainsCombined {
+        //simple case
+        @Rule(around="outerRule")
+        public final TestRule outerOuterRule = new LoggingRule("outerOuter rule");
+
+        @Rule(around="middleRule")
+        public final TestRule outerRule = new LoggingRule("outer rule");
+
+        @Rule(around="innerRule")
+        public final TestRule middleRule = new LoggingRule("middle rule");
+
+        @Rule(around="innerInnerRule")
+        public final TestRule innerRule = new LoggingRule("inner rule");
+
+        @Rule
+        public final TestRule innerInnerRule = new LoggingRule("innerInner rule");
+
+        //constructed ambiguously (two rules have the same around value)
+        @Rule(around="middleRule123")
+        public final TestRule outerRule1 = new LoggingRule("outer rule 123");
+
+        @Rule(around="middleRule123")
+        public final TestRule outerRule2 = new LoggingRule("outer rule 123");
+
+        @Rule(around="middleRule123")
+        public final TestRule outerRule3 = new LoggingRule("outer rule 123");
+
+        @Rule(around="innerRule123")
+        public final TestRule middleRule123 = new LoggingRule("middle rule 123");
+
+        @Rule
+        public final TestRule innerRule123 = new LoggingRule("inner rule 123");
+
+        //two independent RuleChains
+        @Rule(around="middleRuleA")
+        public final TestRule outerRuleA = new LoggingRule("outer rule A");
+
+        @Rule(around="innerRuleA")
+        public final TestRule middleRuleA = new LoggingRule("middle rule A");
+
+        @Rule
+        public final TestRule innerRuleA = new LoggingRule("inner rule A");
+
+        @Rule(around="middleRuleB")
+        public final TestRule outerRuleB = new LoggingRule("outer rule B");
+
+        @Rule(around="innerRuleB")
+        public final TestRule middleRuleB = new LoggingRule("middle rule B");
+
+        @Rule
+        public final TestRule innerRuleB = new LoggingRule("inner rule B");
+
+        @Test
+        public void example() {}
+    }
+
+    @Test
+    public void executeComplexlyCombinedRulesInCorrectOrder() {
+        testResult(UseAllValidRuleChainsCombined.class);
+
+        String startingOuterOuter = "starting outerOuter rule";
+        String startingOuter      = "starting outer rule";
+        String startingMiddle     = "starting middle rule";
+        String startingInner      = "starting inner rule";
+        String startingInnerInner = "starting innerInner rule";
+        String finishedOuterOuter = "finished outerOuter rule";
+        String finishedOuter      = "finished outer rule";
+        String finishedMiddle     = "finished middle rule";
+        String finishedInner      = "finished inner rule";
+        String finishedInnerInner = "finished innerInner rule";
+
+        String startingOuter123 = "starting outer rule 123";
+        String startingMiddle123 = "starting middle rule 123";
+        String startingInner123 = "starting inner rule 123";
+        String finishedInner123 = "finished inner rule 123";
+        String finishedMiddle123 = "finished middle rule 123";
+        String finishedOuter123 = "finished outer rule 123";
+
+        String startingOuterA  = "starting outer rule A";
+        String startingMiddleA = "starting middle rule A";
+        String startingInnerA  = "starting inner rule A";
+        String finishedInnerA  = "finished inner rule A";
+        String finishedMiddleA = "finished middle rule A";
+        String finishedOuterA  = "finished outer rule A";
+        String startingOuterB  = "starting outer rule B";
+        String startingMiddleB = "starting middle rule B";
+        String startingInnerB  = "starting inner rule B";
+        String finishedInnerB  = "finished inner rule B";
+        String finishedMiddleB = "finished middle rule B";
+        String finishedOuterB  = "finished outer rule B";
+
+        assertEquals(32,LOG.size());
+
+        assertTrue(LOG.indexOf(startingOuterOuter) < LOG.indexOf(startingOuter));
+        assertTrue(LOG.indexOf(startingOuter) < LOG.indexOf(startingMiddle));
+        assertTrue(LOG.indexOf(startingMiddle) < LOG.indexOf(startingInner));
+        assertTrue(LOG.indexOf(startingInner) < LOG.indexOf(startingInnerInner));
+        assertTrue(LOG.indexOf(finishedInnerInner) < LOG.indexOf(finishedInner));
+        assertTrue(LOG.indexOf(finishedInner) < LOG.indexOf(finishedMiddle));
+        assertTrue(LOG.indexOf(finishedMiddle) < LOG.indexOf(finishedOuter));
+        assertTrue(LOG.indexOf(finishedOuter) < LOG.indexOf(finishedOuterOuter));
+
+        assertTrue(LOG.indexOf(startingOuter123) < LOG.indexOf(startingMiddle123));
+        assertTrue(LOG.indexOf(startingMiddle123) < LOG.indexOf(startingInner123));
+        assertTrue(LOG.indexOf(finishedInner123) < LOG.indexOf(finishedMiddle123));
+        assertTrue(LOG.indexOf(finishedMiddle123) < LOG.indexOf(finishedOuter123));
+
+        assertTrue(LOG.indexOf(startingOuterA) < LOG.indexOf(startingMiddleA));
+        assertTrue(LOG.indexOf(startingMiddleA) < LOG.indexOf(startingInnerA));
+        assertTrue(LOG.indexOf(finishedInnerA) < LOG.indexOf(finishedMiddleA));
+        assertTrue(LOG.indexOf(finishedMiddleA) < LOG.indexOf(finishedOuterA));
+        assertTrue(LOG.indexOf(startingOuterB) < LOG.indexOf(startingMiddleB));
+        assertTrue(LOG.indexOf(startingMiddleB) < LOG.indexOf(startingInnerB));
+        assertTrue(LOG.indexOf(finishedInnerB) < LOG.indexOf(finishedMiddleB));
+        assertTrue(LOG.indexOf(finishedMiddleB) < LOG.indexOf(finishedOuterB));
+    }
+}


### PR DESCRIPTION
This PR addresses #1045 and is similar to PR #1417, which attempts to resolve #1221.

I extended the `@Rule` interface with an around parameter as suggested. Then I added tests for the behaviour I expect from this feature. I did not implement and/or test the interaction with a superclass (this.\*, super.\*). The actual implementation introduces a new class `SortRules` to the rule package. It handles all `TestRules` of a test class and sorts them when the according method is called. A topological sorting algorithm is implemented, whose performance could possibly be further enhanced.

As I did not discuss the implementation with you before I started working on it, I could totally comprehend a rejection of this PR. Otherwise I am willing to adapt the PR to your wishes :)
I developed this feature implementation in the context of a university lecture on software evolution in collaboration with the lecturers and two classmates. The two classmates also worked on their own issues, you can find their PRs here: #1417, #xxxx (tba)