### PR TITLE
pom.xml modified to resolve lifecycle configuration error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,7 @@
                 </includes>
             </resource>
         </resources>
+        <pluginManagement>
         <plugins>
             <!--
             Both "org.apache" and "org.codehaus" are default providers of MOJO plugins
@@ -380,6 +381,7 @@
                 <version>2.7</version>
             </plugin>
         </plugins>
+        </pluginManagement>
     </build>
 
     <reporting>


### PR DESCRIPTION
While importing this project in different IDE's life cycle configuration error occurred. This PR resolves that error by adding pluginManagement tag in build section.
 