### PR TITLE
Clear thread interrupt status after each test

### DIFF
--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -319,6 +319,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         statement = withBefores(method, test, statement);
         statement = withAfters(method, test, statement);
         statement = withRules(method, test, statement);
+        statement = withInterruptIsolation(statement);
         return statement;
     }
 

--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -214,6 +214,7 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
             statement = withBeforeClasses(statement);
             statement = withAfterClasses(statement);
             statement = withClassRules(statement);
+            statement = withInterruptIsolation(statement);
         }
         return statement;
     }
@@ -289,6 +290,22 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
             @Override
             public void evaluate() {
                 runChildren(notifier);
+            }
+        };
+    }
+
+    /**
+     * @return a {@link Statement}: clears interrupt status of current thread after execution of statement
+     */
+    protected final Statement withInterruptIsolation(final Statement statement) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try {
+                    statement.evaluate();
+                } finally {
+                    Thread.interrupted(); // clearing thread interrupted status for isolation
+                }
             }
         };
     }

--- a/src/test/java/org/junit/tests/running/classes/AllClassesTests.java
+++ b/src/test/java/org/junit/tests/running/classes/AllClassesTests.java
@@ -17,7 +17,8 @@ import org.junit.tests.running.classes.parent.ParentRunnerClassLoaderTest;
         ParentRunnerClassLoaderTest.class,
         RunWithTest.class,
         SuiteTest.class,
-        UseSuiteAsASuperclassTest.class
+        UseSuiteAsASuperclassTest.class,
+        ThreadsTest.class
 })
 public class AllClassesTests {
 }

--- a/src/test/java/org/junit/tests/running/classes/ThreadsTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ThreadsTest.java
@@ -1,0 +1,91 @@
+package org.junit.tests.running.classes;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.internal.runners.ErrorReportingRunner;
+import org.junit.runner.Description;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Request;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunListener;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+import static org.junit.Assert.assertEquals;
+
+public class ThreadsTest {
+    private String log = "";
+
+    public static class TestWithInterrupt {
+
+        @Test
+        public void interruptCurrentThread() {
+            Thread.currentThread().interrupt();
+        }
+
+        @Test
+        public void otherTestCaseInterruptingCurrentThread() {
+            Thread.currentThread().interrupt();
+        }
+
+    }
+
+    @Test
+    public void currentThreadInterruptedStatusIsClearedAfterEachTestExecution() {
+        log = "";
+        JUnitCore jUnitCore = new JUnitCore();
+        jUnitCore.addListener(new RunListener() {
+            @Override
+            public void testFinished(Description description) {
+                log += Thread.currentThread().isInterrupted() + " ";
+            }
+        });
+
+        Result result = jUnitCore.run(TestWithInterrupt.class);
+        assertEquals(0, result.getFailureCount());
+        assertEquals("false false ", log);
+    }
+
+    @RunWith(BlockJUnit4ClassRunner.class)
+    public static class TestWithInterruptFromAfterClass {
+        @AfterClass
+        public static void interruptCurrentThread() {
+            Thread.currentThread().interrupt();
+        }
+
+        @Test
+        public void test() {
+            // no-op
+        }
+    }
+
+    @Test
+    public void currentThreadInterruptStatusIsClearedAfterSuiteExecution() {
+        log = "";
+        JUnitCore jUnitCore = new JUnitCore();
+        jUnitCore.addListener(new RunListener() {
+            @Override
+            public void testSuiteFinished(Description description) throws Exception {
+                log += Thread.currentThread().isInterrupted();
+            }
+        });
+
+        Request request = new Request() {
+            @Override
+            public Runner getRunner() {
+                try {
+                    return new BlockJUnit4ClassRunner(TestWithInterruptFromAfterClass.class) {
+                    };
+                } catch (InitializationError e) {
+                    return new ErrorReportingRunner(TestWithInterruptFromAfterClass.class, e);
+                }
+            }
+        };
+
+        Result result = jUnitCore.run(request);
+        assertEquals(0, result.getFailureCount());
+        assertEquals("false", log);
+    }
+}


### PR DESCRIPTION
The thread interrupt status flag is now cleared from `classBlock()` and
`methodBlock()`. The flag is cleared after each test case completes and
after `AfterClass` methods and `ClassRules` have been executed.

Fixes #1365.

---

Originally submitted as #1569.