### PR TITLE
Consider declaring class for Enclosed tests in  Categories

### DIFF
--- a/src/main/java/org/junit/experimental/categories/Categories.java
+++ b/src/main/java/org/junit/experimental/categories/Categories.java
@@ -278,11 +278,20 @@ public class Categories extends Suite {
             Set<Class<?>> categories= new HashSet<Class<?>>();
             Collections.addAll(categories, directCategories(description));
             Collections.addAll(categories, directCategories(parentDescription(description)));
+            Collections.addAll(categories, directCategories(declaringDescription(description)));
             return categories;
         }
 
         private static Description parentDescription(Description description) {
             Class<?> testClass= description.getTestClass();
+            return testClass == null ? null : Description.createSuiteDescription(testClass);
+        }
+
+        private static Description declaringDescription(Description description) {
+            Class<?> testClass = description.getTestClass();
+            if (testClass != null) {
+                testClass = testClass.getDeclaringClass();
+            }
             return testClass == null ? null : Description.createSuiteDescription(testClass);
         }
 


### PR DESCRIPTION
At QueryDSL, we were surprised that Enclosed tests were not run when the category was included as group filter.

It turns out to be because the declaring class is not considered when determining the categories for a particular test. This pull request changes that behaviour to also consider the declaring class.

Example:

```java
@Category(H2.class)
public class H2LiteralsSuiteTest extends AbstractSuite {

    public static class BeanPopulation extends BeanPopulationBase { }
    public static class Delete extends DeleteBase { }
    public static class Insert extends InsertBase { }
    public static class KeywordQuoting extends KeywordQuotingBase { }
    public static class LikeEscape extends LikeEscapeBase { }
```

Where `AbstractSuite` is annotated with `@RunWith(Enclosed.class)`.

When `<groups>com.querydsl.core.testutil.H2</groups>` is used, none of the inner test classes is executed, unless they themselves are annotated with `@Category(H2.class)`. To us it would make sense that this is implicit.

Source: https://github.com/querydsl/querydsl/blob/master/querydsl-sql/src/test/java/com/querydsl/sql/suites/H2LiteralsSuiteTest.java#L9-L16