### PR TITLE
Reordering modifiers, clean up imports, and deleting commented-out code

### DIFF
--- a/src/main/java/junit/extensions/ActiveTestSuite.java
+++ b/src/main/java/junit/extensions/ActiveTestSuite.java
@@ -43,7 +43,6 @@ public class ActiveTestSuite extends TestSuite {
             public void run() {
                 try {
                     // inlined due to limitation in VA/Java
-                    //ActiveTestSuite.super.runTest(test, result);
                     test.run(result);
                 } finally {
                     ActiveTestSuite.this.runFinished();

--- a/src/main/java/junit/extensions/ActiveTestSuite.java
+++ b/src/main/java/junit/extensions/ActiveTestSuite.java
@@ -1,6 +1,9 @@
 package junit.extensions;
 
-import junit.framework.*;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestResult;
+import junit.framework.TestSuite;
 
 /**
  * A TestSuite for active Tests. It runs each

--- a/src/main/java/junit/extensions/ActiveTestSuite.java
+++ b/src/main/java/junit/extensions/ActiveTestSuite.java
@@ -1,9 +1,6 @@
 package junit.extensions;
 
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestResult;
-import junit.framework.TestSuite;
+import junit.framework.*;
 
 /**
  * A TestSuite for active Tests. It runs each
@@ -43,6 +40,7 @@ public class ActiveTestSuite extends TestSuite {
             public void run() {
                 try {
                     // inlined due to limitation in VA/Java
+                    // ActiveTestSuite.super.runTest(test, result);
                     test.run(result);
                 } finally {
                     ActiveTestSuite.this.runFinished();

--- a/src/main/java/junit/extensions/ActiveTestSuite.java
+++ b/src/main/java/junit/extensions/ActiveTestSuite.java
@@ -62,7 +62,7 @@ public class ActiveTestSuite extends TestSuite {
         }
     }
 
-    synchronized public void runFinished() {
+    public synchronized void runFinished() {
         fActiveTestDeathCount++;
         notifyAll();
     }

--- a/src/main/java/junit/framework/Assert.java
+++ b/src/main/java/junit/framework/Assert.java
@@ -17,7 +17,7 @@ public class Assert {
      * Asserts that a condition is true. If it isn't it throws
      * an AssertionFailedError with the given message.
      */
-    static public void assertTrue(String message, boolean condition) {
+    public static void assertTrue(String message, boolean condition) {
         if (!condition) {
             fail(message);
         }
@@ -27,7 +27,7 @@ public class Assert {
      * Asserts that a condition is true. If it isn't it throws
      * an AssertionFailedError.
      */
-    static public void assertTrue(boolean condition) {
+    public static void assertTrue(boolean condition) {
         assertTrue(null, condition);
     }
 
@@ -35,7 +35,7 @@ public class Assert {
      * Asserts that a condition is false. If it isn't it throws
      * an AssertionFailedError with the given message.
      */
-    static public void assertFalse(String message, boolean condition) {
+    public static void assertFalse(String message, boolean condition) {
         assertTrue(message, !condition);
     }
 
@@ -43,14 +43,14 @@ public class Assert {
      * Asserts that a condition is false. If it isn't it throws
      * an AssertionFailedError.
      */
-    static public void assertFalse(boolean condition) {
+    public static void assertFalse(boolean condition) {
         assertFalse(null, condition);
     }
 
     /**
      * Fails a test with the given message.
      */
-    static public void fail(String message) {
+    public static void fail(String message) {
         if (message == null) {
             throw new AssertionFailedError();
         }
@@ -60,7 +60,7 @@ public class Assert {
     /**
      * Fails a test with no message.
      */
-    static public void fail() {
+    public static void fail() {
         fail(null);
     }
 
@@ -68,7 +68,7 @@ public class Assert {
      * Asserts that two objects are equal. If they are not
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertEquals(String message, Object expected, Object actual) {
+    public static void assertEquals(String message, Object expected, Object actual) {
         if (expected == null && actual == null) {
             return;
         }
@@ -82,14 +82,14 @@ public class Assert {
      * Asserts that two objects are equal. If they are not
      * an AssertionFailedError is thrown.
      */
-    static public void assertEquals(Object expected, Object actual) {
+    public static void assertEquals(Object expected, Object actual) {
         assertEquals(null, expected, actual);
     }
 
     /**
      * Asserts that two Strings are equal.
      */
-    static public void assertEquals(String message, String expected, String actual) {
+    public static void assertEquals(String message, String expected, String actual) {
         if (expected == null && actual == null) {
             return;
         }
@@ -103,7 +103,7 @@ public class Assert {
     /**
      * Asserts that two Strings are equal.
      */
-    static public void assertEquals(String expected, String actual) {
+    public static void assertEquals(String expected, String actual) {
         assertEquals(null, expected, actual);
     }
 
@@ -112,7 +112,7 @@ public class Assert {
      * an AssertionFailedError is thrown with the given message.  If the expected
      * value is infinity then the delta value is ignored.
      */
-    static public void assertEquals(String message, double expected, double actual, double delta) {
+    public static void assertEquals(String message, double expected, double actual, double delta) {
         if (Double.compare(expected, actual) == 0) {
             return;
         }
@@ -125,7 +125,7 @@ public class Assert {
      * Asserts that two doubles are equal concerning a delta. If the expected
      * value is infinity then the delta value is ignored.
      */
-    static public void assertEquals(double expected, double actual, double delta) {
+    public static void assertEquals(double expected, double actual, double delta) {
         assertEquals(null, expected, actual, delta);
     }
 
@@ -134,7 +134,7 @@ public class Assert {
      * are not an AssertionFailedError is thrown with the given message. If the
      * expected value is infinity then the delta value is ignored.
      */
-    static public void assertEquals(String message, float expected, float actual, float delta) {
+    public static void assertEquals(String message, float expected, float actual, float delta) {
         if (Float.compare(expected, actual) == 0) {
             return;
         }
@@ -147,7 +147,7 @@ public class Assert {
      * Asserts that two floats are equal concerning a delta. If the expected
      * value is infinity then the delta value is ignored.
      */
-    static public void assertEquals(float expected, float actual, float delta) {
+    public static void assertEquals(float expected, float actual, float delta) {
         assertEquals(null, expected, actual, delta);
     }
 
@@ -155,14 +155,14 @@ public class Assert {
      * Asserts that two longs are equal. If they are not
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertEquals(String message, long expected, long actual) {
+    public static void assertEquals(String message, long expected, long actual) {
         assertEquals(message, Long.valueOf(expected), Long.valueOf(actual));
     }
 
     /**
      * Asserts that two longs are equal.
      */
-    static public void assertEquals(long expected, long actual) {
+    public static void assertEquals(long expected, long actual) {
         assertEquals(null, expected, actual);
     }
 
@@ -170,14 +170,14 @@ public class Assert {
      * Asserts that two booleans are equal. If they are not
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertEquals(String message, boolean expected, boolean actual) {
+    public static void assertEquals(String message, boolean expected, boolean actual) {
         assertEquals(message, Boolean.valueOf(expected), Boolean.valueOf(actual));
     }
 
     /**
      * Asserts that two booleans are equal.
      */
-    static public void assertEquals(boolean expected, boolean actual) {
+    public static void assertEquals(boolean expected, boolean actual) {
         assertEquals(null, expected, actual);
     }
 
@@ -185,14 +185,14 @@ public class Assert {
      * Asserts that two bytes are equal. If they are not
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertEquals(String message, byte expected, byte actual) {
+    public static void assertEquals(String message, byte expected, byte actual) {
         assertEquals(message, Byte.valueOf(expected), Byte.valueOf(actual));
     }
 
     /**
      * Asserts that two bytes are equal.
      */
-    static public void assertEquals(byte expected, byte actual) {
+    public static void assertEquals(byte expected, byte actual) {
         assertEquals(null, expected, actual);
     }
 
@@ -200,14 +200,14 @@ public class Assert {
      * Asserts that two chars are equal. If they are not
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertEquals(String message, char expected, char actual) {
+    public static void assertEquals(String message, char expected, char actual) {
         assertEquals(message, Character.valueOf(expected), Character.valueOf(actual));
     }
 
     /**
      * Asserts that two chars are equal.
      */
-    static public void assertEquals(char expected, char actual) {
+    public static void assertEquals(char expected, char actual) {
         assertEquals(null, expected, actual);
     }
 
@@ -215,14 +215,14 @@ public class Assert {
      * Asserts that two shorts are equal. If they are not
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertEquals(String message, short expected, short actual) {
+    public static void assertEquals(String message, short expected, short actual) {
         assertEquals(message, Short.valueOf(expected), Short.valueOf(actual));
     }
 
     /**
      * Asserts that two shorts are equal.
      */
-    static public void assertEquals(short expected, short actual) {
+    public static void assertEquals(short expected, short actual) {
         assertEquals(null, expected, actual);
     }
 
@@ -230,21 +230,21 @@ public class Assert {
      * Asserts that two ints are equal. If they are not
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertEquals(String message, int expected, int actual) {
+    public static void assertEquals(String message, int expected, int actual) {
         assertEquals(message, Integer.valueOf(expected), Integer.valueOf(actual));
     }
 
     /**
      * Asserts that two ints are equal.
      */
-    static public void assertEquals(int expected, int actual) {
+    public static void assertEquals(int expected, int actual) {
         assertEquals(null, expected, actual);
     }
 
     /**
      * Asserts that an object isn't null.
      */
-    static public void assertNotNull(Object object) {
+    public static void assertNotNull(Object object) {
         assertNotNull(null, object);
     }
 
@@ -252,7 +252,7 @@ public class Assert {
      * Asserts that an object isn't null. If it is
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertNotNull(String message, Object object) {
+    public static void assertNotNull(String message, Object object) {
         assertTrue(message, object != null);
     }
 
@@ -263,7 +263,7 @@ public class Assert {
      *
      * @param object Object to check or <code>null</code>
      */
-    static public void assertNull(Object object) {
+    public static void assertNull(Object object) {
         if (object != null) {
             assertNull("Expected: <null> but was: " + object.toString(), object);
         }
@@ -273,7 +273,7 @@ public class Assert {
      * Asserts that an object is null.  If it is not
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertNull(String message, Object object) {
+    public static void assertNull(String message, Object object) {
         assertTrue(message, object == null);
     }
 
@@ -281,7 +281,7 @@ public class Assert {
      * Asserts that two objects refer to the same object. If they are not
      * an AssertionFailedError is thrown with the given message.
      */
-    static public void assertSame(String message, Object expected, Object actual) {
+    public static void assertSame(String message, Object expected, Object actual) {
         if (expected == actual) {
             return;
         }
@@ -292,7 +292,7 @@ public class Assert {
      * Asserts that two objects refer to the same object. If they are not
      * the same an AssertionFailedError is thrown.
      */
-    static public void assertSame(Object expected, Object actual) {
+    public static void assertSame(Object expected, Object actual) {
         assertSame(null, expected, actual);
     }
 
@@ -301,7 +301,7 @@ public class Assert {
      * refer to the same object an AssertionFailedError is thrown with the
      * given message.
      */
-    static public void assertNotSame(String message, Object expected, Object actual) {
+    public static void assertNotSame(String message, Object expected, Object actual) {
         if (expected == actual) {
             failSame(message);
         }
@@ -311,21 +311,21 @@ public class Assert {
      * Asserts that two objects do not refer to the same object. If they do
      * refer to the same object an AssertionFailedError is thrown.
      */
-    static public void assertNotSame(Object expected, Object actual) {
+    public static void assertNotSame(Object expected, Object actual) {
         assertNotSame(null, expected, actual);
     }
 
-    static public void failSame(String message) {
+    public static void failSame(String message) {
         String formatted = (message != null) ? message + " " : "";
         fail(formatted + "expected not same");
     }
 
-    static public void failNotSame(String message, Object expected, Object actual) {
+    public static void failNotSame(String message, Object expected, Object actual) {
         String formatted = (message != null) ? message + " " : "";
         fail(formatted + "expected same:<" + expected + "> was not:<" + actual + ">");
     }
 
-    static public void failNotEquals(String message, Object expected, Object actual) {
+    public static void failNotEquals(String message, Object expected, Object actual) {
         fail(format(message, expected, actual));
     }
 

--- a/src/main/java/org/junit/experimental/results/ResultMatchers.java
+++ b/src/main/java/org/junit/experimental/results/ResultMatchers.java
@@ -4,7 +4,6 @@ import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.runner.notification.Failure;
 
 /**
  * Matchers on a PrintableResult, to enable JUnit self-tests.

--- a/src/main/java/org/junit/runner/notification/RunNotifier.java
+++ b/src/main/java/org/junit/runner/notification/RunNotifier.java
@@ -78,7 +78,7 @@ public class RunNotifier {
             fireTestFailures(safeListeners, failures);
         }
 
-        abstract protected void notifyListener(RunListener each) throws Exception;
+        protected abstract void notifyListener(RunListener each) throws Exception;
     }
 
     /**

--- a/src/main/java/org/junit/runners/model/FrameworkField.java
+++ b/src/main/java/org/junit/runners/model/FrameworkField.java
@@ -2,7 +2,6 @@ package org.junit.runners.model;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.util.List;
 
 import org.junit.runners.BlockJUnit4ClassRunner;
 

--- a/src/main/java/org/junit/validator/AnnotationsValidator.java
+++ b/src/main/java/org/junit/validator/AnnotationsValidator.java
@@ -40,7 +40,7 @@ public final class AnnotationsValidator implements TestClassValidator {
         return validationErrors;
     }
 
-    private static abstract class AnnotatableValidator<T extends Annotatable> {
+    private abstract static class AnnotatableValidator<T extends Annotatable> {
         private static final AnnotationValidatorFactory ANNOTATION_VALIDATOR_FACTORY = new AnnotationValidatorFactory();
 
         abstract Iterable<T> getAnnotatablesForTestClass(TestClass testClass);

--- a/src/test/java/junit/tests/runner/ResultTest.java
+++ b/src/test/java/junit/tests/runner/ResultTest.java
@@ -2,8 +2,6 @@ package junit.tests.runner;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;

--- a/src/test/java/junit/tests/runner/ResultTest.java
+++ b/src/test/java/junit/tests/runner/ResultTest.java
@@ -96,7 +96,7 @@ public class ResultTest extends TestCase {
                 fromStream, resourceSerializationFormat);
     }
 
-    static public class AssumptionFailedTest {
+    public static class AssumptionFailedTest {
         @Test
         public void assumptionFailed() throws Exception {
             org.junit.Assume.assumeTrue(false);

--- a/src/test/java/junit/tests/runner/TextRunnerTest.java
+++ b/src/test/java/junit/tests/runner/TextRunnerTest.java
@@ -32,7 +32,7 @@ public class TextRunnerTest extends TestCase {
         Process p = Runtime.getRuntime().exec(cmd);
         InputStream i = p.getInputStream();
         while ((i.read()) != -1)
-            ; //System.out.write(b);
+            ;
         assertTrue((p.waitFor() == 0) == success);
         if (success) {
             assertTrue(p.exitValue() == 0);

--- a/src/test/java/org/junit/experimental/categories/CategoriesAndParameterizedTest.java
+++ b/src/test/java/org/junit/experimental/categories/CategoriesAndParameterizedTest.java
@@ -6,9 +6,7 @@ import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Categories;
 import org.junit.experimental.categories.Categories.IncludeCategory;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;
 import org.junit.runner.RunWith;

--- a/src/test/java/org/junit/experimental/categories/CategoryTest.java
+++ b/src/test/java/org/junit/experimental/categories/CategoryTest.java
@@ -1,28 +1,27 @@
 package org.junit.experimental.categories;
 
+import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.AnyOf.anyOf;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.experimental.results.PrintableResult.testResult;
-import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 import static org.junit.experimental.results.ResultMatchers.failureCountIs;
-import static org.hamcrest.core.AnyOf.anyOf;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsEqual.equalTo;
-import static java.lang.String.format;
+import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.experimental.categories.Categories;
 import org.junit.experimental.categories.Categories.CategoryFilter;
 import org.junit.experimental.categories.Categories.ExcludeCategory;
 import org.junit.experimental.categories.Categories.IncludeCategory;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Request;
 import org.junit.runner.Result;

--- a/src/test/java/org/junit/experimental/categories/CategoryTest.java
+++ b/src/test/java/org/junit/experimental/categories/CategoryTest.java
@@ -411,7 +411,7 @@ public class CategoryTest {
     }
 
     @Category(SlowTests.class)
-    public static abstract class Ancestor{}
+    public abstract static class Ancestor{}
 
     public static class Inherited extends Ancestor {
         @Test

--- a/src/test/java/org/junit/experimental/categories/CategoryValidatorTest.java
+++ b/src/test/java/org/junit/experimental/categories/CategoryValidatorTest.java
@@ -10,8 +10,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
-import org.junit.experimental.categories.CategoryValidator;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.TestClass;
 

--- a/src/test/java/org/junit/experimental/categories/JavadocTest.java
+++ b/src/test/java/org/junit/experimental/categories/JavadocTest.java
@@ -1,17 +1,15 @@
 package org.junit.experimental.categories;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Categories;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Result;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
  * @author tibor17

--- a/src/test/java/org/junit/experimental/categories/MultiCategoryTest.java
+++ b/src/test/java/org/junit/experimental/categories/MultiCategoryTest.java
@@ -1,18 +1,16 @@
 package org.junit.experimental.categories;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Categories;
-import org.junit.experimental.categories.Category;
-import org.junit.runner.JUnitCore;
-import org.junit.runner.Result;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
-
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
 
 /**
  * @author tibor17

--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -16,8 +16,6 @@ import static org.junit.internal.runners.statements.FailOnTimeout.builder;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;

--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -16,6 +16,8 @@ import static org.junit.internal.runners.statements.FailOnTimeout.builder;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;

--- a/src/test/java/org/junit/rules/DisableOnDebugTest.java
+++ b/src/test/java/org/junit/rules/DisableOnDebugTest.java
@@ -48,7 +48,7 @@ public class DisableOnDebugTest {
 
     }
 
-    public static abstract class AbstractDisableOnDebugTest {
+    public abstract static class AbstractDisableOnDebugTest {
 
         @Rule
         public TestRule failOnExecution;

--- a/src/test/java/org/junit/rules/MethodRulesTest.java
+++ b/src/test/java/org/junit/rules/MethodRulesTest.java
@@ -44,7 +44,7 @@ public class MethodRulesTest {
         }
     }
 
-    static abstract class NonPublicExampleTest {
+    abstract static class NonPublicExampleTest {
         @Rule
         public MethodRule example = new TestMethodRule();
 

--- a/src/test/java/org/junit/rules/RuleChainTest.java
+++ b/src/test/java/org/junit/rules/RuleChainTest.java
@@ -10,8 +10,6 @@ import static org.junit.Assert.fail;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.rules.RuleChain.outerRule;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/test/java/org/junit/rules/StopwatchTest.java
+++ b/src/test/java/org/junit/rules/StopwatchTest.java
@@ -49,7 +49,7 @@ public class StopwatchTest {
         }
     }
 
-    public static abstract class AbstractStopwatchTest {
+    public abstract static class AbstractStopwatchTest {
 
         /**
          * Fake implementation of {@link Stopwatch.Clock} that increments the time

--- a/src/test/java/org/junit/rules/TempFolderRuleTest.java
+++ b/src/test/java/org/junit/rules/TempFolderRuleTest.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 public class TempFolderRuleTest {
     private static File[] createdFiles = new File[20];

--- a/src/test/java/org/junit/rules/TestRuleTest.java
+++ b/src/test/java/org/junit/rules/TestRuleTest.java
@@ -1,11 +1,9 @@
 package org.junit.rules;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.hasSingleFailureContaining;
 import static org.junit.experimental.results.ResultMatchers.isSuccessful;
@@ -14,11 +12,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.internal.AssumptionViolatedException;
 import org.junit.runner.Description;
 import org.junit.runner.JUnitCore;
 import org.junit.runner.Result;

--- a/src/test/java/org/junit/runners/AllRunnersTests.java
+++ b/src/test/java/org/junit/runners/AllRunnersTests.java
@@ -1,7 +1,6 @@
 package org.junit.runners;
 
 import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 import org.junit.runners.model.AllModelTests;
 import org.junit.runners.parameterized.AllParameterizedTests;

--- a/src/test/java/org/junit/runners/RuleContainerTest.java
+++ b/src/test/java/org/junit/runners/RuleContainerTest.java
@@ -2,8 +2,6 @@ package org.junit.runners;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Arrays;
-
 import org.junit.Test;
 import org.junit.rules.MethodRule;
 import org.junit.rules.TestRule;

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -237,8 +237,8 @@ public class AssumptionTest {
         assertThat(result.getAssumptionFailureCount(), is(1));
     }
 
-    final static String message = "Some random message string.";
-    final static Throwable e = new Throwable();
+    static final String message = "Some random message string.";
+    static final Throwable e = new Throwable();
 
     /**
      * @see AssumptionTest#assumptionsWithMessage()

--- a/src/test/java/org/junit/tests/experimental/theories/AssumingInTheoriesTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/AssumingInTheoriesTest.java
@@ -31,7 +31,7 @@ public class AssumingInTheoriesTest {
     public static class TheoryWithNoUnassumedParameters {
 
         @DataPoint
-        public final static boolean FALSE = false;
+        public static final boolean FALSE = false;
 
         @Theory
         public void theoryWithNoUnassumedParameters(boolean value) {

--- a/src/test/java/org/junit/tests/experimental/theories/runner/SuccessfulWithDataPointFields.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/SuccessfulWithDataPointFields.java
@@ -195,7 +195,7 @@ public class SuccessfulWithDataPointFields {
     }
 
     @RunWith(Theories.class)
-    static public class StaticPublicNonDataPoints {
+    public static class StaticPublicNonDataPoints {
         // DataPoint which passes the test
         @DataPoint
         public static int ZERO = 0;

--- a/src/test/java/org/junit/tests/junit3compatibility/AllTestsTest.java
+++ b/src/test/java/org/junit/tests/junit3compatibility/AllTestsTest.java
@@ -24,7 +24,7 @@ public class AllTestsTest {
 
     @RunWith(AllTests.class)
     public static class All {
-        static public junit.framework.Test suite() {
+        public static junit.framework.Test suite() {
             TestSuite suite = new TestSuite();
             suite.addTestSuite(OneTest.class);
             return suite;
@@ -60,7 +60,7 @@ public class AllTestsTest {
 
     @RunWith(AllTests.class)
     public static class AllJUnit4 {
-        static public junit.framework.Test suite() {
+        public static junit.framework.Test suite() {
             TestSuite suite = new TestSuite();
             suite.addTest(new JUnit4TestAdapter(JUnit4Test.class));
             return suite;

--- a/src/test/java/org/junit/tests/junit3compatibility/ForwardCompatibilityTest.java
+++ b/src/test/java/org/junit/tests/junit3compatibility/ForwardCompatibilityTest.java
@@ -19,7 +19,7 @@ import org.junit.runner.notification.RunNotifier;
 public class ForwardCompatibilityTest extends TestCase {
     static String fLog;
 
-    static public class NewTest {
+    public static class NewTest {
         @Before
         public void before() {
             fLog += "before ";

--- a/src/test/java/org/junit/tests/junit3compatibility/JUnit38ClassRunnerTest.java
+++ b/src/test/java/org/junit/tests/junit3compatibility/JUnit38ClassRunnerTest.java
@@ -53,7 +53,7 @@ public class JUnit38ClassRunnerTest {
 
     static int count;
 
-    static public class OneTest extends TestCase {
+    public static class OneTest extends TestCase {
         public void testOne() {
         }
     }

--- a/src/test/java/org/junit/tests/junit3compatibility/OldTests.java
+++ b/src/test/java/org/junit/tests/junit3compatibility/OldTests.java
@@ -6,7 +6,7 @@ import org.junit.runners.AllTests;
 
 @RunWith(AllTests.class)
 public class OldTests {
-    static public Test suite() {
+    public static Test suite() {
         return junit.tests.AllTests.suite();
     }
 }

--- a/src/test/java/org/junit/tests/junit3compatibility/SuiteMethodTest.java
+++ b/src/test/java/org/junit/tests/junit3compatibility/SuiteMethodTest.java
@@ -18,7 +18,7 @@ import org.junit.runner.Result;
 public class SuiteMethodTest {
     public static boolean wasRun;
 
-    static public class OldTest extends TestCase {
+    public static class OldTest extends TestCase {
         public OldTest(String name) {
             super(name);
         }
@@ -41,7 +41,7 @@ public class SuiteMethodTest {
         assertTrue(wasRun);
     }
 
-    static public class NewTest {
+    public static class NewTest {
         @Test
         public void sample() {
             wasRun = true;
@@ -81,7 +81,7 @@ public class SuiteMethodTest {
         assertEquals(0, description.getChildren().size());
     }
 
-    static public class NewTestSuiteFails {
+    public static class NewTestSuiteFails {
         @Test
         public void sample() {
             wasRun = true;
@@ -101,7 +101,7 @@ public class SuiteMethodTest {
         assertFalse(wasRun);
     }
 
-    static public class NewTestSuiteNotUsed {
+    public static class NewTestSuiteNotUsed {
         private static boolean wasIgnoredRun;
 
         @Test

--- a/src/test/java/org/junit/tests/listening/ListenerTest.java
+++ b/src/test/java/org/junit/tests/listening/ListenerTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.JUnitCore;
 import org.junit.runner.notification.RunListener;
 
 public class ListenerTest {
-    static private String log;
+    private static String log;
 
     public static class OneTest {
         @Test

--- a/src/test/java/org/junit/tests/manipulation/SingleMethodTest.java
+++ b/src/test/java/org/junit/tests/manipulation/SingleMethodTest.java
@@ -27,7 +27,7 @@ import org.junit.runners.Suite.SuiteClasses;
 public class SingleMethodTest {
     public static int count;
 
-    static public class OneTimeSetup {
+    public static class OneTimeSetup {
         @BeforeClass
         public static void once() {
             count++;
@@ -53,7 +53,7 @@ public class SingleMethodTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class ParameterizedOneTimeSetup {
+    public static class ParameterizedOneTimeSetup {
         @Parameters
         public static List<Object[]> params() {
             return Arrays.asList(new Object[]{1}, new Object[]{2});
@@ -78,7 +78,7 @@ public class SingleMethodTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class ParameterizedOneTimeBeforeClass {
+    public static class ParameterizedOneTimeBeforeClass {
         @Parameters
         public static List<Object[]> params() {
             return Arrays.asList(new Object[]{1}, new Object[]{2});

--- a/src/test/java/org/junit/tests/running/classes/EnclosedTest.java
+++ b/src/test/java/org/junit/tests/running/classes/EnclosedTest.java
@@ -30,7 +30,7 @@ public class EnclosedTest {
             @Test
             public void c() {}
         }
-        abstract public static class C {
+        public abstract static class C {
             @Test public void a() {}
         }
     }

--- a/src/test/java/org/junit/tests/running/classes/ParameterizedTestTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParameterizedTestTest.java
@@ -168,7 +168,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class BadIndexForAnnotatedFieldTest {
+    public static class BadIndexForAnnotatedFieldTest {
         @Parameters
         public static Collection<Object[]> data() {
             return Arrays.asList(new Object[][]{{0}});
@@ -200,7 +200,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class BadNumberOfAnnotatedFieldTest {
+    public static class BadNumberOfAnnotatedFieldTest {
         @Parameters
         public static Collection<Object[]> data() {
             return Arrays.asList(new Object[][]{{0, 0}});
@@ -232,7 +232,7 @@ public class ParameterizedTestTest {
     private static String fLog;
 
     @RunWith(Parameterized.class)
-    static public class BeforeAndAfter {
+    public static class BeforeAndAfter {
         @BeforeClass
         public static void before() {
             fLog += "before ";
@@ -487,7 +487,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class EmptyTest {
+    public static class EmptyTest {
         @BeforeClass
         public static void before() {
             fLog += "before ";
@@ -506,7 +506,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class IncorrectTest {
+    public static class IncorrectTest {
         @Test
         public int test() {
             return 0;
@@ -525,7 +525,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class ProtectedParametersTest {
+    public static class ProtectedParametersTest {
         @Parameters
         protected static Collection<Object[]> data() {
             return Collections.emptyList();
@@ -544,7 +544,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class ParametersNotIterable {
+    public static class ParametersNotIterable {
         @Parameters
         public static String data() {
             return "foo";
@@ -563,7 +563,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class PrivateConstructor {
+    public static class PrivateConstructor {
         private PrivateConstructor(int x) {
 
         }
@@ -613,7 +613,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class SingleArgumentTestWithArray {
+    public static class SingleArgumentTestWithArray {
         @Parameters
         public static Object[] data() {
             return new Object[] { "first test", "second test" };
@@ -634,7 +634,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class SingleArgumentTestWithIterable {
+    public static class SingleArgumentTestWithIterable {
         private static final AtomicBoolean dataCalled = new AtomicBoolean(false);
 
         @Parameters
@@ -677,7 +677,7 @@ public class ParameterizedTestTest {
     }
 
     @RunWith(Parameterized.class)
-    static public class SingleArgumentTestWithCollection {
+    public static class SingleArgumentTestWithCollection {
         @Parameters
         public static Iterable<? extends Object> data() {
             return Collections.unmodifiableCollection(asList("first test", "second test"));
@@ -699,7 +699,7 @@ public class ParameterizedTestTest {
     }
 
 
-    static public class ExceptionThrowingRunnerFactory implements
+    public static class ExceptionThrowingRunnerFactory implements
             ParametersRunnerFactory {
         public Runner createRunnerForTestWithParameters(TestWithParameters test)
                 throws InitializationError {
@@ -710,7 +710,7 @@ public class ParameterizedTestTest {
 
     @RunWith(Parameterized.class)
     @UseParametersRunnerFactory(ExceptionThrowingRunnerFactory.class)
-    static public class TestWithUseParametersRunnerFactoryAnnotation {
+    public static class TestWithUseParametersRunnerFactoryAnnotation {
         @Parameters
         public static Iterable<? extends Object> data() {
             return asList("single test");
@@ -739,7 +739,7 @@ public class ParameterizedTestTest {
     
     @RunWith(Parameterized.class)
     @UseParametersRunnerFactory(ExceptionThrowingRunnerFactory.class)
-    public static abstract class UseParameterizedFactoryAbstractTest {
+    public abstract static class UseParameterizedFactoryAbstractTest {
         @Parameters
         public static Iterable<? extends Object> data() {
             return asList("single test");

--- a/src/test/java/org/junit/tests/running/classes/parent/ParentRunnerClassLoaderTest.java
+++ b/src/test/java/org/junit/tests/running/classes/parent/ParentRunnerClassLoaderTest.java
@@ -1,6 +1,12 @@
 package org.junit.tests.running.classes.parent;
 
 
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.net.URLClassLoader;
+
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.notification.RunNotifier;
@@ -8,13 +14,6 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.ParentRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
-
-import java.lang.reflect.Field;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
 
 public class ParentRunnerClassLoaderTest {
     @Test

--- a/src/test/java/org/junit/tests/running/core/CommandLineTest.java
+++ b/src/test/java/org/junit/tests/running/core/CommandLineTest.java
@@ -28,7 +28,7 @@ public class CommandLineTest {
         System.setOut(oldOut);
     }
 
-    static public class Example {
+    public static class Example {
         @Test
         public void test() {
             testWasRun = true;
@@ -55,7 +55,7 @@ public class CommandLineTest {
 
     private static int fCount;
 
-    static public class Count {
+    public static class Count {
         @Test
         public void increment() {
             fCount++;

--- a/src/test/java/org/junit/tests/running/core/JUnitCoreReturnsCorrectExitCodeTest.java
+++ b/src/test/java/org/junit/tests/running/core/JUnitCoreReturnsCorrectExitCodeTest.java
@@ -8,7 +8,7 @@ import org.junit.runner.JUnitCore;
 
 public class JUnitCoreReturnsCorrectExitCodeTest {
 
-    static public class Fail {
+    public static class Fail {
         @Test
         public void kaboom() {
             fail();
@@ -25,7 +25,7 @@ public class JUnitCoreReturnsCorrectExitCodeTest {
         runClass("Foo", 1);
     }
 
-    static public class Succeed {
+    public static class Succeed {
         @Test
         public void peacefulSilence() {
         }

--- a/src/test/java/org/junit/tests/running/methods/AnnotationTest.java
+++ b/src/test/java/org/junit/tests/running/methods/AnnotationTest.java
@@ -34,7 +34,7 @@ public class AnnotationTest extends TestCase {
         run = false;
     }
 
-    static public class SimpleTest {
+    public static class SimpleTest {
         @Test
         public void success() {
             run = true;
@@ -48,7 +48,7 @@ public class AnnotationTest extends TestCase {
     }
 
     @RunWith(JUnit4.class)
-    static public class SimpleTestWithFutureProofExplicitRunner {
+    public static class SimpleTestWithFutureProofExplicitRunner {
         @Test
         public void success() {
             run = true;
@@ -61,7 +61,7 @@ public class AnnotationTest extends TestCase {
         assertTrue(run);
     }
 
-    static public class SetupTest {
+    public static class SetupTest {
         @Before
         public void before() {
             run = true;
@@ -78,7 +78,7 @@ public class AnnotationTest extends TestCase {
         assertTrue(run);
     }
 
-    static public class TeardownTest {
+    public static class TeardownTest {
         @After
         public void after() {
             run = true;
@@ -95,7 +95,7 @@ public class AnnotationTest extends TestCase {
         assertTrue(run);
     }
 
-    static public class FailureTest {
+    public static class FailureTest {
         @Test
         public void error() throws Exception {
             org.junit.Assert.fail();
@@ -110,7 +110,7 @@ public class AnnotationTest extends TestCase {
         assertEquals(AssertionError.class, result.getFailures().get(0).getException().getClass());
     }
 
-    static public class SetupFailureTest {
+    public static class SetupFailureTest {
         @Before
         public void before() {
             throw new Error();
@@ -131,7 +131,7 @@ public class AnnotationTest extends TestCase {
         assertFalse(run);
     }
 
-    static public class TeardownFailureTest {
+    public static class TeardownFailureTest {
         @After
         public void after() {
             throw new Error();
@@ -150,7 +150,7 @@ public class AnnotationTest extends TestCase {
         assertEquals(Error.class, runner.getFailures().get(0).getException().getClass());
     }
 
-    static public class TestAndTeardownFailureTest {
+    public static class TestAndTeardownFailureTest {
         @After
         public void after() {
             throw new Error("hereAfter");
@@ -170,7 +170,7 @@ public class AnnotationTest extends TestCase {
         assertThat(runner.getFailures().toString(), allOf(containsString("hereAfter"), containsString("inTest")));
     }
 
-    static public class TeardownAfterFailureTest {
+    public static class TeardownAfterFailureTest {
         @After
         public void after() {
             run = true;
@@ -191,7 +191,7 @@ public class AnnotationTest extends TestCase {
     static int count;
     static Collection<Object> tests;
 
-    static public class TwoTests {
+    public static class TwoTests {
         @Test
         public void one() {
             count++;
@@ -214,7 +214,7 @@ public class AnnotationTest extends TestCase {
         assertEquals(2, tests.size());
     }
 
-    static public class OldTest extends TestCase {
+    public static class OldTest extends TestCase {
         public void test() {
             run = true;
         }
@@ -226,7 +226,7 @@ public class AnnotationTest extends TestCase {
         assertTrue(run);
     }
 
-    static public class OldSuiteTest extends TestCase {
+    public static class OldSuiteTest extends TestCase {
         public void testOne() {
             run = true;
         }
@@ -239,7 +239,7 @@ public class AnnotationTest extends TestCase {
         assertTrue(run);
     }
 
-    static public class ExceptionTest {
+    public static class ExceptionTest {
         @Test(expected = Error.class)
         public void expectedException() {
             throw new Error();
@@ -252,7 +252,7 @@ public class AnnotationTest extends TestCase {
         assertEquals(0, result.getFailureCount());
     }
 
-    static public class NoExceptionTest {
+    public static class NoExceptionTest {
         @Test(expected = Error.class)
         public void expectedException() {
         }
@@ -265,7 +265,7 @@ public class AnnotationTest extends TestCase {
         assertEquals("Expected exception: java.lang.Error", result.getFailures().get(0).getMessage());
     }
 
-    static public class OneTimeSetup {
+    public static class OneTimeSetup {
         @BeforeClass
         public static void once() {
             count++;
@@ -287,7 +287,7 @@ public class AnnotationTest extends TestCase {
         assertEquals(1, count);
     }
 
-    static public class OneTimeTeardown {
+    public static class OneTimeTeardown {
         @AfterClass
         public static void once() {
             count++;
@@ -345,7 +345,7 @@ public class AnnotationTest extends TestCase {
         assertEquals("beforeClass before test after afterClass ", log);
     }
 
-    static public class NonStaticOneTimeSetup {
+    public static class NonStaticOneTimeSetup {
         @BeforeClass
         public void once() {
         }
@@ -361,7 +361,7 @@ public class AnnotationTest extends TestCase {
         assertEquals(1, result.getFailureCount());
     }
 
-    static public class ErrorInBeforeClass {
+    public static class ErrorInBeforeClass {
         @BeforeClass
         public static void before() throws Exception {
             throw new Exception();
@@ -383,7 +383,7 @@ public class AnnotationTest extends TestCase {
         assertEquals(ErrorInBeforeClass.class.getName(), description.getDisplayName());
     }
 
-    static public class ErrorInAfterClass {
+    public static class ErrorInAfterClass {
         @Test
         public void test() {
             run = true;
@@ -405,12 +405,12 @@ public class AnnotationTest extends TestCase {
 
     static class SuperInheritance {
         @BeforeClass
-        static public void beforeClassSuper() {
+        public static void beforeClassSuper() {
             log += "Before class super ";
         }
 
         @AfterClass
-        static public void afterClassSuper() {
+        public static void afterClassSuper() {
             log += "After class super ";
         }
 
@@ -425,14 +425,14 @@ public class AnnotationTest extends TestCase {
         }
     }
 
-    static public class SubInheritance extends SuperInheritance {
+    public static class SubInheritance extends SuperInheritance {
         @BeforeClass
-        static public void beforeClassSub() {
+        public static void beforeClassSub() {
             log += "Before class sub ";
         }
 
         @AfterClass
-        static public void afterClassSub() {
+        public static void afterClassSub() {
             log += "After class sub ";
         }
 
@@ -459,7 +459,7 @@ public class AnnotationTest extends TestCase {
         assertEquals("Before class super Before class sub Before super Before sub Test After sub After super After class sub After class super ", log);
     }
 
-    static public abstract class SuperShadowing {
+    public abstract static class SuperShadowing {
 
         @Rule
         public TestRule rule() {
@@ -487,7 +487,7 @@ public class AnnotationTest extends TestCase {
         }
     }
 
-    static public class SubShadowing extends SuperShadowing {
+    public static class SubShadowing extends SuperShadowing {
 
         @Override
         @Rule
@@ -545,7 +545,7 @@ public class AnnotationTest extends TestCase {
                 log);
     }
 
-    static public abstract class SuperStaticMethodShadowing {
+    public abstract static class SuperStaticMethodShadowing {
 
         @ClassRule
         public static TestRule rule() {
@@ -563,7 +563,7 @@ public class AnnotationTest extends TestCase {
         }
     }
 
-    static public class SubStaticMethodShadowing extends SuperStaticMethodShadowing {
+    public static class SubStaticMethodShadowing extends SuperStaticMethodShadowing {
 
         @ClassRule
         public static TestRule rule() {
@@ -596,7 +596,7 @@ public class AnnotationTest extends TestCase {
                 log);
     }
 
-    static public abstract class SuperFieldShadowing {
+    public abstract static class SuperFieldShadowing {
 
         @Rule
         public final TestRule rule = new ExternalResource() {
@@ -612,7 +612,7 @@ public class AnnotationTest extends TestCase {
         };
     }
 
-    static public class SubFieldShadowing extends SuperFieldShadowing {
+    public static class SubFieldShadowing extends SuperFieldShadowing {
 
         @Rule
         public final TestRule rule = new ExternalResource() {
@@ -643,7 +643,7 @@ public class AnnotationTest extends TestCase {
                 log);
     }
 
-    static public abstract class SuperStaticFieldShadowing {
+    public abstract static class SuperStaticFieldShadowing {
 
         @ClassRule
         public static TestRule rule = new ExternalResource() {
@@ -659,7 +659,7 @@ public class AnnotationTest extends TestCase {
         };
     }
 
-    static public class SubStaticFieldShadowing extends SuperStaticFieldShadowing {
+    public static class SubStaticFieldShadowing extends SuperStaticFieldShadowing {
 
         @ClassRule
         public static TestRule rule = new ExternalResource() {
@@ -690,7 +690,7 @@ public class AnnotationTest extends TestCase {
                 log);
     }
 
-    static public class SuperTest {
+    public static class SuperTest {
         @Test
         public void one() {
             log += "Super";
@@ -702,7 +702,7 @@ public class AnnotationTest extends TestCase {
         }
     }
 
-    static public class SubTest extends SuperTest {
+    public static class SubTest extends SuperTest {
         @Override
         @Test
         public void one() {
@@ -720,7 +720,7 @@ public class AnnotationTest extends TestCase {
         assertFalse(log.contains("Super"));
     }
 
-    static public class RunAllAfters {
+    public static class RunAllAfters {
         @Before
         public void good() {
         }
@@ -753,7 +753,7 @@ public class AnnotationTest extends TestCase {
         assertTrue(log.contains("two"));
     }
 
-    static public class RunAllAftersRegardless {
+    public static class RunAllAftersRegardless {
         @Test
         public void empty() {
         }
@@ -780,7 +780,7 @@ public class AnnotationTest extends TestCase {
         assertEquals(2, result.getFailureCount());
     }
 
-    static public class RunAllAfterClasses {
+    public static class RunAllAfterClasses {
         @Before
         public void good() {
         }
@@ -813,19 +813,19 @@ public class AnnotationTest extends TestCase {
         assertTrue(log.contains("two"));
     }
 
-    static public class RunAllAfterClassesRegardless {
+    public static class RunAllAfterClassesRegardless {
         @Test
         public void empty() {
         }
 
         @AfterClass
-        static public void one() {
+        public static void one() {
             log += "one";
             throw new Error();
         }
 
         @AfterClass
-        static public void two() {
+        public static void two() {
             log += "two";
             throw new Error();
         }

--- a/src/test/java/org/junit/tests/running/methods/ParameterizedTestMethodTest.java
+++ b/src/test/java/org/junit/tests/running/methods/ParameterizedTestMethodTest.java
@@ -136,19 +136,19 @@ public class ParameterizedTestMethodTest {
     private Class<?> fClass;
     private int fErrorCount;
 
-    static public class SuperWrong {
+    public static class SuperWrong {
         @Test
         void notPublic() {
         }
     }
 
-    static public class SubWrong extends SuperWrong {
+    public static class SubWrong extends SuperWrong {
         @Test
         public void justFine() {
         }
     }
 
-    static public class SubShadows extends SuperWrong {
+    public static class SubShadows extends SuperWrong {
         @Override
         @Test
         public void notPublic() {


### PR DESCRIPTION
Minor clean up. Does **3** things:

- Removing commented out lines of code.

> "It makes me crazy to see stretches of code that are commented out. 
> Who knows how old it is?
> Who knows whether or not it's meaningful? 
> Yet no one will delete it because everyone assumes someone else needs it or has plans for it. Commented-out code is an abomination." 

-Clean Code (chapter 17) by [Uncle Bob](https://en.wikipedia.org/wiki/Robert_C._Martin)

- Cleaning up unused imports and deleting imports from the same package.

- Reordering modifiers to comply with the Java Language Specification:

> The Java Language Specification recommends listing modifiers in the following order:
> 
> 1. Annotations
> 2. public
> 3. protected
> 4. private
> 5. abstract
> 6. static
> 7. final
> 8. transient
> 9. volatile
> 10. synchronized
> 11. native
> 12. strictfp
