### PR TITLE
Make FrameworkField ctor public. Fixes #1668

### DIFF
--- a/src/main/java/junit/runner/Version.java
+++ b/src/main/java/junit/runner/Version.java
@@ -9,7 +9,7 @@ public class Version {
 	}
 
 	public static String id() {
-		return "4.13-SNAPSHOT";
+		return "4.14-SNAPSHOT";
 	}
 	
 	public static void main(String[] args) {

--- a/src/main/java/org/junit/runners/model/FrameworkField.java
+++ b/src/main/java/org/junit/runners/model/FrameworkField.java
@@ -15,7 +15,12 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 public class FrameworkField extends FrameworkMember<FrameworkField> {
     private final Field field;
 
-    FrameworkField(Field field) {
+    /**
+     * Returns a new {@code FrameworkField} for {@code field}.
+     *
+     * <p>Access relaxed to {@code public} since version 4.14.
+     */
+    public FrameworkField(Field field) {
         if (field == null) {
             throw new NullPointerException(
                     "FrameworkField cannot be created without an underlying field.");
@@ -26,7 +31,7 @@ public class FrameworkField extends FrameworkMember<FrameworkField> {
             // This field could be a public field in a package-scope base class
             try {
                 field.setAccessible(true);
-            } catch (SecurityException  e) {
+            } catch (SecurityException e) {
                 // We may get an IllegalAccessException when we try to access the field
             }
         }


### PR DESCRIPTION
Prior to this change, custom runners could make FrameworkMethod
instances, but not FrameworkField instances. This small change
allows for both now, because FrameworkFields constructor has been
promoted to public from package-private.