### PR TITLE
Fix UnsupportedOperationException on class rules

### DIFF
--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -542,7 +542,7 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
 
         public List<TestRule> getOrderedRules() {
             if (entries.isEmpty()) {
-                return Collections.emptyList();
+                return new ArrayList<TestRule>();
             }
             Collections.sort(entries, RuleContainer.ENTRY_COMPARATOR);
             List<TestRule> result = new ArrayList<TestRule>(entries.size());


### PR DESCRIPTION
Collections.emptyList() returns an immutable list. Calls to `BlockJUnit4ClassRunner#classRules().add(...)` used to work before, now result in UnsupportedOperationException. This fix returns a mutable, empty list.

See https://circleci.com/gh/spektrakel-blog/sparkles/752?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link