### PR TITLE
Changed Assert.assertThat to MatcherAssert.assertThat

### DIFF
--- a/src/test/java/org/junit/AssumptionViolatedExceptionTest.java
+++ b/src/test/java/org/junit/AssumptionViolatedExceptionTest.java
@@ -3,7 +3,7 @@ package org.junit;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeThat;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;

--- a/src/test/java/org/junit/experimental/categories/CategoryTest.java
+++ b/src/test/java/org/junit/experimental/categories/CategoryTest.java
@@ -2,7 +2,7 @@ package org.junit.experimental.categories;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.experimental.results.PrintableResult.testResult;

--- a/src/test/java/org/junit/experimental/categories/CategoryValidatorTest.java
+++ b/src/test/java/org/junit/experimental/categories/CategoryValidatorTest.java
@@ -1,7 +1,7 @@
 package org.junit.experimental.categories;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 

--- a/src/test/java/org/junit/experimental/categories/JavadocTest.java
+++ b/src/test/java/org/junit/experimental/categories/JavadocTest.java
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/org/junit/experimental/categories/MultiCategoryTest.java
+++ b/src/test/java/org/junit/experimental/categories/MultiCategoryTest.java
@@ -11,7 +11,7 @@ import org.junit.runners.Suite;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/src/test/java/org/junit/internal/StackTracesTest.java
+++ b/src/test/java/org/junit/internal/StackTracesTest.java
@@ -2,7 +2,7 @@ package org.junit.internal;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 

--- a/src/test/java/org/junit/internal/builders/AnnotatedBuilderTest.java
+++ b/src/test/java/org/junit/internal/builders/AnnotatedBuilderTest.java
@@ -3,7 +3,7 @@ package org.junit.internal.builders;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runner.Runner;

--- a/src/test/java/org/junit/internal/matchers/StacktracePrintingMatcherTest.java
+++ b/src/test/java/org/junit/internal/matchers/StacktracePrintingMatcherTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.internal.matchers.StacktracePrintingMatcher.isException;
 import static org.junit.internal.matchers.StacktracePrintingMatcher.isThrowable;

--- a/src/test/java/org/junit/internal/matchers/ThrowableCauseMatcherTest.java
+++ b/src/test/java/org/junit/internal/matchers/ThrowableCauseMatcherTest.java
@@ -3,7 +3,7 @@ package org.junit.internal.matchers;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.internal.matchers.ThrowableCauseMatcher.hasCause;
 
 public class ThrowableCauseMatcherTest {

--- a/src/test/java/org/junit/internal/runners/statements/ExpectExceptionTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/ExpectExceptionTest.java
@@ -6,7 +6,7 @@ import org.junit.runners.model.Statement;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 /**

--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -16,8 +16,6 @@ import static org.junit.internal.runners.statements.FailOnTimeout.builder;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;

--- a/src/test/java/org/junit/rules/BlockJUnit4ClassRunnerOverrideTest.java
+++ b/src/test/java/org/junit/rules/BlockJUnit4ClassRunnerOverrideTest.java
@@ -1,6 +1,6 @@
 package org.junit.rules;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.experimental.results.PrintableResult.testResult;

--- a/src/test/java/org/junit/rules/ClassRulesTest.java
+++ b/src/test/java/org/junit/rules/ClassRulesTest.java
@@ -4,7 +4,7 @@
 package org.junit.rules;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;

--- a/src/test/java/org/junit/rules/ExpectedExceptionTest.java
+++ b/src/test/java/org/junit/rules/ExpectedExceptionTest.java
@@ -7,7 +7,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.junit.rules.ExpectedException.none;

--- a/src/test/java/org/junit/rules/MethodRulesTest.java
+++ b/src/test/java/org/junit/rules/MethodRulesTest.java
@@ -3,7 +3,7 @@ package org.junit.rules;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.experimental.results.PrintableResult.testResult;

--- a/src/test/java/org/junit/rules/StopwatchTest.java
+++ b/src/test/java/org/junit/rules/StopwatchTest.java
@@ -3,7 +3,7 @@ package org.junit.rules;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;

--- a/src/test/java/org/junit/rules/TempFolderRuleTest.java
+++ b/src/test/java/org/junit/rules/TempFolderRuleTest.java
@@ -3,7 +3,7 @@ package org.junit.rules;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.failureCountIs;

--- a/src/test/java/org/junit/rules/TemporaryFolderRuleAssuredDeletionTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderRuleAssuredDeletionTest.java
@@ -1,7 +1,7 @@
 package org.junit.rules;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.failureCountIs;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;

--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -3,7 +3,7 @@ package org.junit.rules;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;

--- a/src/test/java/org/junit/rules/TestRuleTest.java
+++ b/src/test/java/org/junit/rules/TestRuleTest.java
@@ -3,7 +3,7 @@ package org.junit.rules;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.experimental.results.PrintableResult.testResult;

--- a/src/test/java/org/junit/rules/TestWatchmanTest.java
+++ b/src/test/java/org/junit/rules/TestWatchmanTest.java
@@ -2,7 +2,7 @@ package org.junit.rules;
 
 import static junit.framework.Assert.fail;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeTrue;
 import static org.junit.runner.JUnitCore.runClasses;
 import org.junit.BeforeClass;

--- a/src/test/java/org/junit/rules/TimeoutRuleTest.java
+++ b/src/test/java/org/junit/rules/TimeoutRuleTest.java
@@ -2,7 +2,7 @@ package org.junit.rules;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/org/junit/rules/VerifierRuleTest.java
+++ b/src/test/java/org/junit/rules/VerifierRuleTest.java
@@ -1,7 +1,7 @@
 package org.junit.rules;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 

--- a/src/test/java/org/junit/runner/notification/ConcurrentRunNotifierTest.java
+++ b/src/test/java/org/junit/runner/notification/ConcurrentRunNotifierTest.java
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/src/test/java/org/junit/runner/notification/RunNotifierTest.java
+++ b/src/test/java/org/junit/runner/notification/RunNotifierTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/test/java/org/junit/runners/model/FrameworkFieldTest.java
+++ b/src/test/java/org/junit/runners/model/FrameworkFieldTest.java
@@ -2,7 +2,7 @@ package org.junit.runners.model;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.rules.ExpectedException.none;
 

--- a/src/test/java/org/junit/runners/model/FrameworkMethodTest.java
+++ b/src/test/java/org/junit/runners/model/FrameworkMethodTest.java
@@ -2,7 +2,7 @@ package org.junit.runners.model;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.rules.ExpectedException.none;
 

--- a/src/test/java/org/junit/tests/ObjectContractTest.java
+++ b/src/test/java/org/junit/tests/ObjectContractTest.java
@@ -1,7 +1,7 @@
 package org.junit.tests;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeThat;
 

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;

--- a/src/test/java/org/junit/tests/deprecated/JUnit4ClassRunnerTest.java
+++ b/src/test/java/org/junit/tests/deprecated/JUnit4ClassRunnerTest.java
@@ -1,7 +1,7 @@
 package org.junit.tests.deprecated;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNoException;

--- a/src/test/java/org/junit/tests/experimental/MatcherTest.java
+++ b/src/test/java/org/junit/tests/experimental/MatcherTest.java
@@ -1,7 +1,7 @@
 package org.junit.tests.experimental;
 
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeThat;
 import static org.junit.experimental.results.ResultMatchers.hasFailureContaining;
 import static org.junit.experimental.results.ResultMatchers.hasSingleFailureContaining;

--- a/src/test/java/org/junit/tests/experimental/max/DescriptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/max/DescriptionTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.annotation.Annotation;
 import java.net.URL;

--- a/src/test/java/org/junit/tests/experimental/max/MaxStarterTest.java
+++ b/src/test/java/org/junit/tests/experimental/max/MaxStarterTest.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.max;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/org/junit/tests/experimental/parallel/ParallelClassTest.java
+++ b/src/test/java/org/junit/tests/experimental/parallel/ParallelClassTest.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.parallel;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.CountDownLatch;

--- a/src/test/java/org/junit/tests/experimental/parallel/ParallelMethodTest.java
+++ b/src/test/java/org/junit/tests/experimental/parallel/ParallelMethodTest.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.parallel;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.CountDownLatch;

--- a/src/test/java/org/junit/tests/experimental/results/PrintableResultTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/PrintableResultTest.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.results;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 

--- a/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
+++ b/src/test/java/org/junit/tests/experimental/results/ResultMatchersTest.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class ResultMatchersTest {
 

--- a/src/test/java/org/junit/tests/experimental/theories/ParameterSignatureTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/ParameterSignatureTest.java
@@ -2,7 +2,7 @@ package org.junit.tests.experimental.theories;
 
 import static org.hamcrest.CoreMatchers.isA;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 

--- a/src/test/java/org/junit/tests/experimental/theories/TestedOnSupplierTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/TestedOnSupplierTest.java
@@ -1,7 +1,7 @@
 package org.junit.tests.experimental.theories;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Method;
 import java.util.List;

--- a/src/test/java/org/junit/tests/experimental/theories/internal/AllMembersSupplierTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/internal/AllMembersSupplierTest.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.theories.internal;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.tests.experimental.theories.TheoryTestUtils.potentialAssignments;
 
 import java.util.Arrays;

--- a/src/test/java/org/junit/tests/experimental/theories/internal/ParameterizedAssertionErrorTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/internal/ParameterizedAssertionErrorTest.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.theories.internal;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeThat;
 

--- a/src/test/java/org/junit/tests/experimental/theories/internal/SpecificDataPointsSupplierTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/internal/SpecificDataPointsSupplierTest.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.theories.internal;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/org/junit/tests/experimental/theories/runner/FailingDataPointMethods.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/FailingDataPointMethods.java
@@ -1,7 +1,7 @@
 package org.junit.tests.experimental.theories.runner;
 
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 import org.junit.Test;

--- a/src/test/java/org/junit/tests/experimental/theories/runner/SuccessfulWithDataPointFields.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/SuccessfulWithDataPointFields.java
@@ -2,7 +2,7 @@ package org.junit.tests.experimental.theories.runner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 

--- a/src/test/java/org/junit/tests/experimental/theories/runner/TheoriesPerformanceTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/TheoriesPerformanceTest.java
@@ -1,6 +1,6 @@
 package org.junit.tests.experimental.theories.runner;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeTrue;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;

--- a/src/test/java/org/junit/tests/experimental/theories/runner/TypeMatchingBetweenMultiDataPointsMethod.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/TypeMatchingBetweenMultiDataPointsMethod.java
@@ -1,6 +1,6 @@
 package org.junit.tests.experimental.theories.runner;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 

--- a/src/test/java/org/junit/tests/experimental/theories/runner/UnsuccessfulWithDataPointFields.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/UnsuccessfulWithDataPointFields.java
@@ -2,7 +2,7 @@ package org.junit.tests.experimental.theories.runner;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.hasFailureContaining;
 import static org.junit.experimental.results.ResultMatchers.hasSingleFailureContaining;

--- a/src/test/java/org/junit/tests/experimental/theories/runner/WhenNoParametersMatch.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/WhenNoParametersMatch.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.theories.runner;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assume.assumeThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 

--- a/src/test/java/org/junit/tests/experimental/theories/runner/WithDataPointMethod.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/WithDataPointMethod.java
@@ -5,7 +5,7 @@ import static org.hamcrest.CoreMatchers.everyItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 import static org.junit.tests.experimental.theories.TheoryTestUtils.potentialAssignments;

--- a/src/test/java/org/junit/tests/experimental/theories/runner/WithExtendedParameterSources.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/WithExtendedParameterSources.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.theories.runner;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 

--- a/src/test/java/org/junit/tests/experimental/theories/runner/WithNamedDataPoints.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/WithNamedDataPoints.java
@@ -2,7 +2,7 @@ package org.junit.tests.experimental.theories.runner;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.tests.experimental.theories.TheoryTestUtils.potentialAssignments;
 
 import java.util.List;

--- a/src/test/java/org/junit/tests/experimental/theories/runner/WithOnlyTestAnnotations.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/WithOnlyTestAnnotations.java
@@ -3,7 +3,7 @@ package org.junit.tests.experimental.theories.runner;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.failureCountIs;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;

--- a/src/test/java/org/junit/tests/experimental/theories/runner/WithUnresolvedGenericTypeVariablesOnTheoryParms.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/WithUnresolvedGenericTypeVariablesOnTheoryParms.java
@@ -1,6 +1,6 @@
 package org.junit.tests.experimental.theories.runner;
 
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.failureCountIs;
 import static org.junit.experimental.results.ResultMatchers.hasFailureContaining;

--- a/src/test/java/org/junit/tests/junit3compatibility/AllTestsTest.java
+++ b/src/test/java/org/junit/tests/junit3compatibility/AllTestsTest.java
@@ -2,7 +2,7 @@ package org.junit.tests.junit3compatibility;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import junit.framework.JUnit4TestAdapter;

--- a/src/test/java/org/junit/tests/listening/TextListenerTest.java
+++ b/src/test/java/org/junit/tests/listening/TextListenerTest.java
@@ -2,7 +2,7 @@ package org.junit.tests.listening;
 
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;

--- a/src/test/java/org/junit/tests/manipulation/SingleMethodTest.java
+++ b/src/test/java/org/junit/tests/manipulation/SingleMethodTest.java
@@ -2,7 +2,7 @@ package org.junit.tests.manipulation;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/org/junit/tests/running/classes/ParentRunnerFilteringTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParentRunnerFilteringTest.java
@@ -1,7 +1,7 @@
 package org.junit.tests.running.classes;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.hasSingleFailureContaining;

--- a/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
@@ -3,7 +3,7 @@ package org.junit.tests.running.classes;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 

--- a/src/test/java/org/junit/tests/running/classes/SuiteTest.java
+++ b/src/test/java/org/junit/tests/running/classes/SuiteTest.java
@@ -1,7 +1,7 @@
 package org.junit.tests.running.classes;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.hasSingleFailureContaining;

--- a/src/test/java/org/junit/tests/running/methods/TimeoutTest.java
+++ b/src/test/java/org/junit/tests/running/methods/TimeoutTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 

--- a/src/test/java/org/junit/tests/validation/BadlyFormedClassesTest.java
+++ b/src/test/java/org/junit/tests/validation/BadlyFormedClassesTest.java
@@ -2,7 +2,7 @@ package org.junit.tests.validation;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/org/junit/validator/AnnotationValidatorFactoryTest.java
+++ b/src/test/java/org/junit/validator/AnnotationValidatorFactoryTest.java
@@ -2,7 +2,7 @@ package org.junit.validator;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/test/java/org/junit/validator/AnnotationsValidatorTest.java
+++ b/src/test/java/org/junit/validator/AnnotationsValidatorTest.java
@@ -2,7 +2,7 @@ package org.junit.validator;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;


### PR DESCRIPTION
Since Assert.assertThat only calls MatcherAssert.assertThat
it makes sense to start cleaning this up to make
 future deprecation an easier process.