### PR TITLE
Add test to verify failed is called when withBefores fails

### DIFF
--- a/src/test/java/org/junit/runner/AllRunnerTests.java
+++ b/src/test/java/org/junit/runner/AllRunnerTests.java
@@ -11,7 +11,8 @@ import org.junit.runners.Suite.SuiteClasses;
         FilterFactoriesTest.class,
         FilterOptionIntegrationTest.class,
         JUnitCommandLineParseResultTest.class,
-        JUnitCoreTest.class, RequestTest.class
+        JUnitCoreTest.class, RequestTest.class,
+        RunnerOrderTest.class
 })
 public class AllRunnerTests {
 }

--- a/src/test/java/org/junit/runner/RunnerOrderTest.java
+++ b/src/test/java/org/junit/runner/RunnerOrderTest.java
@@ -1,0 +1,73 @@
+package org.junit.runner;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+public class RunnerOrderTest {
+
+  @Test
+  public void runnerWithFailingTests() throws InitializationError {
+    ReportingRunner runner = new ReportingRunner(FailingTests.class);
+    runner.run(new RunNotifier());
+
+    assertFalse(runner.started);
+    assertTrue(runner.failed);
+    assertFalse(runner.finished);
+  }
+
+  public static class FailingTests {
+    @Test
+    public void this_test_is_supposed_to_fail() {
+      fail();
+    }
+  }
+
+  class ReportingRunner extends BlockJUnit4ClassRunner {
+
+    private boolean started;
+    private boolean failed;
+    private boolean finished;
+
+    public ReportingRunner(Class<?> testClass) throws InitializationError {
+      super(testClass);
+    }
+
+    @Override
+    protected Statement withBefores(FrameworkMethod method, Object target, Statement statement) {
+      throw new IllegalArgumentException();
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+      RunListener listener = new RunListener() {
+        @Override
+        public void testStarted(Description description) throws Exception {
+          started = true;
+        }
+
+        @Override
+        public void testFailure(Failure failure) throws Exception {
+          failed = true;
+        }
+
+        @Override
+        public void testFinished(Description description) throws Exception {
+          finished = true;
+        }
+      };
+      notifier.addListener(listener);
+      super.run(notifier);
+    }
+  }
+
+}


### PR DESCRIPTION
This is a regression test for a change in behavior between JUnit 4.12
and 4.13.

This test fails on `master`, but passes on `r4.12`. You can run `mvn test` on this PR to see it failing. You can run `mvn test` on https://github.com/TimvdLippe/junit4/tree/run-regression-test-on-4-12 to see it passing.

The difference in behavior seems to be related to the handling of the exception in `withBefores`. The `fail()` ensures that that fails fast. 4.12 will then state that the test was not started, did fail and did not finish, but 4.13 will report all as true.

Related to #1496