### PR TITLE
Deprecate rule ExpectedException

### DIFF
--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -14,11 +14,7 @@ import org.junit.runners.model.Statement;
 
 /**
  * The {@code ExpectedException} rule allows you to verify that your code
- * throws a specific exception. Note that, starting with Java 8,
- * {@link org.junit.Assert#assertThrows(java.lang.Class, org.junit.function.ThrowingRunnable)
- * Assert.assertThrows}
- * is often a better choice since it allows you to express exactly where you
- * expect the exception to be thrown.
+ * throws a specific exception.
  *
  * <h3>Usage</h3>
  *
@@ -110,6 +106,10 @@ import org.junit.runners.model.Statement;
  * exception. E.g. "Test doesn't throw %s." will fail with the error message
  * "Test doesn't throw an instance of foo.".
  *
+ * @deprecated Since 4.13
+ * {@link org.junit.Assert#assertThrows(Class, org.junit.function.ThrowingRunnable)
+ * Assert.assertThrows} can be used to verify that your code throws a specific
+ * exception.
  * @since 4.7
  */
 public class ExpectedException implements TestRule {


### PR DESCRIPTION
The method Assert.assertThrows provides a nicer way for verifying exceptions. In addition the use of ExpectedException is error-prone when used with other rules like TestWatcher because the order of rules is important in that case.

### Pro

`assertThrows` is in any way better than `ExpectedException`:
- the code that throws the exception can be exactly specified
- no dependency on rule ordering
- the exception is exposed so that any of its properties can be checked

### Contra

`assertThrows` is only easy to use with Java 8. For older versions of Java you need boiler-plate code for creating a `ThrowingRunnable`