### PR TITLE
Possibility to specify suite classes in custom Categories subclasses constructor

### DIFF
--- a/src/main/java/org/junit/experimental/categories/Categories.java
+++ b/src/main/java/org/junit/experimental/categories/Categories.java
@@ -307,11 +307,20 @@ public class Categories extends Suite {
 
     public Categories(Class<?> klass, RunnerBuilder builder) throws InitializationError {
         super(klass, builder);
+        initialize(klass);
+    }
+
+    protected Categories(RunnerBuilder builder, Class<?> klass, Class<?>[] suiteClasses) throws InitializationError {
+        super(builder, klass, suiteClasses);
+        initialize(klass);
+    }
+
+    private void initialize(Class<?> klass) throws InitializationError {
         try {
-            Set<Class<?>> included= getIncludedCategory(klass);
-            Set<Class<?>> excluded= getExcludedCategory(klass);
-            boolean isAnyIncluded= isAnyIncluded(klass);
-            boolean isAnyExcluded= isAnyExcluded(klass);
+            Set<Class<?>> included = getIncludedCategory(klass);
+            Set<Class<?>> excluded = getExcludedCategory(klass);
+            boolean isAnyIncluded = isAnyIncluded(klass);
+            boolean isAnyExcluded = isAnyExcluded(klass);
 
             filter(CategoryFilter.categoryFilter(isAnyIncluded, included, isAnyExcluded, excluded));
         } catch (NoTestsRemainException e) {

--- a/src/main/java/org/junit/runners/Suite.java
+++ b/src/main/java/org/junit/runners/Suite.java
@@ -98,7 +98,7 @@ public class Suite extends ParentRunner<Runner> {
      * @param klass the root of the suite
      * @param suiteClasses the classes in the suite
      */
-    protected Suite(RunnerBuilder builder, Class<?> klass, Class<?>[] suiteClasses) throws InitializationError {
+    public Suite(RunnerBuilder builder, Class<?> klass, Class<?>[] suiteClasses) throws InitializationError {
         this(klass, builder.runners(klass, suiteClasses));
     }
 

--- a/src/main/java/org/junit/runners/Suite.java
+++ b/src/main/java/org/junit/runners/Suite.java
@@ -98,7 +98,7 @@ public class Suite extends ParentRunner<Runner> {
      * @param klass the root of the suite
      * @param suiteClasses the classes in the suite
      */
-    public Suite(RunnerBuilder builder, Class<?> klass, Class<?>[] suiteClasses) throws InitializationError {
+    protected Suite(RunnerBuilder builder, Class<?> klass, Class<?>[] suiteClasses) throws InitializationError {
         this(klass, builder.runners(klass, suiteClasses));
     }
 

--- a/src/test/java/org/junit/experimental/categories/CustomCategoriesSuiteTest.java
+++ b/src/test/java/org/junit/experimental/categories/CustomCategoriesSuiteTest.java
@@ -1,0 +1,66 @@
+package org.junit.experimental.categories;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Categories.IncludeCategory;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.RunnerBuilder;
+
+public class CustomCategoriesSuiteTest {
+
+    public static class CustomCategories extends Categories {
+        public CustomCategories(Class<?> klass, RunnerBuilder builder)
+                throws InitializationError {
+            super(builder, klass, suiteClasses());
+        }
+
+        private static Class<?>[] suiteClasses() {
+            // Here a custom algorithm could be invoked to determine which
+            // classes should be run by the test suite.
+            // e.g. Reflections lib. (org.reflections) could be used to
+            // determine subclasses of a abstract test class
+            // which could be provided to the test suite by a custom annotation.
+            return new Class<?>[] { TestWithCategory.class };
+        }
+    }
+
+    public static class TestCategory {
+    }
+
+    @Category(TestCategory.class)
+    public static class TestWithCategory {
+        @Parameters
+        public static Iterable<String> getParameters() {
+            return Arrays.asList("first", "second");
+        }
+
+        @Parameterized.Parameter
+        public String value;
+
+        @Test
+        public void testSomething() {
+            Assert.assertTrue(true);
+        }
+    }
+
+    @RunWith(CustomCategories.class)
+    @IncludeCategory(TestCategory.class)
+    public static class SuiteWithTestWithCategory {
+    }
+
+    @Test
+    public void runsTestsWithCategory() {
+        Result result = new JUnitCore().run(SuiteWithTestWithCategory.class);
+        assertEquals(1, result.getRunCount());
+        assertEquals(0, result.getFailureCount());
+    }
+}


### PR DESCRIPTION
If subclassing the Suite class one can implement a constructor which can invoke a custom static method to specify test suite classes. This is currently not possible with subclasses ob Categories.

Therefore i propose this small fix to expose the constructor with the signature Categories(RunnerBuilder, Class<?>, Class<?>[]) to subclasses.