### PR TITLE
Improve message if file exists instead of folder 

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -206,8 +206,13 @@ public class TemporaryFolder extends ExternalResource {
 
             lastMkdirsCallSuccessful = file.mkdirs();
             if (!lastMkdirsCallSuccessful && !file.isDirectory()) {
-                throw new IOException(
-                        "could not create a folder with the path \'" + relativePath.getPath() + "\'");
+                if (file.exists()) {
+                    throw new IOException(
+                            "a file with the path \'" + relativePath.getPath() + "\' exists");
+                } else {
+                    throw new IOException(
+                            "could not create a folder with the path \'" + relativePath.getPath() + "\'");
+                }
             }
         }
         if (!lastMkdirsCallSuccessful) {

--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -90,7 +90,7 @@ public class TemporaryFolderUsageTest {
         assertTrue("Could not create" + file, file.createNewFile());
 
         thrown.expect(IOException.class);
-        thrown.expectMessage("could not create a folder with the path 'level1'");
+        thrown.expectMessage("a file with the path 'level1' exists");
         tempFolder.newFolder("level1");
     }
 

--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -93,6 +93,17 @@ public class TemporaryFolderUsageTest {
         thrown.expectMessage("could not create a folder with the path 'level1'");
         tempFolder.newFolder("level1");
     }
+
+    @Test
+    public void newFolderWithGivenFolderThrowsIOExceptionWhenFolderCannotBeCreated() throws IOException {
+        tempFolder.create();
+        assertTrue("Could not make folder " + tempFolder.getRoot() + " read only.",
+                tempFolder.getRoot().setReadOnly());
+
+        thrown.expect(IOException.class);
+        thrown.expectMessage("could not create a folder with the path 'level1'");
+        tempFolder.newFolder("level1");
+    }
     
     @Test
     public void newFolderWithPathStartingWithFileSeparatorThrowsIOException()


### PR DESCRIPTION
When `TemporaryFolder(String path)` or `TemporaryFolder(String... paths)` is
called with a path that matches the path of an existing file then an
`IOException` with a message like "a file with path <path> exists" is
thrown.