### PR TITLE
Run tests on Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: java
 
 script: ./mvnw verify javadoc:javadoc site:site


### PR DESCRIPTION
Trusty has support for OpenJDK 6 and other old JDKs.