### PR TITLE
Explain why the thread group is destroyed

### DIFF
--- a/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
+++ b/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
@@ -121,6 +121,12 @@ public class FailOnTimeout extends Statement {
         CallableStatement callable = new CallableStatement();
         FutureTask<Throwable> task = new FutureTask<Throwable>(callable);
         ThreadGroup threadGroup = new ThreadGroup("FailOnTimeoutGroup");
+        // The thread group must be a daemon thread group so that it is
+        // destroyed when the time-limiting thread finishes. Only when the
+        // thread group is destroyed its parent thread group can be destroyed,
+        // too. This is necessary because data may be stored in the parent
+        // thread group's ThreadGroupContext and this data remains until the
+        // parent thread group is destroyed.
         if (!threadGroup.isDaemon()) {
             try {
                 threadGroup.setDaemon(true);


### PR DESCRIPTION
This information is currently only available in GitHub. It should be
close to the code so that the reader can understand why we destroy the
thread group.