### PR TITLE
Refactor/fix assume 

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -749,11 +749,7 @@ public class Assert {
     }
 
     private static void failNotNull(String message, Object actual) {
-        String formatted = "";
-        if (message != null) {
-            formatted = message + " ";
-        }
-        fail(formatted + "expected null, but was:<" + actual + ">");
+        fail(formatMessage(message) + "expected null, but was:<" + actual + ">");
     }
 
     /**
@@ -813,21 +809,12 @@ public class Assert {
     }
 
     private static void failSame(String message) {
-        String formatted = "";
-        if (message != null) {
-            formatted = message + " ";
-        }
-        fail(formatted + "expected not same");
+        fail(formatMessage(message) + "expected not same");
     }
 
-    private static void failNotSame(String message, Object expected,
-            Object actual) {
-        String formatted = "";
-        if (message != null) {
-            formatted = message + " ";
-        }
-        fail(formatted + "expected same:<" + expected + "> was not:<" + actual
-                + ">");
+    private static void failNotSame(String message, Object expected, Object actual) {
+        fail(formatMessage(message) + "expected same:<" + expected + "> was not:<"
+                + actual + ">");
     }
 
     private static void failNotEquals(String message, Object expected,
@@ -1030,5 +1017,8 @@ public class Assert {
 
     private static String buildPrefix(String message) {
         return message != null && message.length() != 0 ? message + ": " : "";
+    }
+    private static String formatMessage(String message) {
+        return message != null ? message + " " : "";
     }
 }

--- a/src/main/java/org/junit/Assume.java
+++ b/src/main/java/org/junit/Assume.java
@@ -54,7 +54,7 @@ public class Assume {
      * The inverse of {@link #assumeTrue(boolean)}.
      */
     public static void assumeFalse(boolean b) {
-        assumeThat(b, is(false));
+        assumeTrue(!b);
     }
 
     /**
@@ -65,6 +65,7 @@ public class Assume {
      * @param message A message to pass to {@link AssumptionViolatedException}.
      */
     public static void assumeTrue(String message, boolean b) {
+
         if (!b) throw new AssumptionViolatedException(message);
     }
 
@@ -72,6 +73,7 @@ public class Assume {
      * The inverse of {@link #assumeTrue(String, boolean)}.
      */
     public static void assumeFalse(String message, boolean b) {
+
         assumeTrue(message, !b);
     }
 


### PR DESCRIPTION
Assume.java
Motivação
assumeFalse(boolean b) usou o correspondente is(false) do Hamcrest, 
alocando memória desnecessária, enquanto assumeFalse(String, boolean) 
já delegado para assumeTrue. Essa inconsistência fez com que 
código mais difícil de entender.

Alterações
assumeFalse(boolean b) simplificado para delegar diretamente para 
assumeTrue(!b), tornando ambas as sobrecargas consistentes.

Impacto
- Remove alocação desnecessária de objetos Hamcrest
- Melhora a consistência entre métodos sobrecarregados
- Sem mudança de comportamento