### PR TITLE
Set 'junit' as `Automatic-Module-Name`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,6 +360,9 @@
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>junit</Automatic-Module-Name>
+                        </manifestEntries>                        
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Prior to this commit, `junit` was derived as the module name from the name of the JAR file. Now, `junit` is set as an explicit module name, stored in the MANIFEST.MF file, to ensure a smooth ride into the modular age for users of JUnit 4.