### PR TITLE
Add a new feature to let test methds in a class run as user specified order

### DIFF
--- a/src/main/java/org/junit/Test.java
+++ b/src/main/java/org/junit/Test.java
@@ -95,4 +95,16 @@ public @interface Test {
      * </p>
      */
     long timeout() default 0L;
+
+    /**
+     * Optionally specify <code>priority</code>, a int value, to let the methods run as <code>priority</code> ascending order,
+     * <p>
+     * <b>NOTE:</b>
+     * <br/>
+     * If you want it works, you must use <code>@FixMethodOrder(MethodSorters.SPECIFIED_PRIORITY)</code> in your test class.
+     * <br/>
+     * If two methods have the same priority, they will run as the {@link org.junit.internal.MethodSorter#DEFAULT} order.
+     * </p>
+     */
+    int priority() default 0;
 }

--- a/src/main/java/org/junit/internal/MethodSorter.java
+++ b/src/main/java/org/junit/internal/MethodSorter.java
@@ -41,7 +41,6 @@ public class MethodSorter {
      * If <code>priority</code> have the same value, it will run as {@link #DEFAULT} order.
      */
     public static final Comparator<Method> SPECIFIED_PRIORITY = new Comparator<Method>() {
-        @Override
         public int compare(Method m1, Method m2) {
             Test a1 = m1.getAnnotation(Test.class);
             Test a2 = m2.getAnnotation(Test.class);

--- a/src/main/java/org/junit/internal/MethodSorter.java
+++ b/src/main/java/org/junit/internal/MethodSorter.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 public class MethodSorter {
     /**
@@ -31,6 +33,24 @@ public class MethodSorter {
                 return comparison;
             }
             return m1.toString().compareTo(m2.toString());
+        }
+    };
+
+    /**
+     * SPECIFIED_PRIORITY sort order. The method will run as the <code>priority</code> ascending order.
+     * If <code>priority</code> have the same value, it will run as {@link #DEFAULT} order.
+     */
+    public static final Comparator<Method> SPECIFIED_PRIORITY = new Comparator<Method>() {
+        @Override
+        public int compare(Method m1, Method m2) {
+            Test a1 = m1.getAnnotation(Test.class);
+            Test a2 = m2.getAnnotation(Test.class);
+            int p1 = a1 == null ? 0 : a1.priority();
+            int p2 = a2 == null ? 0 : a2.priority();
+            if (p1 != p2) {
+                return p1 < p2 ? -1 : 1;
+            }
+            return NAME_ASCENDING.compare(m1, m2);
         }
     };
 

--- a/src/main/java/org/junit/runners/MethodSorters.java
+++ b/src/main/java/org/junit/runners/MethodSorters.java
@@ -3,6 +3,7 @@ package org.junit.runners;
 import java.lang.reflect.Method;
 import java.util.Comparator;
 
+import org.junit.Test;
 import org.junit.internal.MethodSorter;
 
 /**
@@ -12,6 +13,14 @@ import org.junit.internal.MethodSorter;
  * @since 4.11
  */
 public enum MethodSorters {
+
+    /**
+     * Sorts the test methods by the specified priority order.
+     *
+     * @see {@link Test#priority()}
+     */
+    SPECIFIED_PRIORITY(MethodSorter.SPECIFIED_PRIORITY),
+
     /**
      * Sorts the test methods by the method name, in lexicographic order,
      * with {@link Method#toString()} used as a tiebreaker

--- a/src/main/java/org/junit/runners/MethodSorters.java
+++ b/src/main/java/org/junit/runners/MethodSorters.java
@@ -17,7 +17,7 @@ public enum MethodSorters {
     /**
      * Sorts the test methods by the specified priority order.
      *
-     * @see {@link Test#priority()}
+     * @see Test#priority()
      */
     SPECIFIED_PRIORITY(MethodSorter.SPECIFIED_PRIORITY),
 

--- a/src/test/java/org/junit/internal/AllInternalTests.java
+++ b/src/test/java/org/junit/internal/AllInternalTests.java
@@ -17,6 +17,7 @@ import org.junit.runners.Suite.SuiteClasses;
         ErrorReportingRunnerTest.class,
         ExpectExceptionTest.class,
         FailOnTimeoutTest.class,
+        MethodSorterPriorityTest.class,
         MethodSorterTest.class,
         StacktracePrintingMatcherTest.class,
         StackTracesTest.class,

--- a/src/test/java/org/junit/internal/MethodSorterPriorityTest.java
+++ b/src/test/java/org/junit/internal/MethodSorterPriorityTest.java
@@ -1,0 +1,45 @@
+package org.junit.internal;
+
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.lang.reflect.Method;
+
+
+@FixMethodOrder(MethodSorters.SPECIFIED_PRIORITY)
+public class MethodSorterPriorityTest {
+
+    @Test(priority = 10)
+    public void testM2() throws Exception {
+        printMethodInfo();
+    }
+
+    @Test(priority = 2)
+    public void testM3() throws Exception {
+        printMethodInfo();
+    }
+
+    @Test
+    public void testM1() throws Exception {
+        printMethodInfo();
+    }
+
+    @Test(priority = -10)
+    public void testA10() throws Exception {
+        printMethodInfo();
+    }
+
+    private void printMethodInfo() throws NoSuchMethodException {
+        StackTraceElement[] stackTrace = new Exception().getStackTrace();
+        final int offset = 1;
+        StringBuilder info = new StringBuilder();
+        info.append(stackTrace[offset].getClassName())
+                .append(".").append(stackTrace[offset].getMethodName());
+        Method m = this.getClass().getMethod(stackTrace[offset].getMethodName());
+        Test ann = m.getAnnotation(Test.class);
+        info.append(" -> ").append(ann.priority());
+        System.out.println(info);
+    }
+}
+

--- a/src/test/java/org/junit/internal/MethodSorterPriorityTest.java
+++ b/src/test/java/org/junit/internal/MethodSorterPriorityTest.java
@@ -1,45 +1,85 @@
 package org.junit.internal;
 
-import org.junit.FixMethodOrder;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
 import org.junit.runners.MethodSorters;
 
-import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.*;
 
 
 @FixMethodOrder(MethodSorters.SPECIFIED_PRIORITY)
 public class MethodSorterPriorityTest {
+    private static ExecutorService executorService;
 
-    @Test(priority = 10)
-    public void testM2() throws Exception {
-        printMethodInfo();
+    @BeforeClass
+    public static void startExecutorService() {
+        executorService = Executors.newFixedThreadPool(1);
     }
 
-    @Test(priority = 2)
-    public void testM3() throws Exception {
-        printMethodInfo();
+    @AfterClass
+    public static void shutDownExecutorService() {
+        executorService.shutdown();
+        executorService = null;
+    }
+
+    private static Result runTest(final Class<?> testClass) {
+        Future<Result> future = executorService.submit(new Callable<Result>() {
+            public Result call() throws Exception {
+                JUnitCore core = new JUnitCore();
+                return core.run(testClass);
+            }
+        });
+
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Could not run test " + testClass, e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException("Could not run test " + testClass, e);
+        }
+    }
+
+    private static List<String> realMethodList = new LinkedList<String>();
+
+    private static void markCurrentMethodInfo() {
+        StackTraceElement[] stackTrace = new Exception().getStackTrace();
+        final int offset = 2;
+        realMethodList.add(stackTrace[offset].getMethodName());
+    }
+
+    @FixMethodOrder(MethodSorters.SPECIFIED_PRIORITY)
+    public static class MethodPriorityClass {
+
+        @Test(priority = 3)
+        public void testMethod1() {
+            markCurrentMethodInfo();
+        }
+
+        @Test(priority = 1)
+        public void testMethod2() {
+            markCurrentMethodInfo();
+        }
+
+        @Test(priority = 2)
+        public void testMethod3() {
+            markCurrentMethodInfo();
+        }
     }
 
     @Test
-    public void testM1() throws Exception {
-        printMethodInfo();
+    public void testMethodPriority() {
+        runTest(MethodPriorityClass.class);
+        List<String> expectedMethodList = Arrays.asList("testMethod2", "testMethod3", "testMethod1");
+        Assert.assertEquals(expectedMethodList.size(), realMethodList.size());
+        for (int i = 0; i < realMethodList.size(); i++) {
+            Assert.assertEquals(expectedMethodList.get(i), realMethodList.get(i));
+        }
+        realMethodList.clear();
     }
 
-    @Test(priority = -10)
-    public void testA10() throws Exception {
-        printMethodInfo();
-    }
-
-    private void printMethodInfo() throws NoSuchMethodException {
-        StackTraceElement[] stackTrace = new Exception().getStackTrace();
-        final int offset = 1;
-        StringBuilder info = new StringBuilder();
-        info.append(stackTrace[offset].getClassName())
-                .append(".").append(stackTrace[offset].getMethodName());
-        Method m = this.getClass().getMethod(stackTrace[offset].getMethodName());
-        Test ann = m.getAnnotation(Test.class);
-        info.append(" -> ").append(ann.priority());
-        System.out.println(info);
-    }
 }
 


### PR DESCRIPTION
This is a new feature to let JUnit run as you specified order. What we need do is two steps:
1. Adding annotation 'FixMethodOrder(MethodSorters.SPECIFIED_PRIORITY)'.
2. Specify 'priority' value for methed annotation 'Test'.

This feature is an optional featue to let JUnit users specify method order in some special scenarios.
More details please refer to the comments in changed code.