### PR TITLE
Made some variable names more consistent with the other parts.

### DIFF
--- a/src/main/java/org/junit/runner/Description.java
+++ b/src/main/java/org/junit/runner/Description.java
@@ -222,11 +222,11 @@ public class Description implements Serializable {
         if (isTest()) {
             return 1;
         }
-        int result = 0;
+        int conut = 0;
         for (Description child : fChildren) {
-            result += child.testCount();
+            conut += child.testCount();
         }
-        return result;
+        return conut;
     }
 
     @Override

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -164,9 +164,9 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 
     protected void validateNoNonStaticInnerClass(List<Throwable> errors) {
         if (getTestClass().isANonStaticInnerClass()) {
-            String gripe = "The inner class " + getTestClass().getName()
+            String message = "The inner class " + getTestClass().getName()
                     + " is not static.";
-            errors.add(new Exception(gripe));
+            errors.add(new Exception(message));
         }
     }
 
@@ -186,8 +186,8 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
      */
     protected void validateOnlyOneConstructor(List<Throwable> errors) {
         if (!hasOneConstructor()) {
-            String gripe = "Test class should have exactly one public constructor";
-            errors.add(new Exception(gripe));
+            String message = "Test class should have exactly one public constructor";
+            errors.add(new Exception(message));
         }
     }
 
@@ -199,8 +199,8 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
         if (!getTestClass().isANonStaticInnerClass()
                 && hasOneConstructor()
                 && (getTestClass().getOnlyConstructor().getParameterTypes().length != 0)) {
-            String gripe = "Test class should have exactly one public zero-argument constructor";
-            errors.add(new Exception(gripe));
+            String message = "Test class should have exactly one public zero-argument constructor";
+            errors.add(new Exception(message));
         }
     }
 

--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -208,9 +208,9 @@ public class TemporaryFolderUsageTest {
     public void newRandomFileIsCreatedUnderRootFolder() throws IOException {
         tempFolder.create();
 
-        File f = tempFolder.newFile();
-        assertFileExists(f);
-        assertFileCreatedUnderRootFolder("Random file", f);
+        File file = tempFolder.newFile();
+        assertFileExists(file);
+        assertFileCreatedUnderRootFolder("Random file", file);
     }
 
     @Test
@@ -218,33 +218,33 @@ public class TemporaryFolderUsageTest {
         final String fileName = "SampleFile.txt";
         tempFolder.create();
 
-        File f = tempFolder.newFile(fileName);
+        File file = tempFolder.newFile(fileName);
 
-        assertFileExists(f);
-        assertFileCreatedUnderRootFolder("Named file", f);
-        assertThat("file name", f.getName(), equalTo(fileName));
+        assertFileExists(file);
+        assertFileCreatedUnderRootFolder("Named file", file);
+        assertThat("file name", file.getName(), equalTo(fileName));
     }
 
     @Test
     public void newRandomFolderIsCreatedUnderRootFolder() throws IOException {
         tempFolder.create();
 
-        File f = tempFolder.newFolder();
-        assertFileIsDirectory(f);
-        assertFileCreatedUnderRootFolder("Random folder", f);
+        File file = tempFolder.newFolder();
+        assertFileIsDirectory(file);
+        assertFileCreatedUnderRootFolder("Random folder", file);
     }
 
     @Test
     public void newNestedFoldersCreatedUnderRootFolder() throws IOException {
         tempFolder.create();
 
-        File f = tempFolder.newFolder("top", "middle", "bottom");
-        assertFileIsDirectory(f);
-        assertParentFolderForFileIs(f, new File(tempFolder.getRoot(),
+        File file = tempFolder.newFolder("top", "middle", "bottom");
+        assertFileIsDirectory(file);
+        assertParentFolderForFileIs(file, new File(tempFolder.getRoot(),
                 "top/middle"));
-        assertParentFolderForFileIs(f.getParentFile(),
+        assertParentFolderForFileIs(file.getParentFile(),
                 new File(tempFolder.getRoot(), "top"));
-        assertFileCreatedUnderRootFolder("top", f.getParentFile()
+        assertFileCreatedUnderRootFolder("top", file.getParentFile()
                 .getParentFile());
     }
 
@@ -269,15 +269,15 @@ public class TemporaryFolderUsageTest {
         checkFileExists("exists", file, false);
     }
 
-    private void checkFileExists(String msg, File file, boolean exists) {
+    private void checkFileExists(String message, File file, boolean exists) {
         assertThat("File is null", file, is(notNullValue()));
-        assertThat("File '" + file.getAbsolutePath() + "' " + msg,
+        assertThat("File '" + file.getAbsolutePath() + "' " + message,
                 file.exists(), is(exists));
     }
 
-    private void checkFileIsDirectory(String msg, File file, boolean isDirectory) {
+    private void checkFileIsDirectory(String message, File file, boolean isDirectory) {
         assertThat("File is null", file, is(notNullValue()));
-        assertThat("File '" + file.getAbsolutePath() + "' " + msg,
+        assertThat("File '" + file.getAbsolutePath() + "' " + message,
                 file.isDirectory(), is(isDirectory));
     }
 
@@ -291,12 +291,12 @@ public class TemporaryFolderUsageTest {
         checkFileIsDirectory("is not a directory", file, true);
     }
 
-    private void assertFileCreatedUnderRootFolder(String msg, File f) {
-        assertParentFolderForFileIs(f, tempFolder.getRoot());
+    private void assertFileCreatedUnderRootFolder(String message, File file) {
+        assertParentFolderForFileIs(file, tempFolder.getRoot());
     }
 
-    private void assertParentFolderForFileIs(File f, File parentFolder) {
-        assertThat("'" + f.getAbsolutePath() + "': not under root",
-                f.getParentFile(), is(parentFolder));
+    private void assertParentFolderForFileIs(File file, File parentFolder) {
+        assertThat("'" + file.getAbsolutePath() + "': not under root",
+                file.getParentFile(), is(parentFolder));
     }
 }


### PR DESCRIPTION
Hello, we're developing an automated system that detects inconsistent variable names in a large software project. Our system checks if each variable name is consistent with other variables in the project in its usage pattern, and proposes correct candidates if inconsistency is detected. This is a part of academic research that we hope to publish soon, but as a part of the evaluation, we applied our systems to your projects and got a few interesting results. We carefully reviewed our system output and manually created a patch to correct a few variable names. We would be delighted if this patch is found to be useful. If you have a question or suggestion regarding this patch, we'd happily
answer. Thank you.

P.S. our patch is purely for readability purposes and does not change any functionality. A couple of issues that we've noticed were left untouched. For example, mixed use of variable names "msg" and "message" were fairly widespread, but we have only corrected a few notable instances to minimize our impact.