### PR TITLE
Revert "Fluent expectations for ExpectedException".

### DIFF
--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -177,9 +177,8 @@ public class ExpectedException implements TestRule {
      * @deprecated use {@code org.hamcrest.junit.ExpectedException.expect()}
      */
     @Deprecated
-    public ExpectedException expect(Matcher<?> matcher) {
+    public void expect(Matcher<?> matcher) {
         matcherBuilder.add(matcher);
-        return this;
     }
 
     /**
@@ -191,9 +190,8 @@ public class ExpectedException implements TestRule {
      *     throw new NullPointerException();
      * }</pre>
      */
-    public ExpectedException expect(Class<? extends Throwable> type) {
+    public void expect(Class<? extends Throwable> type) {
         expect(instanceOf(type));
-        return this;
     }
 
     /**
@@ -205,9 +203,8 @@ public class ExpectedException implements TestRule {
      *     throw new NullPointerException(&quot;What happened?&quot;);
      * }</pre>
      */
-    public ExpectedException expectMessage(String substring) {
+    public void expectMessage(String substring) {
         expectMessage(containsString(substring));
-        return this;
     }
 
     /**
@@ -222,9 +219,8 @@ public class ExpectedException implements TestRule {
      * @deprecated use {@code org.hamcrest.junit.ExpectedException.expectMessage()}
      */
     @Deprecated
-    public ExpectedException expectMessage(Matcher<String> matcher) {
+    public void expectMessage(Matcher<String> matcher) {
         expect(hasMessage(matcher));
-        return this;
     }
 
     /**
@@ -240,9 +236,8 @@ public class ExpectedException implements TestRule {
      * @deprecated use {@code org.hamcrest.junit.ExpectedException.expectCause()}
      */
     @Deprecated
-    public ExpectedException expectCause(Matcher<?> expectedCause) {
+    public void expectCause(Matcher<?> expectedCause) {
         expect(hasCause(expectedCause));
-        return this;
     }
 
     /**


### PR DESCRIPTION
The change was not binary compatible with JUnit 4.12.
In addition, the preferred way to check for exceptions
in JUnit 4.13 is with Assert.assertThrows() so we will
be not adding new major features to ExpectedException.

This reverts commit 1db00d5a965951ea3667480a96467b43a80823c1.