### PR TITLE
Don't convert assumption failures to errors in ErrorCollector.addErro…

### DIFF
--- a/src/main/java/org/junit/rules/ErrorCollector.java
+++ b/src/main/java/org/junit/rules/ErrorCollector.java
@@ -43,19 +43,15 @@ public class ErrorCollector extends Verifier {
     }
 
     /**
-     * Adds a Throwable to the table.  Execution continues, but the test will fail at the end.
+     * Adds a {@code Throwable} to the table.  Execution continues, but the {@code Throwable(s)}
+     * will be re-thrown at the end, as a {@link MultipleFailureException} if there is more
+     * than one.
      */
     public void addError(Throwable error) {
         if (error == null) {
             throw new NullPointerException("Error cannot be null");
         }
-        if (error instanceof AssumptionViolatedException) {
-            AssertionError e = new AssertionError(error.getMessage());
-            e.initCause(error);
-            errors.add(e);
-        } else {
-            errors.add(error);
-        }
+        errors.add(error);
     }
 
     /**

--- a/src/test/java/org/junit/rules/ErrorCollectorTest.java
+++ b/src/test/java/org/junit/rules/ErrorCollectorTest.java
@@ -37,7 +37,7 @@ public class ErrorCollectorTest {
                         hasNumberOfFailures(2)},
                 {
                     AddInternalAssumptionViolatedException.class,
-                        allOf(hasSingleFailure(), hasNoAssumptionFailure())},
+                        hasSingleAssumptionFailure()},
                 {
                     CheckMatcherThatDoesNotFailWithoutProvidedReason.class,
                         everyTestRunSuccessful()},


### PR DESCRIPTION
…r().

Provides clearer results when calling sub-methods or when wrapping tests via a Rule.