### PR TITLE
Use assertThrows

### DIFF
--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -5,18 +5,18 @@ import static java.lang.Math.atan;
 import static java.lang.System.currentTimeMillis;
 import static java.lang.Thread.sleep;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.internal.runners.statements.FailOnTimeout.builder;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runners.model.Statement;
 import org.junit.runners.model.TestTimedOutException;
 
@@ -27,73 +27,83 @@ public class FailOnTimeoutTest {
     private static final long TIMEOUT = 100;
     private static final long DURATION_THAT_EXCEEDS_TIMEOUT = 60 * 60 * 1000; //1 hour
 
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     private final TestStatement statement = new TestStatement();
 
     private final FailOnTimeout failOnTimeout = builder().withTimeout(TIMEOUT, MILLISECONDS).build(statement);
 
     @Test
-    public void throwsTestTimedOutException() throws Throwable {
-        thrown.expect(TestTimedOutException.class);
-        evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
+    public void throwsTestTimedOutException() {
+        assertThrows(
+                TestTimedOutException.class,
+                evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT));
     }
 
     @Test
-    public void throwExceptionWithNiceMessageOnTimeout() throws Throwable {
-        thrown.expectMessage("test timed out after 100 milliseconds");
-        evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
+    public void throwExceptionWithNiceMessageOnTimeout() {
+        TestTimedOutException e = assertThrows(
+                TestTimedOutException.class,
+                evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT));
+        assertEquals("test timed out after 100 milliseconds", e.getMessage());
     }
 
     @Test
-    public void sendUpExceptionThrownByStatement() throws Throwable {
+    public void sendUpExceptionThrownByStatement() {
         RuntimeException exception = new RuntimeException();
-        thrown.expect(is(exception));
-        evaluateWithException(exception);
+        RuntimeException e = assertThrows(
+                RuntimeException.class,
+                evaluateWithException(exception));
+        assertSame(exception, e);
     }
 
     @Test
     public void throwExceptionIfTheSecondCallToEvaluateNeedsTooMuchTime()
             throws Throwable {
-        thrown.expect(TestTimedOutException.class);
-        evaluateWithWaitDuration(0);
-        evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
+        evaluateWithWaitDuration(0).run();
+        assertThrows(
+                TestTimedOutException.class,
+                evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT));
     }
 
     @Test
-    public void throwTimeoutExceptionOnSecondCallAlthoughFirstCallThrowsException()
-            throws Throwable {
-        thrown.expectMessage("test timed out after 100 milliseconds");
+    public void throwTimeoutExceptionOnSecondCallAlthoughFirstCallThrowsException() {
         try {
-            evaluateWithException(new RuntimeException());
+            evaluateWithException(new RuntimeException()).run();
         } catch (Throwable expected) {
         }
-        evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
+
+        TestTimedOutException e = assertThrows(
+                TestTimedOutException.class,
+                evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT));
+        assertEquals("test timed out after 100 milliseconds", e.getMessage());
     }
 
     @Test
-    public void throwsExceptionWithTimeoutValueAndTimeUnitSet()
-            throws Throwable {
-        try {
-            evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT);
-            fail("No exception was thrown when test timed out");
-        } catch (TestTimedOutException e) {
-            assertEquals(TIMEOUT, e.getTimeout());
-            assertEquals(TimeUnit.MILLISECONDS, e.getTimeUnit());
-        }
+    public void throwsExceptionWithTimeoutValueAndTimeUnitSet() {
+        TestTimedOutException e = assertThrows(
+                TestTimedOutException.class,
+                evaluateWithWaitDuration(DURATION_THAT_EXCEEDS_TIMEOUT));
+        assertEquals(TIMEOUT, e.getTimeout());
+        assertEquals(TimeUnit.MILLISECONDS, e.getTimeUnit());
     }
 
-    private void evaluateWithException(Exception exception) throws Throwable {
-        statement.nextException = exception;
-        statement.waitDuration = 0;
-        failOnTimeout.evaluate();
+    private ThrowingRunnable evaluateWithException(final Exception exception) {
+        return new ThrowingRunnable() {
+            public void run() throws Throwable {
+                statement.nextException = exception;
+                statement.waitDuration = 0;
+                failOnTimeout.evaluate();
+            }
+        };
     }
 
-    private void evaluateWithWaitDuration(long waitDuration) throws Throwable {
-        statement.nextException = null;
-        statement.waitDuration = waitDuration;
-        failOnTimeout.evaluate();
+    private ThrowingRunnable evaluateWithWaitDuration(final long waitDuration) {
+        return new ThrowingRunnable() {
+            public void run() throws Throwable {
+                statement.nextException = null;
+                statement.waitDuration = waitDuration;
+                failOnTimeout.evaluate();
+            }
+        };
     }
 
     private static final class TestStatement extends Statement {


### PR DESCRIPTION
Improve readability of tests because the assert explicitly wraps the statement that throws the exception.