### PR TITLE
Add assertThrows overloads with ThrowingSupplier

### DIFF
--- a/src/main/java/org/junit/function/ThrowingRunnable.java
+++ b/src/main/java/org/junit/function/ThrowingRunnable.java
@@ -1,13 +1,16 @@
 package org.junit.function;
 
 /**
- * This interface facilitates the use of
- * {@link org.junit.Assert#assertThrows(Class, ThrowingRunnable)} from Java 8. It allows method
- * references to void methods (that declare checked exceptions) to be passed directly into
- * {@code assertThrows}
- * without wrapping. It is not meant to be implemented directly.
+ * Represents an executable operation that may throw a {@code Throwable}.
+ *
+ * <p>This interface facilitates the use of {@link org.junit.Assert#assertThrows(Class, ThrowingRunnable)}
+ * from Java 8 and above. It allows method references to methods without arguments (that declare checked
+ * exceptions) to be passed directly into {@code assertThrows} without wrapping. It is not meant to be
+ * implemented directly.
  *
  * @since 4.13
+ * @see org.junit.Assert#assertThrows(Class, ThrowingRunnable)
+ * @see org.junit.Assert#assertThrows(String, Class, ThrowingRunnable)
  */
 public interface ThrowingRunnable {
     void run() throws Throwable;

--- a/src/main/java/org/junit/function/ThrowingSupplier.java
+++ b/src/main/java/org/junit/function/ThrowingSupplier.java
@@ -1,0 +1,17 @@
+package org.junit.function;
+
+/**
+ * Represents a supplier of results that may throw a {@code Throwable}.
+ *
+ * <p>This interface facilitates the use of {@link org.junit.Assert#assertThrows(Class, ThrowingSupplier)}
+ * from Java 8 and above. It allows method references to methods without arguments (that declare checked
+ * exceptions) to be passed directly into {@code assertThrows} without wrapping. It is not meant to be
+ * implemented directly.
+ *
+ * @since 4.13
+ * @see org.junit.Assert#assertThrows(Class, ThrowingSupplier)
+ * @see org.junit.Assert#assertThrows(String, Class, ThrowingSupplier)
+ */
+public interface ThrowingSupplier<T> {
+    T get() throws Throwable;
+}


### PR DESCRIPTION
This PR aligns `Assert` with Jupiter's `Assertions` class by adding overloaded variants of `assertThrows` that take a `ThrowingSupplier` instead of a `ThrowingRunnable` which was originally proposed and implemented by @cushon in https://github.com/junit-team/junit5/pull/1401.

If the given `ThrowingSupplier` fails to throw the expected exception and instead returns a value, the string representation of the value is included in the failure message to aide debugging.