### PR TITLE
Refactor BlockJUnit4ClassRunner.possiblyExpectingExceptions

### DIFF
--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -330,8 +330,8 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
     protected Statement possiblyExpectingExceptions(FrameworkMethod method,
             Object test, Statement next) {
         Test annotation = method.getAnnotation(Test.class);
-        return expectsException(annotation) ? new ExpectException(next,
-                getExpectedException(annotation)) : next;
+        Class<? extends Throwable> expectedExceptionClass = getExpectedException(annotation);
+        return expectedExceptionClass != null ? new ExpectException(next, expectedExceptionClass) : next;
     }
 
     /**
@@ -455,10 +455,6 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         } else {
             return annotation.expected();
         }
-    }
-
-    private boolean expectsException(Test annotation) {
-        return getExpectedException(annotation) != null;
     }
 
     private long getTimeout(Test annotation) {


### PR DESCRIPTION
Extract to local variable the result of getExpectedException(), thus saving one extra call.