### PR TITLE
Fix assertSame to match semantics of == for primitive types

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -773,6 +773,54 @@ public class Assert {
     }
 
     /**
+     * Asserts that two boolean values are the same. If they are not, an
+     * {@link AssertionError} is thrown with the given message.
+     *
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code>
+     * okay)
+     * @param expected the expected object
+     * @param actual the value to compare to <code>expected</code>
+     */
+    public static void assertSame(String message, boolean expected, boolean actual) {
+        if (expected == actual) {
+            return;
+        }
+        failNotSame(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two long values are the same. If they are not, an
+     * {@link AssertionError} is thrown with the given message.
+     *
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code>
+     * okay)
+     * @param expected the expected object
+     * @param actual the value to compare to <code>expected</code>
+     */
+    public static void assertSame(String message, long expected, long actual) {
+        if (expected == actual) {
+            return;
+        }
+        failNotSame(message, expected, actual);
+    }
+
+    /**
+     * Asserts that two double values are the same. If they are not, an
+     * {@link AssertionError} is thrown with the given message.
+     *
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code>
+     * okay)
+     * @param expected the expected object
+     * @param actual the value to compare to <code>expected</code>
+     */
+    public static void assertSame(String message, double expected, double actual) {
+        if (expected == actual) {
+            return;
+        }
+        failNotSame(message, expected, actual);
+    }
+
+    /**
      * Asserts that two objects refer to the same object. If they are not the
      * same, an {@link AssertionError} without a message is thrown.
      *
@@ -781,6 +829,87 @@ public class Assert {
      */
     public static void assertSame(Object expected, Object actual) {
         assertSame(null, expected, actual);
+    }
+
+    /**
+     * Asserts that two boolean values are the same. If they are not the
+     * same, an {@link AssertionError} without a message is thrown.
+     *
+     * @param expected the expected value
+     * @param actual the value to compare to <code>expected</code>
+     */
+    public static void assertSame(boolean expected, boolean actual) {
+        assertSame(null, expected, actual);
+    }
+
+    /**
+     * Asserts that two long values are the same. If they are not the
+     * same, an {@link AssertionError} without a message is thrown.
+     *
+     * @param expected the expected value
+     * @param actual the value to compare to <code>expected</code>
+     */
+    public static void assertSame(long expected, long actual) {
+        assertSame(null, expected, actual);
+    }
+
+    /**
+     * Asserts that two double values are the same. If they are not the
+     * same, an {@link AssertionError} without a message is thrown.
+     *
+     * @param expected the expected value
+     * @param actual the value to compare to <code>expected</code>
+     */
+    public static void assertSame(double expected, double actual) {
+        assertSame(null, expected, actual);
+    }
+
+    /**
+     * Asserts that two boolean values are not the same. If they are the same value,
+     * an {@link AssertionError} is thrown with the given message.
+     *
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code>
+     * okay)
+     * @param unexpected the value you don't expect
+     * @param actual the value to compare to <code>unexpected</code>
+     */
+    public static void assertNotSame(String message, boolean unexpected,
+            boolean actual) {
+        if (unexpected == actual) {
+            failSame(message);
+        }
+    }
+
+    /**
+     * Asserts that two long values are not the same. If they are the same value,
+     * an {@link AssertionError} is thrown with the given message.
+     *
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code>
+     * okay)
+     * @param unexpected the value you don't expect
+     * @param actual the value to compare to <code>unexpected</code>
+     */
+    public static void assertNotSame(String message, long unexpected,
+            long actual) {
+        if (unexpected == actual) {
+            failSame(message);
+        }
+    }
+
+    /**
+     * Asserts that two double values are not the same. If they are the same value,
+     * an {@link AssertionError} is thrown with the given message.
+     *
+     * @param message the identifying message for the {@link AssertionError} (<code>null</code>
+     * okay)
+     * @param unexpected the value you don't expect
+     * @param actual the value to compare to <code>unexpected</code>
+     */
+    public static void assertNotSame(String message, double unexpected,
+            double actual) {
+        if (unexpected == actual) {
+            failSame(message);
+        }
     }
 
     /**
@@ -798,6 +927,42 @@ public class Assert {
         if (unexpected == actual) {
             failSame(message);
         }
+    }
+
+    /**
+     * Asserts that two boolean values are not the same value. If they are
+     * the same, an {@link AssertionError} without a message is
+     * thrown.
+     *
+     * @param unexpected the value you don't expect
+     * @param actual the value to compare to <code>unexpected</code>
+     */
+    public static void assertNotSame(boolean unexpected, boolean actual) {
+        assertNotSame(null, unexpected, actual);
+    }
+
+    /**
+     * Asserts that two long values are not the same value. If they are
+     * the same, an {@link AssertionError} without a message is
+     * thrown.
+     *
+     * @param unexpected the value you don't expect
+     * @param actual the value to compare to <code>unexpected</code>
+     */
+    public static void assertNotSame(long unexpected, long actual) {
+        assertNotSame(null, unexpected, actual);
+    }
+
+    /**
+     * Asserts that two double values are not the same value. If they are
+     * the same, an {@link AssertionError} without a message is
+     * thrown.
+     *
+     * @param unexpected the value you don't expect
+     * @param actual the value to compare to <code>unexpected</code>
+     */
+    public static void assertNotSame(double unexpected, double actual) {
+        assertNotSame(null, unexpected, actual);
     }
 
     /**

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -605,10 +605,271 @@ public class AssertionTest {
     }
 
     @Test
-    public void notSameNullMessage() {
-        Object o = new Object();
+    public void sameBoolean() {
+        boolean b = true;
+        assertSame(b, b);
+    }
+
+    @Test
+    public void sameByte() {
+        byte b = 123;
+        assertSame(b, b);
+    }
+
+    @Test
+    public void sameChar() {
+        char c = '\u0123';
+        assertSame(c, c);
+    }
+
+    @Test
+    public void sameShort() {
+        short n = 1234;
+        assertSame(n, n);
+    }
+
+    @Test
+    public void sameIntSmall() {
+        int i = 123;
+        assertSame(i, i);
+    }
+
+    @Test
+    public void sameIntLarge() {
+        int i = 123456;
+        assertSame(i, i);
+    }
+
+    @Test
+    public void sameIntFloat() {
+        int i = 123456;
+        float f = 123456;
+        assertSame(i, f);
+    }
+
+    @Test
+    public void sameFloatInt() {
+        int i = 123456;
+        float f = 123456;
+        assertSame(i, f);
+    }
+
+    public void sameIntLong() {
+        int i = 123456;
+        long l = 123456;
+        assertSame(i, l);
+    }
+
+    @Test
+    public void sameLongInt() {
+        long l = 123456;
+        int i = 123456;
+        assertSame(l, i);
+    }
+
+    @Test
+    public void sameFloat() {
+        float f = 123.456f;
+        assertSame(f, f);
+    }
+
+    @Test
+    public void sameDouble() {
+        double d = 123.456E129;
+        assertSame(d, d);
+    }
+
+    @Test
+    public void notSameBoolean() {
+        boolean b1 = true;
+        boolean b2 = false;
+        assertNotSame(b1, b2);
+    }
+
+    @Test
+    public void notSameByte() {
+        byte b1 = 123;
+        byte b2 = 124;
+        assertNotSame(b1, b2);
+    }
+
+    @Test
+    public void notSameChar() {
+        char c1 = '\u0123';
+        char c2 = '\u0124';
+        assertNotSame(c1, c2);
+    }
+
+    @Test
+    public void notSameShort() {
+        short a = 1234;
+        short b = 1235;
+        assertNotSame(a, b);
+    }
+
+    @Test
+    public void notSameIntSmall() {
+        int i1 = 111;
+        int i2 = 112;
+        assertNotSame(i1, i2);
+    }
+
+    @Test
+    public void notSameIntLarge() {
+        int i1 = 1111111111;
+        int i2 = 1111111112;
+        assertNotSame(i1, i2);
+    }
+
+    @Test
+    public void notSameLong() {
+        long l1 = 11111111111L;
+        long l2 = 11111111112L;
+        assertNotSame(l1, l2);
+    }
+
+    @Test
+    public void notSameFloat() {
+        float f1 = 1111111.1f;
+        float f2 = 1111111.2f;
+        assertNotSame(f1, f2);
+    }
+
+    @Test
+    public void notSameDouble() {
+        double d1 = 1.111E129;
+        double d2 = 1.112E129;
+        assertNotSame(d1, d2);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sameBooleanFail() {
+        assertSame(true, false);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sameByteFail() {
+        assertSame((byte)111, (byte)112);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sameShortFail() {
+        assertSame((short)1234, (short)1235);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sameIntSmallFail() {
+        assertSame(111, 112);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sameIntLargeFail() {
+        assertSame(111111, 111112);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sameLongFail() {
+        assertSame(11111111111L, 11111111112L);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sameFloatFail() {
+        assertSame(1111111.1f, 1111111.2f);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void sameDoubleFail() {
+        assertSame(1.111E129, 1.112E129);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void notSameBooleanFail() {
+        boolean b = true;
+        assertNotSame(b, b);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void notSameByteFail() {
+        byte b = 123;
+        assertNotSame(b, b);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void notSameShortFail() {
+        short a = 1234;
+        assertNotSame(a, a);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void notSameIntSmallFail() {
+        int i = 123;
+        assertNotSame(i, i);
+    }
+    
+    @Test(expected = AssertionError.class)
+    public void notSameIntLargeFail() {
+        int i = 111111;
+        assertNotSame(i, i);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void notSameLongFail() {
+        long l = 11111111111L;
+        assertNotSame(l, l);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void notSameFloatFail() {
+        float f = 1111111.1f;
+        assertNotSame(f, f);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void notSameDoubleFail() {
+        double d =  1.111E129;
+        assertNotSame(d, d);
+    }
+
+    @Test
+    public void sameIntWithMessage() {
         try {
-            assertNotSame(o, o);
+            assertSame("not same", 111111, 111112);
+        } catch (AssertionError exception) {
+            assertEquals("not same expected same:<111111> was not:<111112>",
+                    exception.getMessage());
+            return;
+        }
+        throw new AssertionError(ASSERTION_ERROR_EXPECTED);
+    }
+
+    @Test
+    public void sameIntNullMessage() {
+        try {
+            assertSame(111111, 111112);
+        } catch (AssertionError exception) {
+            assertEquals("expected same:<111111> was not:<111112>", exception.getMessage());
+            return;
+        }
+        throw new AssertionError(ASSERTION_ERROR_EXPECTED);
+    }
+
+    @Test
+    public void notSameIntWithMessage() {
+        int i = 111111;
+        try {
+            assertNotSame("message", i, i);
+        } catch (AssertionError exception) {
+            assertEquals("message expected not same", exception.getMessage());
+            return;
+        }
+        throw new AssertionError(ASSERTION_ERROR_EXPECTED);
+    }
+
+    @Test
+    public void notSameIntNullMessage() {
+        int i = 111111;
+        try {
+            assertNotSame(i, i);
         } catch (AssertionError exception) {
             assertEquals("expected not same", exception.getMessage());
             return;


### PR DESCRIPTION
This PR attempts to address some potentially unexpected behaviour of assertSame() when passed primitive expected and actual arguments.

Currently:

1. assertSame(123, 123) passes because the although the primitive int arguments are boxed into Integer, most implementations of JVM cache the boxed Integers for values of 0 through 127.
2. assertSame(130, 130) fails because the primitive int arguments are boxed into 2 distinct instances of Integer.
3. assertSame(true, true) and assertSame(false, false) both pass but only because JVM implementations typically box boolean values to the same 2 constant instances Boolean.TRUE and Boolean.FALSE.
4. assertSame() for the other primitive types (char, byte, short, long, float and double) will likewise succeed or fail on the basis of whether the JVM boxing implementation decides to resolve the two arguments to the same reference or not.

Although some might argue that developers simply avoid using assertSame() with primitive types, plenty of API returns primitive values, and if assertSame() is used then the principle of "least surprise" should apply.

The solution implemented in this PR follows the rationale that:

- assertEquals(a, b) should correspond to the semantics of a.equals(b) for distinct objects or boxed primitives, with the addition of corner cases for one or both arguments being null
- assertSame(a, b) should correspond to the semantics of a == b for both Objects and primitive values.

I initially considered whether assertSame(a, b) might correspond to the (JavaScript / ECMA) semantics of a === b, (i.e. both type and value the same) however that would be quite laborious to implement due to implicit Method Invocation Conversions.

I have implemented new assertSame() functions with signatures taking boolean, long, and double primitive arguments. The aforementioned implicit Method Invocation Conversions take care of the remaining primitive types.

I realize the new assertSame(boolean, boolean) is redundant owing to the fact that assertSame(Object, Object) happens to work as expected for boxed boolean values, however it is there for consistency.  If all other primitive types are spared auto-boxing when passed to assertSame() why should boolean be left out?