### PR TITLE
Remove oraclejdk7 since it is longer supported by travi…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 script: mvn verify javadoc:javadoc site:site
 jdk:
-  - oraclejdk7
   - oraclejdk8
+  - openjdk8
   - openjdk7
-  - openjdk6


### PR DESCRIPTION
…sCI & add openjdk8 to travis.yml

openjdk6 is no longer supported by travisCI: 

see: https://github.com/travis-ci/travis-ci/issues/8199

---

oraclejdk7 is longer supported by travisCI:

see: https://github.com/travis-ci/travis-ci/issues/7884

---

-- openJDk8 has been available for some time

see: https://github.com/travis-ci/travis-ci/issues/6483