### PR TITLE
Close `ObjectOutputStream` in a finally clause

### DIFF
--- a/src/main/java/org/junit/experimental/max/MaxHistory.java
+++ b/src/main/java/org/junit/experimental/max/MaxHistory.java
@@ -75,10 +75,15 @@ public class MaxHistory implements Serializable {
     }
 
     private void save() throws IOException {
-        ObjectOutputStream stream = new ObjectOutputStream(new FileOutputStream(
-                fHistoryStore));
-        stream.writeObject(this);
-        stream.close();
+        ObjectOutputStream stream = null;
+        try {
+            stream = new ObjectOutputStream(new FileOutputStream(fHistoryStore));
+            stream.writeObject(this);
+        } finally {
+            if (stream != null) {
+                stream.close();
+            }
+        }
     }
 
     Long getFailureTimestamp(Description key) {


### PR DESCRIPTION
- Used a finally block to close the stream.
- fix https://github.com/junit-team/junit4/issues/1556