### PR TITLE
Provide helpful message if parameter cannot be set.

### DIFF
--- a/src/main/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParameters.java
+++ b/src/main/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParameters.java
@@ -73,6 +73,13 @@ public class BlockJUnit4ClassRunnerWithParameters extends
             int index = annotation.value();
             try {
                 field.set(testClassInstance, parameters[index]);
+            } catch (IllegalAccessException e) {
+                IllegalAccessException wrappedException = new IllegalAccessException(
+                        "Cannot set parameter '" + field.getName()
+                                + "'. Ensure that the field '" + field.getName()
+                                + "' is public.");
+                wrappedException.initCause(e);
+                throw wrappedException;
             } catch (IllegalArgumentException iare) {
                 throw new Exception(getTestClass().getName()
                         + ": Trying to set " + field.getName()

--- a/src/test/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParametersTest.java
+++ b/src/test/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParametersTest.java
@@ -1,22 +1,30 @@
 package org.junit.runners.parameterized;
 
 import static java.util.Collections.emptyList;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.rules.ExpectedException.none;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Collections;
 import java.util.List;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.model.TestClass;
 
 public class BlockJUnit4ClassRunnerWithParametersTest {
     private static final List<Object> NO_PARAMETERS = emptyList();
+
+    @Rule
+    public final ExpectedException thrown = none();
 
     @RunWith(Parameterized.class)
     @DummyAnnotation
@@ -41,5 +49,32 @@ public class BlockJUnit4ClassRunnerWithParametersTest {
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     private static @interface DummyAnnotation {
+    }
+
+    @RunWith(Parameterized.class)
+    public static class ClassWithPrivateParameter {
+        @Parameterized.Parameter
+        private String parameter;
+
+        @Test
+        public void dummyTest() {
+        }
+    }
+
+    @Test
+    public void providesHelpfulMessageIfParameterFieldCannotBeSet()
+            throws Exception {
+        TestWithParameters testWithParameters = new TestWithParameters(
+                "dummy name",
+                new TestClass(ClassWithPrivateParameter.class),
+                Collections.<Object>singletonList("dummy parameter"));
+        BlockJUnit4ClassRunnerWithParameters runner = new BlockJUnit4ClassRunnerWithParameters(
+                testWithParameters);
+
+        thrown.expect(IllegalAccessException.class);
+        thrown.expectCause(instanceOf(IllegalAccessException.class));
+        thrown.expectMessage("Cannot set parameter 'parameter'. Ensure that the field 'parameter' is public.");
+
+        runner.createTest();
     }
 }


### PR DESCRIPTION
For private @Parameter fields is users get an exception like "java.lang.IllegalAccessException: Class ... can not access a member of class X with modifiers private" The new message "Cannot set parameter 'parameter'. Ensure that the the field 'parameter' is public." tells the user what they should do.

The reason for adding this feature is the Stackoverflow question https://stackoverflow.com/questions/44522046/reflection-exception-in-parameterized-junit-test-using-array-parameter/44522988