### PR TITLE
Fix unused object creation in WithParameterSupplier

### DIFF
--- a/src/test/java/org/junit/tests/experimental/theories/runner/WithParameterSupplier.java
+++ b/src/test/java/org/junit/tests/experimental/theories/runner/WithParameterSupplier.java
@@ -159,7 +159,7 @@ public class WithParameterSupplier {
     
     @Test
     public void shouldAcceptSuppliersWithTestClassConstructor() throws Exception {
-        new Theories(TestClassUsingSupplierWithTestClassConstructor.class);
+        Theories unused = new Theories(TestClassUsingSupplierWithTestClassConstructor.class);
     }
 
 }


### PR DESCRIPTION
Capture unused Theories creation into an unused variable (ErrorProne's CheckReturnValue can be configured to require all constructor calls to be used).