### PR TITLE
Assume that TemporaryFolderUsageTest.newFolderWithGivenFolderThrowsIO…

### DIFF
--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -97,7 +98,7 @@ public class TemporaryFolderUsageTest {
     @Test
     public void newFolderWithGivenFolderThrowsIOExceptionWhenFolderCannotBeCreated() throws IOException {
         tempFolder.create();
-        assertTrue("Could not make folder " + tempFolder.getRoot() + " read only.",
+        assumeTrue("Could not make folder " + tempFolder.getRoot() + " read only.",
                 tempFolder.getRoot().setReadOnly());
 
         thrown.expect(IOException.class);


### PR DESCRIPTION
org.junit.rules.TemporaryFolderUsageTest#newFolderWithGivenFolderThrowsIOExceptionWhenFolderCannotBeCreated fails on Windows systems as a folder cannot be set to read-only. This is a pre-condition for the test and it has been changed such that the test is skipped if this cannot be satisified.