### PR TITLE
Recommend to set order for ExpectedException

### DIFF
--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -68,6 +68,13 @@ import org.junit.runners.model.Statement;
  *     throw new NullPointerException(&quot;What happened?&quot;);
  * }</pre>
  *
+ * <p>It is recommended to set the {@link org.junit.Rule#order() order} of the
+ * {@code ExpectedException} to {@code Integer.MAX_VALUE} if it is used together
+ * with another rule that handles exceptions, e.g. {@link ErrorCollector}.
+ * Otherwise failing tests may be successful.
+ * <pre> &#064;Rule(order = Integer.MAX_VALUE)
+ * public ExpectedException thrown = ExpectedException.none();</pre>
+ *
  * <h3>AssumptionViolatedExceptions</h3>
  * <p>JUnit uses {@link AssumptionViolatedException}s for indicating that a test
  * provides no useful information. (See {@link org.junit.Assume} for more

--- a/src/test/java/org/junit/rules/ExpectedExceptionTest.java
+++ b/src/test/java/org/junit/rules/ExpectedExceptionTest.java
@@ -86,7 +86,10 @@ public class ExpectedExceptionTest {
                 {
                         UseCustomMessageWithPlaceHolder.class,
                         hasSingleFailureWithMessage(ARBITRARY_MESSAGE
-                                + " - an instance of java.lang.IllegalArgumentException") }
+                                + " - an instance of java.lang.IllegalArgumentException") },
+                {
+                        ErrorCollectorShouldFailAlthoughExpectedExceptionDoesNot.class,
+                        hasSingleFailureWithMessage(ARBITRARY_MESSAGE) }
         });
     }
 
@@ -362,6 +365,22 @@ public class ExpectedExceptionTest {
         public void noThrow() {
             thrown.expect(IllegalArgumentException.class);
             thrown.reportMissingExceptionWithMessage(ARBITRARY_MESSAGE);
+        }
+    }
+
+    public static class ErrorCollectorShouldFailAlthoughExpectedExceptionDoesNot {
+
+        @Rule
+        public ErrorCollector collector = new ErrorCollector();
+
+        @Rule(order = Integer.MAX_VALUE)
+        public ExpectedException thrown = ExpectedException.none();
+
+        @Test
+        public void test() {
+            collector.addError(new AssertionError(ARBITRARY_MESSAGE));
+            thrown.expect(Exception.class);
+            throw new RuntimeException();
         }
     }
 }


### PR DESCRIPTION
A test that should fail because of ErrorCollector may not fail when this test throws an exception that is expected by ExpectedException.

Fixes #1466.