### PR TITLE
Fix testRemoveElement of ListTest 

### DIFF
--- a/src/test/java/junit/samples/ListTest.java
+++ b/src/test/java/junit/samples/ListTest.java
@@ -38,7 +38,7 @@ public class ListTest extends TestCase {
 
     public void testContains() {
         assertTrue(fullList.contains(1));
-        assertTrue(!emptyList.contains(1));
+        assertFalse(emptyList.contains(1));
     }
 
     public void testElementAt() {
@@ -61,7 +61,7 @@ public class ListTest extends TestCase {
     }
 
     public void testRemoveElement() {
-        fullList.remove(Integer.valueOf(3));
-        assertTrue(!fullList.contains((Integer) 3));
+        fullList.remove(2);
+        assertFalse(fullList.contains(3));
     }
 }

--- a/src/test/java/junit/samples/ListTest.java
+++ b/src/test/java/junit/samples/ListTest.java
@@ -61,8 +61,7 @@ public class ListTest extends TestCase {
     }
 
     public void testRemoveElement() {
-        int i = fullList.remove(2);
-        assertEquals(i, 3);
-        assertTrue(!fullList.contains(3));
+        fullList.remove(Integer.valueOf(3));
+        assertTrue(!fullList.contains((Integer) 3));
     }
 }

--- a/src/test/java/junit/samples/ListTest.java
+++ b/src/test/java/junit/samples/ListTest.java
@@ -61,7 +61,7 @@ public class ListTest extends TestCase {
     }
 
     public void testRemoveElement() {
-        fullList.remove(2);
+        fullList.remove(Integer.valueOf(3));
         assertFalse(fullList.contains(3));
     }
 }

--- a/src/test/java/junit/samples/ListTest.java
+++ b/src/test/java/junit/samples/ListTest.java
@@ -61,7 +61,8 @@ public class ListTest extends TestCase {
     }
 
     public void testRemoveElement() {
-        fullList.remove(3);
+        int i = fullList.remove(2);
+        assertEquals(i, 3);
         assertTrue(!fullList.contains(3));
     }
 }


### PR DESCRIPTION
The test failed due to IndexOutOfBoundsException in fullList.remove(3). It seems that the value 3 should be removed but unfortunately ArrayList.remove() takes the index of the element and not the element itself. This fix ensures that element 3 is removed by its index. 