### PR TITLE
Fix tests for floating point assertions

### DIFF
--- a/src/test/java/junit/tests/framework/DoublePrecisionAssertTest.java
+++ b/src/test/java/junit/tests/framework/DoublePrecisionAssertTest.java
@@ -11,17 +11,19 @@ public class DoublePrecisionAssertTest extends TestCase {
     public void testAssertEqualsNaNFails() {
         try {
             assertEquals(1.234, Double.NaN, 0.0);
-            fail();
         } catch (AssertionFailedError e) {
+            return;
         }
+        fail();
     }
 
     public void testAssertNaNEqualsFails() {
         try {
             assertEquals(Double.NaN, 1.234, 0.0);
-            fail();
         } catch (AssertionFailedError e) {
+            return;
         }
+        fail();
     }
 
     public void testAssertNaNEqualsNaN() {
@@ -31,17 +33,19 @@ public class DoublePrecisionAssertTest extends TestCase {
     public void testAssertPosInfinityNotEqualsNegInfinity() {
         try {
             assertEquals(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0.0);
-            fail();
         } catch (AssertionFailedError e) {
+            return;
         }
+        fail();
     }
 
     public void testAssertPosInfinityNotEquals() {
         try {
             assertEquals(Double.POSITIVE_INFINITY, 1.23, 0.0);
-            fail();
         } catch (AssertionFailedError e) {
+            return;
         }
+        fail();
     }
 
     public void testAssertPosInfinityEqualsInfinity() {

--- a/src/test/java/junit/tests/framework/FloatAssertTest.java
+++ b/src/test/java/junit/tests/framework/FloatAssertTest.java
@@ -11,17 +11,19 @@ public class FloatAssertTest extends TestCase {
     public void testAssertEqualsNaNFails() {
         try {
             assertEquals(1.234f, Float.NaN, 0.0);
-            fail();
         } catch (AssertionFailedError e) {
+            return;
         }
+        fail();
     }
 
     public void testAssertNaNEqualsFails() {
         try {
             assertEquals(Float.NaN, 1.234f, 0.0);
-            fail();
         } catch (AssertionFailedError e) {
+            return;
         }
+        fail();
     }
 
     public void testAssertNaNEqualsNaN() {
@@ -31,17 +33,19 @@ public class FloatAssertTest extends TestCase {
     public void testAssertPosInfinityNotEqualsNegInfinity() {
         try {
             assertEquals(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, 0.0);
-            fail();
         } catch (AssertionFailedError e) {
+            return;
         }
+        fail();
     }
 
     public void testAssertPosInfinityNotEquals() {
         try {
             assertEquals(Float.POSITIVE_INFINITY, 1.23f, 0.0);
-            fail();
         } catch (AssertionFailedError e) {
+            return;
         }
+        fail();
     }
 
     public void testAssertPosInfinityEqualsInfinity() {
@@ -55,9 +59,10 @@ public class FloatAssertTest extends TestCase {
     public void testAllInfinities() {
         try {
             assertEquals(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
-            fail();
         } catch (AssertionFailedError e) {
+            return;
         }
+        fail();
     }
 
 }

--- a/src/test/java/junit/tests/framework/FloatAssertTest.java
+++ b/src/test/java/junit/tests/framework/FloatAssertTest.java
@@ -57,12 +57,7 @@ public class FloatAssertTest extends TestCase {
     }
 
     public void testAllInfinities() {
-        try {
-            assertEquals(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
-        } catch (AssertionFailedError e) {
-            return;
-        }
-        fail();
+        assertEquals(Float.POSITIVE_INFINITY, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
     }
 
 }


### PR DESCRIPTION
The issue is that both

```java
assertEquals(1.0, 2.0, 0.0);
```

and

```java
fail();
```

throw an `AssertionFailedError`, so these tests were actually not testing anything...