### PR TITLE
Fix test "threadGroupNotLeaked"

### DIFF
--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -212,7 +212,7 @@ public class FailOnTimeoutTest {
     public void threadGroupNotLeaked() throws Throwable {
         Collection<ThreadGroup> groupsBeforeSet = subGroupsOfCurrentThread();
         
-        evaluateWithWaitDuration(0);
+        evaluateWithWaitDuration(0).run();
         
         for (ThreadGroup group: subGroupsOfCurrentThread()) {
             if (!groupsBeforeSet.contains(group) && "FailOnTimeoutGroup".equals(group.getName())) {


### PR DESCRIPTION
The FailOnTimeout statement was not executed because the Runnable's
"run" method was not called.