### PR TITLE
Make assertEquals platform independent

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -121,6 +121,13 @@ public class Assert {
         }
     }
 
+    private static Object toPlatformIndependent(Object in) {
+        if (in instanceof String) {
+            return ((String)in).replaceAll("\\n|\\r\\n", System.getProperty("line.separator"));
+        }
+        return in;
+    }
+
     private static boolean equalsRegardingNull(Object expected, Object actual) {
         if (expected == null) {
             return actual == null;
@@ -144,6 +151,19 @@ public class Assert {
      */
     public static void assertEquals(Object expected, Object actual) {
         assertEquals(null, expected, actual);
+    }
+
+    /**
+     * Asserts that two objects are equal ignoring platform difference. If
+     * they are not, a {@link AssertionError} without a message is thrown. If
+     * <code>expected</code> and <code>actual</code> are <code>null</code>,
+     * they are considered equal.
+     *
+     * @param expected expected value
+     * @param actual the value to check against <code>expected</code>
+     */
+    public static void assertEqualsPlatformIndependent(Object expected, Object actual) {
+        assertEquals(null, toPlatformIndependent(expected), toPlatformIndependent(actual));
     }
 
     /**

--- a/src/test/java/org/junit/tests/assertion/ComparisonFailureTest.java
+++ b/src/test/java/org/junit/tests/assertion/ComparisonFailureTest.java
@@ -1,15 +1,16 @@
 package org.junit.tests.assertion;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Arrays;
 import java.util.Collection;
 
 import org.junit.ComparisonFailure;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+
+import static org.junit.Assert.*;
 
 @RunWith(Parameterized.class)
 public class ComparisonFailureTest {
@@ -73,6 +74,22 @@ public class ComparisonFailureTest {
 	public void compactFailureMessage() {
 		ComparisonFailure failure = new ComparisonFailure("", expected, actual);
 		assertEquals(message, failure.getMessage());
+	}
+
+	@Test
+	public void testAssertStringEqualsPlatformIndependent() {
+		final String expected = "first line\r\n"
+				+ "second line\n";
+		final String actual = "first line\r\n"
+				+ "second line\r\n";
+		ThrowingRunnable runnable = new ThrowingRunnable() {
+			@Override
+			public void run() throws Throwable {
+				assertEquals(expected, actual);
+			}
+		};
+		assertThrows(ComparisonFailure.class, runnable);
+		assertEqualsPlatformIndependent(expected, actual);
 	}
 	
 }


### PR DESCRIPTION
we use assertEquals to check the equality of objects in many scenarios, but an annoying issue is that line separator is different in unix and windows, sometimes we encounted the junit failed just only caused by platform dependent, in fact, the problem has been mentioned frequently in Stackoverflow, maybe we can fix it

![image](https://user-images.githubusercontent.com/7313035/147179732-596d4e89-e76a-464e-bebd-5a35c3dc3064.png)
![image](https://user-images.githubusercontent.com/7313035/147179462-d025383f-1110-4ec7-99af-5e443a7403a0.png)
