### PR TITLE
order TestWatcher to be outermost

### DIFF
--- a/src/main/java/org/junit/rules/DefaultOrder.java
+++ b/src/main/java/org/junit/rules/DefaultOrder.java
@@ -9,5 +9,6 @@ import java.lang.annotation.Target;
 @Inherited
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface OutermostRule {
+public @interface DefaultOrder {
+    int value();
 }

--- a/src/main/java/org/junit/rules/OutermostRule.java
+++ b/src/main/java/org/junit/rules/OutermostRule.java
@@ -1,0 +1,13 @@
+package org.junit.rules;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Inherited
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OutermostRule {
+}

--- a/src/main/java/org/junit/rules/TestWatcher.java
+++ b/src/main/java/org/junit/rules/TestWatcher.java
@@ -43,6 +43,7 @@ import org.junit.runners.model.Statement;
  *
  * @since 4.9
  */
+@OutermostRule
 public abstract class TestWatcher implements TestRule {
     public Statement apply(final Statement base, final Description description) {
         return new Statement() {

--- a/src/main/java/org/junit/rules/TestWatcher.java
+++ b/src/main/java/org/junit/rules/TestWatcher.java
@@ -43,7 +43,7 @@ import org.junit.runners.model.Statement;
  *
  * @since 4.9
  */
-@OutermostRule
+@DefaultOrder(Integer.MIN_VALUE)
 public abstract class TestWatcher implements TestRule {
     public Statement apply(final Statement base, final Description description) {
         return new Statement() {

--- a/src/main/java/org/junit/runners/RuleContainer.java
+++ b/src/main/java/org/junit/runners/RuleContainer.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.junit.Rule;
 import org.junit.rules.MethodRule;
+import org.junit.rules.OutermostRule;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
@@ -40,6 +41,9 @@ class RuleContainer {
 
     static final Comparator<RuleEntry> ENTRY_COMPARATOR = new Comparator<RuleEntry>() {
         public int compare(RuleEntry o1, RuleEntry o2) {
+            if (o1.outermost != o2.outermost) {
+                return o1.outermost ? 1 : -1;
+            }
             int result = compareInt(o1.order, o2.order);
             return result != 0 ? result : o1.type - o2.type;
         }
@@ -101,11 +105,13 @@ class RuleContainer {
         static final int TYPE_METHOD_RULE = 0;
 
         final Object rule;
+        final boolean outermost;
         final int type;
         final int order;
 
         RuleEntry(Object rule, int type, Integer order) {
             this.rule = rule;
+            this.outermost = rule.getClass().isAnnotationPresent(OutermostRule.class);
             this.type = type;
             this.order = order != null ? order.intValue() : Rule.DEFAULT_ORDER;
         }

--- a/src/main/java/org/junit/runners/RuleContainer.java
+++ b/src/main/java/org/junit/runners/RuleContainer.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import org.junit.Rule;
 import org.junit.rules.MethodRule;
-import org.junit.rules.OutermostRule;
+import org.junit.rules.DefaultOrder;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
@@ -41,9 +41,6 @@ class RuleContainer {
 
     static final Comparator<RuleEntry> ENTRY_COMPARATOR = new Comparator<RuleEntry>() {
         public int compare(RuleEntry o1, RuleEntry o2) {
-            if (o1.outermost != o2.outermost) {
-                return o1.outermost ? 1 : -1;
-            }
             int result = compareInt(o1.order, o2.order);
             return result != 0 ? result : o1.type - o2.type;
         }
@@ -105,15 +102,20 @@ class RuleContainer {
         static final int TYPE_METHOD_RULE = 0;
 
         final Object rule;
-        final boolean outermost;
         final int type;
         final int order;
 
         RuleEntry(Object rule, int type, Integer order) {
             this.rule = rule;
-            this.outermost = rule.getClass().isAnnotationPresent(OutermostRule.class);
             this.type = type;
-            this.order = order != null ? order.intValue() : Rule.DEFAULT_ORDER;
+            int orderValue = order != null ? order.intValue() : Rule.DEFAULT_ORDER;
+            if (orderValue == Rule.DEFAULT_ORDER) {
+                DefaultOrder defaultOrder = rule.getClass().getAnnotation(DefaultOrder.class);
+                if (defaultOrder != null) {
+                    orderValue = defaultOrder.value();
+                }
+            }
+            this.order = orderValue;
         }
     }
 }

--- a/src/test/java/org/junit/rules/ClassRulesTest.java
+++ b/src/test/java/org/junit/rules/ClassRulesTest.java
@@ -263,12 +263,12 @@ public class ClassRulesTest {
 
         @Test
         public void foo() {
-            log.append(" foo");
+            log.append("foo ");
         }
 
         @Test
         public void bar() {
-            log.append(" bar");
+            log.append("bar ");
         }
     }
 
@@ -277,7 +277,7 @@ public class ClassRulesTest {
         log.setLength(0);
         Result result = JUnitCore.runClasses(ClassRuleOrdering.class);
         assertTrue(result.wasSuccessful());
-        assertEquals(" outer.begin inner.begin bar foo inner.end outer.end", log.toString());
+        assertEquals("outer.begin inner.begin bar foo inner.end outer.end ", log.toString());
     }
 
     @FixMethodOrder(MethodSorters.NAME_ASCENDING)
@@ -294,12 +294,12 @@ public class ClassRulesTest {
 
         @Test
         public void foo() {
-            log.append(" foo");
+            log.append("foo ");
         }
 
         @Test
         public void bar() {
-            log.append(" bar");
+            log.append("bar ");
         }
     }
 
@@ -308,6 +308,6 @@ public class ClassRulesTest {
         log.setLength(0);
         Result result = JUnitCore.runClasses(ClassRuleOrderingDefault.class);
         assertTrue(result.wasSuccessful());
-        assertEquals(" inner.begin outer.begin bar foo outer.end inner.end", log.toString());
+        assertEquals("inner.begin outer.begin bar foo outer.end inner.end ", log.toString());
     }
 }

--- a/src/test/java/org/junit/rules/LoggingStatement.java
+++ b/src/test/java/org/junit/rules/LoggingStatement.java
@@ -14,11 +14,11 @@ class LoggingStatement extends Statement {
     }
 
     public void evaluate() throws Throwable {
-        log.append(" ").append(name).append(".begin");
+        log.append(name).append(".begin ");
         try {
             base.evaluate();
         } finally {
-            log.append(" ").append(name).append(".end");
+            log.append(name).append(".end ");
         }
     }
 }

--- a/src/test/java/org/junit/rules/TestRuleTest.java
+++ b/src/test/java/org/junit/rules/TestRuleTest.java
@@ -812,7 +812,7 @@ public class TestRuleTest {
 
         ruleLog.setLength(0);
         Result result3 = JUnitCore.runClasses(TestWatcherOrdering3.class);
-        assertTrue(result2.wasSuccessful());
+        assertTrue(result3.wasSuccessful());
         assertEquals("inner.begin starting foo succeeded finished inner.end ",
                 ruleLog.toString());
     }

--- a/src/test/java/org/junit/rules/TestRuleTest.java
+++ b/src/test/java/org/junit/rules/TestRuleTest.java
@@ -709,7 +709,7 @@ public class TestRuleTest {
 
         @Test
         public void foo() {
-            ruleLog.append(" foo");
+            ruleLog.append("foo ");
         }
     }
 
@@ -718,7 +718,7 @@ public class TestRuleTest {
         ruleLog.setLength(0);
         Result result = JUnitCore.runClasses(TestRuleIsAroundMethodRule.class);
         assertTrue(result.wasSuccessful());
-        assertEquals(" testRule.begin methodRule.begin foo methodRule.end testRule.end",
+        assertEquals("testRule.begin methodRule.begin foo methodRule.end testRule.end ",
                 ruleLog.toString());
     }
 
@@ -731,7 +731,7 @@ public class TestRuleTest {
 
         @Test
         public void foo() {
-            ruleLog.append(" foo");
+            ruleLog.append("foo ");
         }
     }
 
@@ -740,7 +740,7 @@ public class TestRuleTest {
         ruleLog.setLength(0);
         Result result = JUnitCore.runClasses(TestRuleOrdering.class);
         assertTrue(result.wasSuccessful());
-        assertEquals(" outer.begin inner.begin foo inner.end outer.end", ruleLog.toString());
+        assertEquals("outer.begin inner.begin foo inner.end outer.end ", ruleLog.toString());
     }
 
     public static class TestRuleOrderingWithMethodRule {
@@ -752,7 +752,7 @@ public class TestRuleTest {
 
         @Test
         public void foo() {
-            ruleLog.append(" foo");
+            ruleLog.append("foo ");
         }
     }
 
@@ -761,7 +761,48 @@ public class TestRuleTest {
         ruleLog.setLength(0);
         Result result = JUnitCore.runClasses(TestRuleOrderingWithMethodRule.class);
         assertTrue(result.wasSuccessful());
-        assertEquals(" methodRule.begin testRule.begin foo testRule.end methodRule.end",
+        assertEquals("methodRule.begin testRule.begin foo testRule.end methodRule.end ",
+                ruleLog.toString());
+    }
+
+    public static class TestWatcherOrdering1 {
+        @Rule(order = 1)
+        public final TestRule watcher = new LoggingTestWatcher(ruleLog);
+
+        @Rule(order = 2)
+        public final TestRule rule = new LoggingTestRule(ruleLog, "inner");
+
+        @Test
+        public void foo() {
+            ruleLog.append("foo ");
+        }
+    }
+
+    public static class TestWatcherOrdering2 {
+        @Rule(order = 2)
+        public final TestRule watcher = new LoggingTestWatcher(ruleLog);
+
+        @Rule(order = 1)
+        public final TestRule rule = new LoggingTestRule(ruleLog, "inner");
+
+        @Test
+        public void foo() {
+            ruleLog.append("foo ");
+        }
+    }
+
+    @Test
+    public void TestWatcherOrdering() {
+        ruleLog.setLength(0);
+        Result result1 = JUnitCore.runClasses(TestWatcherOrdering1.class);
+        assertTrue(result1.wasSuccessful());
+        assertEquals("starting inner.begin foo inner.end succeeded finished ",
+                ruleLog.toString());
+
+        ruleLog.setLength(0);
+        Result result2 = JUnitCore.runClasses(TestWatcherOrdering2.class);
+        assertTrue(result2.wasSuccessful());
+        assertEquals("starting inner.begin foo inner.end succeeded finished ",
                 ruleLog.toString());
     }
 }

--- a/src/test/java/org/junit/rules/TestRuleTest.java
+++ b/src/test/java/org/junit/rules/TestRuleTest.java
@@ -765,43 +765,35 @@ public class TestRuleTest {
                 ruleLog.toString());
     }
 
-    public static class TestWatcherOrdering1 {
+    public abstract static class TestWatcherOrdering {
+        @Test
+        public void foo() {
+            ruleLog.append("foo ");
+        }
+    }
+
+    public static class TestWatcherOrdering1 extends TestWatcherOrdering {
         @Rule
         public final TestRule rule1 = new LoggingTestWatcher(ruleLog);
 
         @Rule
         public final TestRule rule2 = new LoggingTestRule(ruleLog, "inner");
-
-        @Test
-        public void foo() {
-            ruleLog.append("foo ");
-        }
     }
 
-    public static class TestWatcherOrdering2 {
+    public static class TestWatcherOrdering2 extends TestWatcherOrdering {
         @Rule
         public final TestRule rule1 = new LoggingTestRule(ruleLog, "inner");
 
         @Rule
         public final TestRule rule2 = new LoggingTestWatcher(ruleLog);
-
-        @Test
-        public void foo() {
-            ruleLog.append("foo ");
-        }
     }
 
-    public static class TestWatcherOrdering3 {
+    public static class TestWatcherOrdering3 extends TestWatcherOrdering {
         @Rule(order = 1)
         public final TestRule rule1 = new LoggingTestRule(ruleLog, "inner");
 
         @Rule(order = 2)
         public final TestRule rule2 = new LoggingTestWatcher(ruleLog);
-
-        @Test
-        public void foo() {
-            ruleLog.append("foo ");
-        }
     }
 
     @Test

--- a/src/test/java/org/junit/rules/TestRuleTest.java
+++ b/src/test/java/org/junit/rules/TestRuleTest.java
@@ -766,11 +766,11 @@ public class TestRuleTest {
     }
 
     public static class TestWatcherOrdering1 {
-        @Rule(order = 1)
-        public final TestRule watcher = new LoggingTestWatcher(ruleLog);
+        @Rule
+        public final TestRule rule1 = new LoggingTestWatcher(ruleLog);
 
-        @Rule(order = 2)
-        public final TestRule rule = new LoggingTestRule(ruleLog, "inner");
+        @Rule
+        public final TestRule rule2 = new LoggingTestRule(ruleLog, "inner");
 
         @Test
         public void foo() {
@@ -779,11 +779,24 @@ public class TestRuleTest {
     }
 
     public static class TestWatcherOrdering2 {
-        @Rule(order = 2)
-        public final TestRule watcher = new LoggingTestWatcher(ruleLog);
+        @Rule
+        public final TestRule rule1 = new LoggingTestRule(ruleLog, "inner");
 
+        @Rule
+        public final TestRule rule2 = new LoggingTestWatcher(ruleLog);
+
+        @Test
+        public void foo() {
+            ruleLog.append("foo ");
+        }
+    }
+
+    public static class TestWatcherOrdering3 {
         @Rule(order = 1)
-        public final TestRule rule = new LoggingTestRule(ruleLog, "inner");
+        public final TestRule rule1 = new LoggingTestRule(ruleLog, "inner");
+
+        @Rule(order = 2)
+        public final TestRule rule2 = new LoggingTestWatcher(ruleLog);
 
         @Test
         public void foo() {
@@ -803,6 +816,12 @@ public class TestRuleTest {
         Result result2 = JUnitCore.runClasses(TestWatcherOrdering2.class);
         assertTrue(result2.wasSuccessful());
         assertEquals("starting inner.begin foo inner.end succeeded finished ",
+                ruleLog.toString());
+
+        ruleLog.setLength(0);
+        Result result3 = JUnitCore.runClasses(TestWatcherOrdering3.class);
+        assertTrue(result2.wasSuccessful());
+        assertEquals("inner.begin starting foo succeeded finished inner.end ",
                 ruleLog.toString());
     }
 }


### PR DESCRIPTION
As a possible way to address ordering in #1436

The change of spaces is done to make `LoggingTestRule` consistent with `LoggingTestWatcher`.