### PR TITLE
ignoring unnecessarily generated surefire report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
           distribution: temurin
           cache: maven
       - name: Build and verify
-        run: ./mvnw verify javadoc:javadoc site:site --batch-mode --errors --settings .github/workflows/settings.xml
+        run: ./mvnw verify javadoc:javadoc site:site --batch-mode --errors --settings .github/workflows/settings.xml -DdisableXmlReport=true
 
   publish-snapshots:
     name: Publish snapshot artifacts


### PR DESCRIPTION
In our analysis, we observe that this target/surefire-report/ directory is generated but not later used during the CI build. Hence, we propose to disable generating this directory to save runtime.
The generation of this directory can be disabled by simply adding -DdisableXmlReport=true to the mvn command.