### PR TITLE
ThreadGroup instance leaked when using Timeout rule

### DIFF
--- a/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
+++ b/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
@@ -131,7 +131,11 @@ public class FailOnTimeout extends Statement {
                 throw throwable;
             }
         } finally {
-            thread.join(100);
+            try {
+                thread.join(1);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             try {
                 threadGroup.destroy();
             } catch (IllegalThreadStateException e) {

--- a/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
+++ b/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
@@ -122,12 +122,22 @@ public class FailOnTimeout extends Statement {
         FutureTask<Throwable> task = new FutureTask<Throwable>(callable);
         ThreadGroup threadGroup = new ThreadGroup("FailOnTimeoutGroup");
         Thread thread = new Thread(threadGroup, task, "Time-limited test");
-        thread.setDaemon(true);
-        thread.start();
-        callable.awaitStarted();
-        Throwable throwable = getResult(task, thread);
-        if (throwable != null) {
-            throw throwable;
+        try {
+            thread.setDaemon(true);
+            thread.start();
+            callable.awaitStarted();
+            Throwable throwable = getResult(task, thread);
+            if (throwable != null) {
+                throw throwable;
+            }
+        } finally {
+            thread.join(100);
+            try {
+                threadGroup.destroy();
+            } catch (IllegalThreadStateException e) {
+                // If a thread from the group is still alive, the ThreadGroup cannot be destroyed.
+                // Swallow the exception to keep the same behavior prior to this change.
+            }
         }
     }
 

--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -205,7 +205,7 @@ public class FailOnTimeoutTest {
         evaluateWithWaitDuration(0);
         
         for (ThreadGroup group: subGroupsOfCurrentThread()) {
-            if(!groupsBeforeSet.contains(group) && "FailOnTimeoutGroup".equals(group.getName())) {
+            if (!groupsBeforeSet.contains(group) && "FailOnTimeoutGroup".equals(group.getName())) {
                 fail("A 'FailOnTimeoutGroup' thread group remains referenced after the test execution.");
             }
         }


### PR DESCRIPTION
This was seen with heavy impact because Spring uses the ThreadGroupContext to store internal information.

The thread group created for handling the timeout of tests is never destroy, so the `main` thread group keeps a reference to all timeout groups created during the tests. This causes the threadGroup to remain in memory, and all of its context along with it.

This change avoids that by destroying the ThreadGroup after the test.

However, in some cases (like if a thread from the group is hanged), the ThreadGroup destruction fails. In that case, the exception is ignored so the behavior is not changed.