### PR TITLE
Add methods for content equals comparision (#1432)

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -812,6 +812,40 @@ public class Assert {
         assertNotSame(null, unexpected, actual);
     }
 
+    /**
+     * Asserts that two {@link CharSequence} instances have same content.
+     * If they do not, an {@link AssertionError} is thrown. If
+     * <code>expected</code> and <code>actual</code> are <code>null</code>,
+     * they are considered same content.
+     *
+     * @param expected the expected contents
+     * @param actual the object to compare to
+     */
+    public static void assertContentEquals(String expected, CharSequence actual)  {
+        assertContentEquals(null, expected, actual);
+    }
+
+    /**
+     * Asserts that two {@link CharSequence} instances have same content.
+     * If they do not, an {@link AssertionError} is thrown with the given message. If
+     * <code>expected</code> and <code>actual</code> are <code>null</code>,
+     * they are considered same content.
+     *
+     * @param message the identifying message for the {@link AssertionError}
+     * @param expected the expected contents
+     * @param actual the object to compare to
+     */
+    public static void assertContentEquals(String message, String expected, CharSequence actual) {
+        if (equalsRegardingNull(expected, actual)) {
+            return;
+        }
+        if (expected == null || actual == null) {
+            failNotEquals(message, expected, actual);
+        }
+
+        assertEquals(message, expected, actual.toString());
+    }
+
     private static void failSame(String message) {
         String formatted = "";
         if (message != null) {

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertContentEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
@@ -954,6 +955,90 @@ public class AssertionTest {
             return;
         }
         throw new AssertionError(ASSERTION_ERROR_EXPECTED);
+    }
+
+    @Test
+    public void assertContentEqualsPass() throws Exception {
+        String expected = "StringValue";
+        CharSequence charSequence = new String("StringValue");
+        assertContentEquals(expected, charSequence);
+    }
+
+    @Test
+    public void assertContentEqualsPassBothNull() throws Exception {
+        String expected = null;
+        CharSequence charSequence = null;
+        assertContentEquals(expected, charSequence);
+    }
+
+    @Test
+    public void assertContentsActualNull() {
+        String expected = "StringValue";
+        CharSequence charSequence = null;
+        try {
+            assertContentEquals(expected, charSequence);
+        } catch (AssertionError exception) {
+            String expectedException = "expected:<StringValue> but was:<null>";
+            assertEquals(expectedException, exception.getMessage());
+            return;
+        }
+        fail("Expected an AssertionError");
+    }
+
+    @Test
+    public void assertContentsExpectedNull() {
+        String expected = null;
+        CharSequence charSequence = new String("StringValue");
+        try {
+            assertContentEquals(expected, charSequence);
+        } catch (AssertionError exception) {
+            String expectedException = "expected:<null> but was:<StringValue>";
+            assertEquals(expectedException, exception.getMessage());
+            return;
+        }
+        fail("Expected an AssertionError");
+    }
+
+    @Test
+    public void assertContentEqualsNotEqualButSameLength() {
+        String expected = "StringValue";
+        CharSequence charSequence = new String("NotTheSame!");
+        try {
+            assertContentEquals(expected, charSequence);
+        } catch (AssertionError exception) {
+            String expectedException = "expected:<[StringValue]> but was:<[NotTheSame!]>";
+            assertEquals(expectedException, exception.getMessage());
+            return;
+        }
+        fail("Expected an AssertionError");
+    }
+
+    @Test
+    public void assertContentEqualsNotEqualDifferentLength() {
+        String expected = "StringValue";
+        CharSequence charSequence = new String("NotTheSame");
+        try {
+            assertContentEquals(expected, charSequence);
+        } catch (AssertionError exception) {
+            String expectedException = "expected:<[StringValu]e> but was:<[NotTheSam]e>";
+            assertEquals(expectedException, exception.getMessage());
+            return;
+        }
+        fail("Expected an AssertionError");
+    }
+
+    @Test
+    public void assertContentEqualsPassCustomMessage() throws Exception {
+        String expected = "StringValue";
+        CharSequence charSequence = new String("StringValue");
+        assertContentEquals("My Message", expected, charSequence);
+    }
+
+    @Test
+    public void assertContentEqualsPassBothNullCustomMessage() throws Exception {
+        String expected = null;
+        CharSequence charSequence = null;
+        assertContentEquals("My Message", expected, charSequence);
     }
 
     private static class NestedException extends RuntimeException {


### PR DESCRIPTION
I am opening this PR, because https://github.com/junit-team/junit4/pull/1439 was stuck on review. I fixed the review comments from that PR. 

Also after discussions https://github.com/junit-team/junit4/pull/1439#discussion_r117915718 I am dropping string length comparison. Javadocs for this document was change a bit to follow assertEquals style and I've added one more unit test for when expected is null.