### PR TITLE
Restore that fields shadow fields from super class

### DIFF
--- a/src/main/java/org/junit/runners/model/FrameworkField.java
+++ b/src/main/java/org/junit/runners/model/FrameworkField.java
@@ -47,7 +47,7 @@ public class FrameworkField extends FrameworkMember<FrameworkField> {
 
     @Override
     public boolean isShadowedBy(FrameworkField otherMember) {
-        return isStatic() && otherMember.getName().equals(getName());
+        return otherMember.getName().equals(getName());
     }
 
     @Override

--- a/src/main/java/org/junit/runners/model/FrameworkMember.java
+++ b/src/main/java/org/junit/runners/model/FrameworkMember.java
@@ -12,13 +12,7 @@ public abstract class FrameworkMember<T extends FrameworkMember<T>> implements
         Annotatable {
     abstract boolean isShadowedBy(T otherMember);
 
-    /**
-     * Check if this member is shadowed by any of the given members. If it
-     * is, the other member is removed.
-     * 
-     * @return member that should be used, or {@code null} if no member should be used.
-     */
-    final T handlePossibleShadowedMember(List<T> members) {
+    T handlePossibleBridgeMethod(List<T> members) {
         for (int i = members.size() - 1; i >=0; i--) {
             T otherMember = members.get(i);
             if (isShadowedBy(otherMember)) {
@@ -36,11 +30,6 @@ public abstract class FrameworkMember<T extends FrameworkMember<T>> implements
             }
         }
         // No shadow or bridge method found. The caller should add *this* member.
-        return self();
-    }
-
-    @SuppressWarnings("unchecked")
-    private T self() {
         return (T) this;
     }
 

--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -84,7 +84,7 @@ public class TestClass implements Annotatable {
         for (Annotation each : member.getAnnotations()) {
             Class<? extends Annotation> type = each.annotationType();
             List<T> members = getAnnotatedMembers(map, type, true);
-            T memberToAdd = member.handlePossibleShadowedMember(members);
+            T memberToAdd = member.handlePossibleBridgeMethod(members);
             if (memberToAdd == null) {
                 return;
             }

--- a/src/test/java/org/junit/runners/model/TestClassTest.java
+++ b/src/test/java/org/junit/runners/model/TestClassTest.java
@@ -46,9 +46,9 @@ public class TestClassTest {
     }
 
     @Test
-    public void fieldsOnSubclassesDoNotShadowSuperclasses() {
+    public void fieldsOnSubclassesShadowSuperclasses() {
         assertThat(new TestClass(SubclassWithField.class).getAnnotatedFields(
-                Rule.class).size(), is(2));
+                Rule.class).size(), is(1));
     }
 
     public static class OuterClass {

--- a/src/test/java/org/junit/tests/running/methods/AnnotationTest.java
+++ b/src/test/java/org/junit/tests/running/methods/AnnotationTest.java
@@ -633,13 +633,13 @@ public class AnnotationTest extends TestCase {
         }
     }
 
-    public void testFieldsNeverTreatedAsShadowed() throws Exception {
+    public void testFieldsShadowFieldsFromParent() throws Exception {
         log = "";
         assertThat(testResult(SubFieldShadowing.class), isSuccessful());
         assertEquals(
-                "super.rule.before() sub.rule.before() "
+                "sub.rule.before() "
                 + "Test "
-                + "sub.rule.after() super.rule.after() ",
+                + "sub.rule.after() ",
                 log);
     }
 


### PR DESCRIPTION
This commit restores the shadowing behaviour of JUnit 4.12. Some users of JUnit 4 have tests that rely on this behaviour. Their tests would fail with JUnit 4.13.

This commit finally reverts 39b8a92d24e6c81e4fc614cdf13003ce17bbc166. Some parts have already been reverted by ed6813d3bbe2da4d67892f73e641fa80ab4d126e.