### PR TITLE
Fix dead link to the Ant task in faq.fml

### DIFF
--- a/src/site/fml/faq.fml
+++ b/src/site/fml/faq.fml
@@ -1171,7 +1171,7 @@ oneTimeTearDown()</pre>
     </ol>
     <p>
       Refer to the <a
-      href="http://jakarta.apache.org/ant/manual/OptionalTasks/junit.html">JUnit
+      href="https://ant.apache.org/manual/Tasks/junit.html">JUnit
       Ant Task</a> for more information.
     </p></answer>
         </faq>
@@ -1231,7 +1231,7 @@ oneTimeTearDown()</pre>
     </ol>
     <p>
       Refer to the 
-      <a href="http://jakarta.apache.org/ant/manual/OptionalTasks/junit.html">JUnit Ant Task</a>
+      <a href="https://ant.apache.org/manual/Tasks/junit.html">JUnit Ant Task</a>
       for more information.
     </p></answer>
         </faq>


### PR DESCRIPTION
URL http://ant.apache.org/manual/OptionalTasks/junit.html is dead.  Use
up-to-date URL for documentation of Ant's JUnit task in file 'faq.fml'.
This is similar to commit 24dfdd76 (Fix dead link to the ant task in FAQ
(#1478), 2017-08-08).

----

I've stumbled by accident upon my fork of junit4 repository, which I created way back in 2017, and while trying to remember what I've done with it (PR #1478, commit 24dfdd76), I have discovered that a similar dead link is present in more places. So here's a fix for that.