### PR TITLE
Explicitly wrap float parameter for consistency

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -596,7 +596,7 @@ public class Assert {
     public static void assertNotEquals(String message, float unexpected,
             float actual, float delta) {
         if (!floatIsDifferent(unexpected, actual, delta)) {
-            failEquals(message, actual);
+            failEquals(message, Float.valueOf(actual));
         }
     }
 


### PR DESCRIPTION
In #1141, while [this param named **actual**](https://github.com/junit-team/junit4/pull/1141/files#diff-73eb269f6f932a6bd4cc17c2cfd54571R598) was unwrapped, other params are still wrapped in Double or Float#valueOf.
I consider that its wrapping is necessary for consistency.