### PR TITLE
Use an indexed for loop to avoid defining an unused variable.

### DIFF
--- a/src/main/java/org/junit/internal/runners/ErrorReportingRunner.java
+++ b/src/main/java/org/junit/internal/runners/ErrorReportingRunner.java
@@ -37,6 +37,10 @@ public class ErrorReportingRunner extends Runner {
     @Override
     public Description getDescription() {
         Description description = Description.createSuiteDescription(classNames);
+        /*
+         * Use an indexed loop instead of a foreach: That avoids declaring a variable that some
+         * tools will see as "unused."
+         */
         for (int i = 0; i < causes.size(); i++) {
             description.addChild(describeCause());
         }

--- a/src/main/java/org/junit/internal/runners/ErrorReportingRunner.java
+++ b/src/main/java/org/junit/internal/runners/ErrorReportingRunner.java
@@ -37,7 +37,7 @@ public class ErrorReportingRunner extends Runner {
     @Override
     public Description getDescription() {
         Description description = Description.createSuiteDescription(classNames);
-        for (Throwable each : causes) {
+        for (int i = 0; i < causes.size(); i++) {
             description.addChild(describeCause());
         }
         return description;


### PR DESCRIPTION
The background is that we run this code through a compiler that complains about unused variables.

As I see it, it doesn't really make sense for the compiler to complain about an unused variable in this case. But given that it does, this could work around the problem for us.

Since there's no benefit to normal users from this PR, I'd also be OK with just maintaining a patch on our end. It's not hard; I just expect to be asked "Did you try to upstream this?" and so I'd like to be able to answer "yes" :)

---

In all this, I'm assuming that the looping _is_ intentional. The other possibility would be that we're actually supposed to call `addChild` only once. But I'm assuming that the `Description` returned by `getDescription()` is supposed to include one entry for each `Description` that will be created during `run`.

This appears to date back to https://github.com/junit-team/junit4/commit/e07e59eb9d24f6e4fa85dd99f311c1feca6ea983#diff-a36cb3d7d02522c18ce7059634d1cd9adabe56a773024708a53017d07d8900e7R29.

(_Arguably_, this PR makes the connection between `getDescription` and `run` clearer. But if we're concerned about that, maybe a code comment would be called for, and/or maybe `run` should use an indexed `for`, too...?)
