### PR TITLE
Improve assumeNotNull to allow custom message

### DIFF
--- a/src/main/java/org/junit/Assume.java
+++ b/src/main/java/org/junit/Assume.java
@@ -80,8 +80,17 @@ public class Assume {
      * the test will halt and be ignored.
      */
     public static void assumeNotNull(Object... objects) {
-        assumeThat(objects, notNullValue());
-        assumeThat(asList(objects), everyItem(notNullValue()));
+        assumeNotNull(null, objects);
+    }
+
+    /**
+     * If called with a {@code null} array or one or more {@code null} elements in {@code objects},
+     * the test will halt and be ignored.
+     * @param message A message to pass to {@link AssumptionViolatedException}.
+     */
+    public static void assumeNotNull(String message, Object... objects) {
+        assumeThat(message, objects, notNullValue());
+        assumeThat(message, asList(objects), everyItem(notNullValue()));
     }
 
     /**

--- a/src/test/java/org/junit/tests/experimental/AssumptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/AssumptionTest.java
@@ -248,6 +248,12 @@ public class AssumptionTest {
         public void testMethod() {
             assumeTrue(message, false);
         }
+
+        @Test
+        public void testAssumeNotNull() {
+            Object[] objects = {1, 2, null};
+            assumeNotNull(message,objects);
+        }
     }
 
     @Test
@@ -255,7 +261,9 @@ public class AssumptionTest {
         final List<Failure> failures =
                 runAndGetAssumptionFailures(HasAssumeWithMessage.class);
 
-        assertTrue(failures.get(0).getMessage().contains(message));
+        for (Failure failure : failures) {
+            assertTrue(failure.getMessage().contains(message));
+        }
     }
 
     /**


### PR DESCRIPTION
Added assumeNotNull method that allows custom message, just like other assertions and assumptions

After added

```
        @Test
        public void testAssumeNotNull() {
            Object[] objects = {1, 2, null};
            assumeNotNull("One of the objects is null",objects);
        }

```
Output

`org.junit.AssumptionViolatedException: One of the objects is null: got: <[1, 2, null]>, expected: every item is not null`

In my company, we use junit4 and I tried to add custom message into the assumeNotNull method, just like other assertions and assumption methods of junit4. Then I realized that, assumeNotNull only accepts objects, so I thought that this could be useful