### PR TITLE
Prevent TemporaryFolder paths from escaping the root

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -154,7 +154,12 @@ public class TemporaryFolder extends ExternalResource {
      * Returns a new fresh file with the given name under the temporary folder.
      */
     public File newFile(String fileName) throws IOException {
-        File file = new File(getRoot(), fileName);
+        File root = getRoot();
+        File file = new File(root, fileName);
+        if (new File(fileName).isAbsolute() || !isPathInFolder(root, file)) {
+            throw new IOException(
+                    "file name \"" + fileName + "\" is not a relative path");
+        }
         if (!file.createNewFile()) {
             throw new IOException(
                     "a file with the name \'" + fileName + "\' already exists in the test folder");
@@ -206,6 +211,10 @@ public class TemporaryFolder extends ExternalResource {
         for (String path : paths) {
             relativePath = new File(relativePath, path);
             file = new File(root, relativePath.getPath());
+            if (!isPathInFolder(root, file)) {
+                throw new IOException(
+                        "folder path \'" + relativePath.getPath() + "\' is not a relative path");
+            }
 
             lastMkdirsCallSuccessful = file.mkdirs();
             if (!lastMkdirsCallSuccessful && !file.isDirectory()) {
@@ -223,6 +232,18 @@ public class TemporaryFolder extends ExternalResource {
                     "a folder with the path \'" + relativePath.getPath() + "\' already exists");
         }
         return file;
+    }
+
+    private static boolean isPathInFolder(File folder, File file) throws IOException {
+        File canonicalFolder = folder.getCanonicalFile();
+        File canonicalFile = file.getCanonicalFile();
+        while (canonicalFile != null) {
+            if (canonicalFolder.equals(canonicalFile)) {
+                return true;
+            }
+            canonicalFile = canonicalFile.getParentFile();
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
+++ b/src/test/java/org/junit/rules/TemporaryFolderUsageTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
@@ -120,6 +121,50 @@ public class TemporaryFolderUsageTest {
         thrown.expect(IOException.class);
         thrown.expectMessage("folder path '" + fileAtRoot + "' is not a relative path");
         tempFolder.newFolder(fileAtRoot);
+    }
+
+    @Test
+    public void newFileWithParentTraversalPathThrowsIOException()
+            throws IOException {
+        tempFolder.create();
+        File fileOutsideRoot = new File(tempFolder.getRoot().getParentFile(),
+                "junit-outside-" + System.currentTimeMillis() + ".txt");
+        String fileName = ".." + File.separator + fileOutsideRoot.getName();
+
+        try {
+            try {
+                tempFolder.newFile(fileName);
+                fail("Expected IOException");
+            } catch (IOException e) {
+                assertThat(e.getMessage(),
+                        is("file name \"" + fileName + "\" is not a relative path"));
+            }
+            assertFileDoesNotExist(fileOutsideRoot);
+        } finally {
+            fileOutsideRoot.delete();
+        }
+    }
+
+    @Test
+    public void newFolderWithParentTraversalPathThrowsIOException()
+            throws IOException {
+        tempFolder.create();
+        File folderOutsideRoot = new File(tempFolder.getRoot().getParentFile(),
+                "junit-outside-" + System.currentTimeMillis());
+        String path = ".." + File.separator + folderOutsideRoot.getName();
+
+        try {
+            try {
+                tempFolder.newFolder(path);
+                fail("Expected IOException");
+            } catch (IOException e) {
+                assertThat(e.getMessage(),
+                        is("folder path '" + path + "' is not a relative path"));
+            }
+            assertFileDoesNotExist(folderOutsideRoot);
+        } finally {
+            folderOutsideRoot.delete();
+        }
     }
     
     @Test


### PR DESCRIPTION
TemporaryFolder promises to create named files and folders under its temporary root. The existing implementation rejected absolute folder paths, but parent traversal such as `..` could still create files or folders outside the root.

This change validates canonical paths before creating named files or folders, so traversal paths are rejected before anything is created.

Tests:
- Manually ran `org.junit.rules.TemporaryFolderUsageTest` with `JUnitCore` (26 tests)
- `git diff --check`

I could not run `./mvnw.cmd -Dtest=org.junit.rules.TemporaryFolderUsageTest test` locally because Maven Wrapper was unable to download/start Maven in this environment.