### PR TITLE
Tidy up FailOnTimeoutTest

### DIFF
--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -120,7 +120,9 @@ public class FailOnTimeoutTest {
     }
 
     @Test
-    public void stopEndlessStatement() throws Throwable {
+    public void statementThatCanBeInterruptedIsStoppedAfterTimeout() throws Throwable {
+        // RunForASecond can be interrupted because it uses Thread.sleep which
+        // can be interrupted.
         RunForASecond runForASecond = new RunForASecond();
         assertThrows(
                 TestTimedOutException.class,

--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -58,14 +58,14 @@ public class FailOnTimeoutTest {
     public void throwsTestTimedOutException() {
         assertThrows(
                 TestTimedOutException.class,
-                run(failAfter50Ms(new InfiniteLoop())));
+                run(failAfter50Ms(new RunForASecond())));
     }
 
     @Test
     public void throwExceptionWithNiceMessageOnTimeout() {
         Exception e = assertThrows(
                 Exception.class,
-                run(failAfter50Ms(new InfiniteLoop())));
+                run(failAfter50Ms(new RunForASecond())));
         assertEquals("test timed out after 50 milliseconds", e.getMessage());
     }
 
@@ -87,7 +87,7 @@ public class FailOnTimeoutTest {
         statement.delegate = new FastStatement();
         failOnTimeout.evaluate();
 
-        statement.delegate = new InfiniteLoop();
+        statement.delegate = new RunForASecond();
         assertThrows(
                 TestTimedOutException.class,
                 run(failOnTimeout));
@@ -104,7 +104,7 @@ public class FailOnTimeoutTest {
                 run(failOnTimeout)
         );
 
-        statement.delegate = new InfiniteLoop();
+        statement.delegate = new RunForASecond();
         assertThrows(
                 TestTimedOutException.class,
                 run(failOnTimeout));
@@ -114,24 +114,24 @@ public class FailOnTimeoutTest {
     public void throwsExceptionWithTimeoutValueAndTimeUnitSet() {
         TestTimedOutException e = assertThrows(
                 TestTimedOutException.class,
-                run(failAfter50Ms(new InfiniteLoop())));
+                run(failAfter50Ms(new RunForASecond())));
         assertEquals(50, e.getTimeout());
         assertEquals(MILLISECONDS, e.getTimeUnit());
     }
 
     @Test
     public void stopEndlessStatement() throws Throwable {
-        InfiniteLoop infiniteLoop = new InfiniteLoop();
+        RunForASecond runForASecond = new RunForASecond();
         assertThrows(
                 TestTimedOutException.class,
-                run(failAfter50Ms(infiniteLoop)));
+                run(failAfter50Ms(runForASecond)));
 
         sleep(20); // time to interrupt the thread
-        infiniteLoop.stillExecuting.set(false);
+        runForASecond.stillExecuting.set(false);
         sleep(20); // time to increment the count
         assertFalse(
                 "Thread has not been stopped.",
-                infiniteLoop.stillExecuting.get());
+                runForASecond.stillExecuting.get());
     }
 
     @Test
@@ -262,12 +262,13 @@ public class FailOnTimeoutTest {
         }
     }
 
-    private static final class InfiniteLoop extends Statement {
+    private static final class RunForASecond extends Statement {
         final AtomicBoolean stillExecuting = new AtomicBoolean();
 
         @Override
         public void evaluate() throws Throwable {
-            while (true) {
+            long timeout = currentTimeMillis() + 1000L;
+            while (currentTimeMillis() < timeout) {
                 sleep(10); // sleep in order to enable interrupting thread
                 stillExecuting.set(true);
             }

--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -81,7 +81,7 @@ public class FailOnTimeoutTest {
     @Test
     public void throwExceptionIfTheSecondCallToEvaluateNeedsTooMuchTime()
             throws Throwable {
-        DelegateStatement statement = new DelegateStatement();
+        DelegatingStatement statement = new DelegatingStatement();
         FailOnTimeout failOnTimeout = failAfter50Ms(statement);
 
         statement.delegate = new FastStatement();
@@ -95,7 +95,7 @@ public class FailOnTimeoutTest {
 
     @Test
     public void throwTimeoutExceptionOnSecondCallAlthoughFirstCallThrowsException() {
-        DelegateStatement statement = new DelegateStatement();
+        DelegatingStatement statement = new DelegatingStatement();
         FailOnTimeout failOnTimeout = failAfter50Ms(statement);
 
         statement.delegate = new Fail(new AssertionError("first execution failed"));
@@ -249,7 +249,7 @@ public class FailOnTimeoutTest {
         };
     }
 
-    private static class DelegateStatement extends Statement {
+    private static class DelegatingStatement extends Statement {
         Statement delegate;
 
         @Override

--- a/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/internal/runners/statements/FailOnTimeoutTest.java
@@ -55,16 +55,9 @@ public class FailOnTimeoutTest {
     }
 
     @Test
-    public void throwsTestTimedOutException() {
-        assertThrows(
-                TestTimedOutException.class,
-                run(failAfter50Ms(new RunForASecond())));
-    }
-
-    @Test
-    public void throwExceptionWithNiceMessageOnTimeout() {
+    public void throwsTestTimedOutExceptionWithMeaningfulMessage() {
         Exception e = assertThrows(
-                Exception.class,
+                TestTimedOutException.class,
                 run(failAfter50Ms(new RunForASecond())));
         assertEquals("test timed out after 50 milliseconds", e.getMessage());
     }


### PR DESCRIPTION
Improve readability and reusability. When I started to read the test it took me some time to understand it. The reason was the configurable statement `TestStatement` and the `evaluateWith...` methods. The refactored test uses fixed Statements when possible and uses smaller methods for wrapping `FailOnTimeout` with a `ThrowingRunnable` and for wrapping an arbitrary statement with a `FailOnTimeout`. It also calls `FailOnTimeout#evaluate` directly when possible.