### PR TITLE
Remove generic wildcard in return parameters

### DIFF
--- a/src/main/java/junit/framework/TestSuite.java
+++ b/src/main/java/junit/framework/TestSuite.java
@@ -56,12 +56,12 @@ public class TestSuite implements Test {
         Object test;
         try {
             if (constructor.getParameterTypes().length == 0) {
-                test = constructor.newInstance(new Object[0]);
+                test = constructor.newInstance();
                 if (test instanceof TestCase) {
                     ((TestCase) test).setName(name);
                 }
             } else {
-                test = constructor.newInstance(new Object[]{name});
+                test = constructor.newInstance(name);
             }
         } catch (InstantiationException e) {
             return (warning("Cannot instantiate test case: " + name + " (" + Throwables.getStacktrace(e) + ")"));

--- a/src/main/java/junit/framework/TestSuite.java
+++ b/src/main/java/junit/framework/TestSuite.java
@@ -47,7 +47,7 @@ public class TestSuite implements Test {
      * mountains, our intrepid adventurers type...
      */
     static public Test createTest(Class<?> theClass, String name) {
-        Constructor<?> constructor;
+        Constructor constructor;
         try {
             constructor = getTestConstructor(theClass);
         } catch (NoSuchMethodException e) {
@@ -77,7 +77,7 @@ public class TestSuite implements Test {
      * Gets a constructor which takes a single String as
      * its argument or a no arg constructor.
      */
-    public static Constructor<?> getTestConstructor(Class<?> theClass) throws NoSuchMethodException {
+    public static Constructor getTestConstructor(Class<?> theClass) throws NoSuchMethodException {
         try {
             return theClass.getConstructor(String.class);
         } catch (NoSuchMethodException e) {

--- a/src/main/java/org/junit/internal/runners/TestClass.java
+++ b/src/main/java/org/junit/internal/runners/TestClass.java
@@ -94,7 +94,7 @@ public class TestClass {
         return results;
     }
 
-    public Constructor<?> getConstructor() throws SecurityException, NoSuchMethodException {
+    public Constructor getConstructor() throws SecurityException, NoSuchMethodException {
         return klass.getConstructor();
     }
 

--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -200,7 +200,7 @@ public class TestClass implements Annotatable {
      * AssertionError} if there are more or less than one.
      */
 
-    public Constructor<?> getOnlyConstructor() {
+    public Constructor getOnlyConstructor() {
         Constructor<?>[] constructors = clazz.getConstructors();
         Assert.assertEquals(1, constructors.length);
         return constructors[0];


### PR DESCRIPTION
- remove generic wildcard in return parameters.
- remove explicit array creation in `newInstance(Object ... initargs)` method.