### PR TITLE
Made ExpectedExceptio.isAnyExceptionExpected public.

### DIFF
--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -247,8 +247,9 @@ public class ExpectedException implements TestRule {
 
     /**
      * Check if any Exception is expected.
+     * @since 4.13
      */
-    public boolean isAnyExceptionExpected() {
+    public final boolean isAnyExceptionExpected() {
         return matcherBuilder.expectsThrowable();
     }
 

--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -245,6 +245,13 @@ public class ExpectedException implements TestRule {
         return this;
     }
 
+    /**
+     * Check if any Exception is expected.
+     */
+    public boolean isAnyExceptionExpected() {
+        return matcherBuilder.expectsThrowable();
+    }
+
     private class ExpectedExceptionStatement extends Statement {
         private final Statement next;
 
@@ -272,10 +279,6 @@ public class ExpectedException implements TestRule {
         } else {
             throw e;
         }
-    }
-
-    private boolean isAnyExceptionExpected() {
-        return matcherBuilder.expectsThrowable();
     }
 
     private void failDueToMissingException() throws AssertionError {


### PR DESCRIPTION
Is there any harm in making this method public?

I have a base class for our test classes that has both an ExpectedException rule and a Verifier rule. The problem is that I don't want to run the Verifier if any exception is expected. So this is my current solution:

```
public abstract class TestBase {
    private Method isAnyExceptionExpected;

    public TestBase() throws Exception {
        this.isAnyExceptionExpected = ExpectedException.class.getDeclaredMethod("isAnyExceptionExpected");
        this.isAnyExceptionExpected.setAccessible(true);
    }

    @Rule
    public ExpectedException thrown = ExpectedException.none();

    @Rule
    public Verifier verifier = new Verifier() {
        @Override
        public void verify() {
            try {
                if (!(boolean) isAnyExceptionExpected.invoke(thrown)) {
                    verifyStuff();
                    verifyOtherStuff();
                    alsoVerifyThis();
                }
            } catch (IllegalAccessException | InvocationTargetException e) {
                System.err.print("Reflection exception: " + e.getMessage());  // ugh...
            }
        }
    };

    @Before
    public void beforeEach() throws Exception {
        doAwesomeSetup();
    }
}
```