### PR TITLE
Fix TemporaryFolder deletion after test execution

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -295,8 +295,8 @@ public class TemporaryFolder extends ExternalResource {
         boolean result = true;
         File[] files = file.listFiles();
         if (files != null) {
-            for (File each : files) {
-                result = result && recursiveDelete(each);
+            for (int i = 0; i < files.length && result; i++) {
+                result = recursiveDelete(files[i]);
             }
         }
         return result && file.delete();

--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -292,13 +292,14 @@ public class TemporaryFolder extends ExternalResource {
         if (file.delete()) {
             return true;
         }
-        boolean result = true;
         File[] files = file.listFiles();
         if (files != null) {
-            for (int i = 0; i < files.length && result; i++) {
-                result = recursiveDelete(files[i]);
+            for (File each : files) {
+                if (!recursiveDelete(each)) {
+                    return false;
+                }
             }
         }
-        return result && file.delete();
+        return file.delete();
     }
 }


### PR DESCRIPTION
Fixed a no-op loop that could occur after we fail to delete one of the files under the current TemporaryFolder. I thought it is better to delete as many files as possible before returning back to TemporaryFolder#delete() caller function.