### PR TITLE
ExternalResource: declare after() to throw Exception

### DIFF
--- a/src/main/java/org/junit/rules/ExternalResource.java
+++ b/src/main/java/org/junit/rules/ExternalResource.java
@@ -78,9 +78,9 @@ public abstract class ExternalResource implements TestRule {
     /**
      * Override to tear down your specific external resource.
      *
-     * @throws Exception if teardown fails
+     * @throws Throwable if teardown fails
      */
-    protected void after() throws Exception {
+    protected void after() throws Throwable {
         // do nothing
     }
 }

--- a/src/main/java/org/junit/rules/ExternalResource.java
+++ b/src/main/java/org/junit/rules/ExternalResource.java
@@ -77,8 +77,10 @@ public abstract class ExternalResource implements TestRule {
 
     /**
      * Override to tear down your specific external resource.
+     *
+     * @throws Exception if teardown fails
      */
-    protected void after() {
+    protected void after() throws Exception {
         // do nothing
     }
 }


### PR DESCRIPTION
So that clients don't have to try-catch-and-rethrow explicitly checked exceptions.

You may not be happy with changing the signature, though :(