### PR TITLE
Use Google's Maven Central mirror

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,4 +1,12 @@
 <settings>
+    <mirrors xmlns="http://maven.apache.org/SETTINGS/1.1.0">
+        <mirror>
+            <mirrorOf>central</mirrorOf>
+            <name>GCS Maven Central mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+            <id>google-maven-central</id>
+        </mirror>
+    </mirrors>
     <servers>
         <server>
             <id>junit-snapshot-repo</id>


### PR DESCRIPTION
We are using Maven 3.1.1 which by default uses HTTP instead of HTTPS for resolving artifacts from Maven Central. Maven Central recently discontinued HTTP support. Therefore the build on Travis started failing. By using an HTTPS mirror of Maven Central the build on Travis will work again.

I chose Google's mirror because Travis uses this mirror by default, too. I did not upgrade to a new version of Maven because there is no newer version with Java 5 support and it should be possible to build JUnit 4 with Java 5 so that we can easily ensure that it works with Java 5.