### PR TITLE
Support the selection of a default Runner in ClassRequest

### DIFF
--- a/src/main/java/org/junit/internal/builders/AllDefaultPossibilitiesBuilder.java
+++ b/src/main/java/org/junit/internal/builders/AllDefaultPossibilitiesBuilder.java
@@ -31,6 +31,7 @@ public class AllDefaultPossibilitiesBuilder extends RunnerBuilder {
                 annotatedBuilder(),
                 suiteMethodBuilder(),
                 junit3Builder(),
+                defaultBuilder(),
                 junit4Builder());
 
         for (RunnerBuilder each : builders) {
@@ -56,6 +57,10 @@ public class AllDefaultPossibilitiesBuilder extends RunnerBuilder {
 
     protected IgnoredBuilder ignoredBuilder() {
         return new IgnoredBuilder();
+    }
+
+    protected RunnerBuilder defaultBuilder() {
+        return new NullBuilder();
     }
 
     protected RunnerBuilder suiteMethodBuilder() {

--- a/src/main/java/org/junit/internal/builders/AnnotatedBuilder.java
+++ b/src/main/java/org/junit/internal/builders/AnnotatedBuilder.java
@@ -2,7 +2,6 @@ package org.junit.internal.builders;
 
 import org.junit.runner.RunWith;
 import org.junit.runner.Runner;
-import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.RunnerBuilder;
 
 import java.lang.reflect.Modifier;
@@ -69,8 +68,6 @@ import java.lang.reflect.Modifier;
  * @since 4.0
  */
 public class AnnotatedBuilder extends RunnerBuilder {
-    private static final String CONSTRUCTOR_ERROR_FORMAT = "Custom runner class %s should have a public constructor with signature %s(Class testClass)";
-
     private final RunnerBuilder suiteBuilder;
 
     public AnnotatedBuilder(RunnerBuilder suiteBuilder) {
@@ -83,7 +80,7 @@ public class AnnotatedBuilder extends RunnerBuilder {
              currentTestClass = getEnclosingClassForNonStaticMemberClass(currentTestClass)) {
             RunWith annotation = currentTestClass.getAnnotation(RunWith.class);
             if (annotation != null) {
-                return buildRunner(annotation.value(), testClass);
+                return buildRunner(annotation.value(), testClass, suiteBuilder);
             }
         }
 
@@ -95,22 +92,6 @@ public class AnnotatedBuilder extends RunnerBuilder {
             return currentTestClass.getEnclosingClass();
         } else {
             return null;
-        }
-    }
-
-    public Runner buildRunner(Class<? extends Runner> runnerClass,
-            Class<?> testClass) throws Exception {
-        try {
-            return runnerClass.getConstructor(Class.class).newInstance(testClass);
-        } catch (NoSuchMethodException e) {
-            try {
-                return runnerClass.getConstructor(Class.class,
-                        RunnerBuilder.class).newInstance(testClass, suiteBuilder);
-            } catch (NoSuchMethodException e2) {
-                String simpleName = runnerClass.getSimpleName();
-                throw new InitializationError(String.format(
-                        CONSTRUCTOR_ERROR_FORMAT, simpleName, simpleName));
-            }
         }
     }
 }

--- a/src/main/java/org/junit/internal/builders/DefaultBuilder.java
+++ b/src/main/java/org/junit/internal/builders/DefaultBuilder.java
@@ -1,0 +1,18 @@
+package org.junit.internal.builders;
+
+import org.junit.runner.Runner;
+import org.junit.runners.model.RunnerBuilder;
+
+public class DefaultBuilder extends RunnerBuilder {
+  private Class<? extends Runner> defaultRunnerClass;
+  private RunnerBuilder suiteBuilder;
+
+  public DefaultBuilder(Class<? extends Runner> defaultRunnerClass, RunnerBuilder suiteBuilder) {
+    this.defaultRunnerClass = defaultRunnerClass;
+    this.suiteBuilder = suiteBuilder;
+  }
+
+  public Runner runnerForClass(Class<?> testClass) throws Throwable {
+        return buildRunner(defaultRunnerClass, testClass, suiteBuilder);
+    }
+}

--- a/src/main/java/org/junit/internal/requests/ClassRequest.java
+++ b/src/main/java/org/junit/internal/requests/ClassRequest.java
@@ -1,6 +1,7 @@
 package org.junit.internal.requests;
 
 import org.junit.internal.builders.AllDefaultPossibilitiesBuilder;
+import org.junit.internal.builders.DefaultBuilder;
 import org.junit.internal.builders.SuiteMethodBuilder;
 import org.junit.runner.Request;
 import org.junit.runner.Runner;
@@ -17,10 +18,17 @@ public class ClassRequest extends Request {
     private final Class<?> fTestClass;
     private final boolean canUseSuiteMethod;
     private volatile Runner runner;
+    private Class<? extends Runner> defaultRunnerClass;
 
-    public ClassRequest(Class<?> testClass, boolean canUseSuiteMethod) {
+    public ClassRequest(Class<?> testClass, boolean canUseSuiteMethod,
+                        Class<? extends Runner> defaultRunnerClass) {
         this.fTestClass = testClass;
         this.canUseSuiteMethod = canUseSuiteMethod;
+        this.defaultRunnerClass = defaultRunnerClass;
+    }
+
+    public ClassRequest(Class<?> testClass, boolean canUseSuiteMethod) {
+        this(testClass, canUseSuiteMethod, null);
     }
 
     public ClassRequest(Class<?> testClass) {
@@ -44,6 +52,14 @@ public class ClassRequest extends Request {
         @Override
         protected RunnerBuilder suiteMethodBuilder() {
             return new CustomSuiteMethodBuilder();
+        }
+
+        @Override
+        protected RunnerBuilder defaultBuilder() {
+            if (defaultRunnerClass != null) {
+                return new DefaultBuilder(defaultRunnerClass, this);
+            }
+            return super.defaultBuilder();
         }
     }
 

--- a/src/main/java/org/junit/runner/Request.java
+++ b/src/main/java/org/junit/runner/Request.java
@@ -63,6 +63,19 @@ public abstract class Request {
 
     /**
      * Create a <code>Request</code> that, when processed, will run all the tests
+     * in a class. If the class does not set the runner to use, a runner of the given
+     * class will be used by default.
+     *
+     * @param clazz the class containing the tests
+     * @param defaultRunnerClass the class of the runner to use by default
+     * @return a <code>Request</code> that will cause all tests in the class to be run
+     */
+    public static Request classWithDefaultRunner(Class<?> clazz, Class<? extends Runner> defaultRunnerClass) {
+        return new ClassRequest(clazz, true, defaultRunnerClass);
+    }
+
+    /**
+     * Create a <code>Request</code> that, when processed, will run all the tests
      * in a set of classes.
      *
      * @param computer Helps construct Runners from classes

--- a/src/main/java/org/junit/runners/model/RunnerBuilder.java
+++ b/src/main/java/org/junit/runners/model/RunnerBuilder.java
@@ -37,6 +37,8 @@ import org.junit.runner.Runner;
  * @since 4.5
  */
 public abstract class RunnerBuilder {
+    private static final String CONSTRUCTOR_ERROR_FORMAT = "Custom runner class %s should have a public constructor with signature %s(Class testClass)";
+
     private final Set<Class<?>> parents = new HashSet<Class<?>>();
 
     /**
@@ -78,6 +80,22 @@ public abstract class RunnerBuilder {
 
     void removeParent(Class<?> klass) {
         parents.remove(klass);
+    }
+
+    public Runner buildRunner(Class<? extends Runner> runnerClass,
+            Class<?> testClass, RunnerBuilder suiteBuilder) throws Exception {
+        try {
+            return runnerClass.getConstructor(Class.class).newInstance(testClass);
+        } catch (NoSuchMethodException e) {
+            try {
+                return runnerClass.getConstructor(Class.class,
+                        RunnerBuilder.class).newInstance(testClass, suiteBuilder);
+            } catch (NoSuchMethodException e2) {
+                String simpleName = runnerClass.getSimpleName();
+                throw new InitializationError(String.format(
+                        CONSTRUCTOR_ERROR_FORMAT, simpleName, simpleName));
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This patch updates `Request` and `ClassRequest` to enable the configuration of a default JUnit4 Runner other than `BlockJUnit4ClassRunner`. The only visible change is a new static method in Request, `classWithDefaultRunner`, which configures the runner class to use if not configured in the test.

The context of this change is the following: when managing a large test suite that gets contributions from a large development team, it's typical to enforce certain logic across all tests for global state initialization and cleanup. In the particular case of Twitter for Android, all our tests set up global application graphs before test execution and reset static state afterwards. It is critical for correctness that every single test follows this pattern. This seems to be a particular example of the general need for a mechanism that configures the global state of the test environment.

This is typically achieved by forcing all tests to use a single shared runner or to extend a base class. However, these approaches are error prone, since they require dilligence for setting up the test correctly, or an external validation (eg. a checkstyle detector). A default test runner is a low-tech solution to this problem: a test runner extending `BlockJUnit4ClassRunner` implements state management logic and is configured to be used with all tests that don't explicitly say otherwise.

#1219 proposes an alternative solution to a similar problem. I feel that this approach covers the general need in a simple, non-intrusive way.

The change is incomplete and doesn't implement tests, and it's meant a small proof of concept for feedback.